### PR TITLE
add support for variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
 ## tip
+
+* FEATURE: add support for variables in the query. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/5).

--- a/src/__mocks__/datasource.ts
+++ b/src/__mocks__/datasource.ts
@@ -1,0 +1,51 @@
+import { DataSourceInstanceSettings, PluginType } from '@grafana/data';
+import { TemplateSrv } from '@grafana/runtime';
+
+import { VictoriaLogsDatasource } from '../datasource';
+import { Options } from '../types';
+
+const defaultTemplateSrvMock = {
+  replace: (input: string) => input,
+};
+
+export function createDatasource(
+  templateSrvMock: Partial<TemplateSrv> = defaultTemplateSrvMock,
+  settings: Partial<DataSourceInstanceSettings<Options>> = {}
+): VictoriaLogsDatasource {
+  const customSettings: DataSourceInstanceSettings<Options> = {
+    url: 'myloggingurl',
+    id: 0,
+    uid: '',
+    type: '',
+    name: '',
+    meta: {
+      id: 'id',
+      name: 'name',
+      type: PluginType.datasource,
+      module: '',
+      baseUrl: '',
+      info: {
+        author: {
+          name: 'Test',
+        },
+        description: '',
+        links: [],
+        logos: {
+          large: '',
+          small: '',
+        },
+        screenshots: [],
+        updated: '',
+        version: '',
+      },
+    },
+    readOnly: false,
+    jsonData: {
+      maxLines: '20',
+    },
+    access: 'direct',
+    ...settings,
+  };
+
+  return new VictoriaLogsDatasource(customSettings, templateSrvMock as TemplateSrv);
+}

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,0 +1,92 @@
+import { TemplateSrv } from "@grafana/runtime";
+
+import { createDatasource } from "./__mocks__/datasource";
+import { VictoriaLogsDatasource } from "./datasource";
+
+const replaceMock = jest.fn().mockImplementation((a: string) => a);
+
+const templateSrvStub = {
+  replace: replaceMock,
+} as unknown as TemplateSrv;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('VictoriaLogsDatasource', () => {
+  let ds: VictoriaLogsDatasource;
+
+  beforeEach(() => {
+    ds = createDatasource(templateSrvStub);
+  });
+
+  describe('When interpolating variables', () => {
+    let customVariable: any;
+    beforeEach(() => {
+      customVariable = {
+        id: '',
+        global: false,
+        multi: false,
+        includeAll: false,
+        allValue: null,
+        query: '',
+        options: [],
+        current: {},
+        name: '',
+        type: 'custom',
+        label: null,
+        skipUrlSync: false,
+        index: -1,
+        initLock: null,
+      };
+    });
+
+    it('should only escape single quotes for string value', () => {
+      expect(ds.interpolateQueryExpr("abc'$^*{}[]+?.()|", customVariable)).toEqual("abc\\\\'$^*{}[]+?.()|");
+    });
+
+    it('should return a number for number value', () => {
+      expect(ds.interpolateQueryExpr(1000 as any, customVariable)).toEqual(1000);
+    });
+  });
+
+  describe('applyTemplateVariables', () => {
+    it('should call replace function for expr', () => {
+      const expr = '_stream:{app!~"$name"}'
+      const variables = { name: 'bar' };
+      replaceMock.mockImplementation(() => `_stream:{app!~"${variables.name}"}`);
+      const interpolatedQuery = ds.applyTemplateVariables({ expr, refId: 'A' }, {});
+      expect(interpolatedQuery.expr).toBe(`_stream:{app!~"bar"}`);
+    });
+
+    it('should replace variables in a simple string query', () => {
+      const expr = 'error';
+      replaceMock.mockImplementation((input) => input);
+      const interpolatedQuery = ds.applyTemplateVariables({ expr, refId: 'A' }, {});
+      expect(interpolatedQuery.expr).toBe('error');
+    });
+
+    it('should replace variables with logical operators', () => {
+      const expr = '$severity AND _time:$time';
+      const variables = { severity: 'error', time: '5m' };
+      replaceMock.mockImplementation(() => `${variables.severity} AND _time:${variables.time}`);
+      const interpolatedQuery = ds.applyTemplateVariables({ expr, refId: 'A' }, {});
+      expect(interpolatedQuery.expr).toBe('error AND _time:5m');
+    });
+
+    it('should replace variables with exact match function', () => {
+      const expr = 'log.level:exact("$level")';
+      const variables = { level: 'error' };
+      replaceMock.mockImplementation(() => `log.level:exact("${variables.level}")`);
+      const interpolatedQuery = ds.applyTemplateVariables({ expr, refId: 'A' }, {});
+      expect(interpolatedQuery.expr).toBe('log.level:exact("error")');
+    });
+
+    it('should not replace a variable if it is not declared', () => {
+      const expr = '_stream:{app!~"$undeclaredVariable"}';
+      replaceMock.mockImplementation((input) => input);
+      const interpolatedQuery = ds.applyTemplateVariables({ expr, refId: 'A' }, {});
+      expect(interpolatedQuery.expr).toBe(expr);
+    });
+  });
+});

--- a/src/parsingUtils.ts
+++ b/src/parsingUtils.ts
@@ -1,0 +1,33 @@
+const varTypeFunc = [
+  (v: string) => `\$${v}`,
+  (v: string, f?: string) => `[[${v}${f ? `:${f}` : ''}]]`,
+  (v: string, f?: string) => `\$\{${v}${f ? `:${f}` : ''}\}`,
+];
+
+export const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?]]|\${(\w+)(?:\.([^:^}]+))?(?::([^}]+))?}/g;
+
+export function returnVariables(expr: string) {
+  const replacer = (match: string, type: any, v: any, f: any) => varTypeFunc[parseInt(type, 10)](v, f)
+  return expr.replace(/__V_(\d)__(.+?)__V__(?:__F__(\w+)__F__)?/g, replacer);
+}
+
+
+export function replaceVariables(expr: string) {
+  return expr.replace(variableRegex, (match, var1, var2, fmt2, var3, fieldPath, fmt3) => {
+    const fmt = fmt2 || fmt3;
+    let variable = var1;
+    let varType = '0';
+
+    if (var2) {
+      variable = var2;
+      varType = '1';
+    }
+
+    if (var3) {
+      variable = var3;
+      varType = '2';
+    }
+
+    return `__V_${varType}__` + variable + '__V__' + (fmt ? '__F__' + fmt + '__F__' : '');
+  });
+}


### PR DESCRIPTION
The pull request adds support for variables in queries, including [Grafana's global variables]( https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#global-variables).
 
 #5