### PR TITLE
Bug fixes for query expression and entries limit checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 
 * BUGFIX: fix a bug where a manually removed filter would persist in the query after the "Run query" button is clicked.See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/8).
 * BUGFIX: fix query handling to correctly apply `_time` filter across all queries. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/12) and [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5920).
+* BUGFIX: fix an issue where sometimes an empty response was returned despite having data in VictoriaLogs. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/10).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## tip
 
 * FEATURE: add support for variables in the query. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/5).
+
+* BUGFIX: fix a bug where a manually removed filter would persist in the query after the "Run query" button is clicked.See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/8).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * FEATURE: add support for variables in the query. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/5).
+* FEATURE: add client-side record limit check for VictoriaLogs < v0.5.0 support. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/9).
 
 * BUGFIX: fix a bug where a manually removed filter would persist in the query after the "Run query" button is clicked.See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/8).
 * BUGFIX: fix query handling to correctly apply `_time` filter across all queries. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/12) and [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5920).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 * FEATURE: add support for variables in the query. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/5).
 
 * BUGFIX: fix a bug where a manually removed filter would persist in the query after the "Run query" button is clicked.See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/8).
+* BUGFIX: fix query handling to correctly apply `_time` filter across all queries. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/12) and [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5920).

--- a/src/components/QueryEditor/QueryField.tsx
+++ b/src/components/QueryEditor/QueryField.tsx
@@ -45,7 +45,7 @@ const QueryField: React.FC<QueryFieldProps> = (props) => {
       >
         <div className="gf-form--grow flex-shrink-1 min-width-15">
           <MonacoQueryFieldWrapper
-            runQueryOnBlur
+            runQueryOnBlur={false}
             history={history ?? []}
             onChange={onChangeQuery}
             onRunQuery={onRunQuery}

--- a/src/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/src/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -20,13 +20,13 @@ export const MonacoQueryFieldWrapper = (props: Props) => {
   };
 
   const handleBlur = (value: string) => {
+    onChange(value);
+
     if (runQueryOnBlur) {
       // run handleRunQuery only if the current value is different from the last-time-executed value
       if (value !== lastRunValueRef.current) {
         handleRunQuery(value);
       }
-    } else {
-      onChange(value);
     }
   };
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -40,7 +40,7 @@ export class VictoriaLogsDatasource
       // include time range in query if not already present
       if (!/_time/.test(q.expr)) {
         const timerange = `_time:[${request.range.from.toISOString()}, ${request.range.to.toISOString()}]`
-        q.expr = `${timerange} AND ${q.expr}`;
+        q.expr = `${timerange} AND (${q.expr})`;
       }
       return { ...q, maxLines: q.maxLines ?? this.maxLines }
     });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -29,7 +29,7 @@ export class VictoriaLogsDatasource
     super(instanceSettings);
 
     const settingsData = instanceSettings.jsonData || {};
-    this.maxLines = parseInt(settingsData.maxLines ?? '0', 10) || 10;
+    this.maxLines = parseInt(settingsData.maxLines ?? '0', 10) || 1000;
     this.annotations = {
       QueryEditor: QueryEditor,
     };
@@ -58,7 +58,7 @@ export class VictoriaLogsDatasource
       .query(fixedRequest)
       .pipe(
         map((response) =>
-          transformBackendResult(response, fixedRequest.targets, [])
+          transformBackendResult(response, fixedRequest.targets, [], this.maxLines)
         )
       );
   }


### PR DESCRIPTION
- Fixed a bug where a manually removed filter would persist in the query after the "Run query" button was clicked. (#8)
- Fixed query handling to correctly apply the `_time` filter across all queries. (#12)
- Fixed an issue where sometimes an empty response was returned despite having data in VictoriaLogs. (#10)
- Added a client-side record limit check for VictoriaLogs `< v0.5.0` support. (#9)