### PR TITLE
Enable `metrics` flag for datasource list visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: change the `metrics` flag from `false` to `true` in `plugin.json` to ensure the plugin appears in the Grafana datasource selection list.
+
 ## v0.2.0
 
 * FEATURE: add support for variables in the query. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/5).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The VictoriaLogs datasource plugin allows you to query and visualize
 
 * [Installation](#installation)
 * [How to make new release](#how-to-make-new-release)
+* [Notes](#notes)
 * [License](#license)
 
 ## Installation
@@ -281,6 +282,12 @@ This command will build frontend part and backend part or the plugin and locate 
 1. Run `git push origin v1.xx.y` to push the tag created `v1.xx.y` at step 2 to public GitHub repository
 1. Go to <https://github.com/VictoriaMetrics/victorialogs-datasource/releases> and verify that draft release with the name `TAG` has been created and this release contains all the needed binaries and checksums.
 1. Remove the `draft` checkbox for the `TAG` release and manually publish it.
+
+## Notes
+
+In the `plugin.json` file of our plugin, the `metrics` field is set to `true`. This is not to support metric queries in the classical sense but to ensure our plugin can be selected in the Grafana panel editor.
+
+For more information on the fields in `plugin.json`, please refer to the [Grafana documentation](https://grafana.com/developers/plugin-tools/reference-plugin-json#properties).
 
 ## License
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -4,7 +4,7 @@
   "id": "victorialogs-datasource",
   "category": "logging",
   "logs": true,
-  "metrics": false,
+  "metrics": true,
   "alerting": false,
   "annotations": true,
   "streaming": false,


### PR DESCRIPTION
#### Problem:
Plugin is not visible in the datasource selection list when editing a panel in Grafana.

<img width="427" alt="image" src="https://github.com/VictoriaMetrics/victorialogs-datasource/assets/29711459/1700882d-9c0f-4e42-87f8-1772a9e12de4">

Plugins with the `metrics` flag set to `false` in `plugin.json` are not displayed in the datasource selection list. For more details, refer to the [Grafana documentation](https://grafana.com/developers/plugin-tools/reference-plugin-json#properties).

#### Solution:
The `metrics` flag has been changed from `false` to `true`. This change does not alter the plugin's functionality or indicate support for metric queries but is necessary to make the plugin appear in the Grafana datasource selection list.
