### PR TITLE
fix: change time range to start and end query args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: change time range limitation from `_time` in the expression to `start` and `end` query args. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/22).
+
 ## v0.2.1
 
 * BUGFIX: change the `metrics` flag from `false` to `true` in `plugin.json` to ensure the plugin appears in the Grafana datasource selection list.

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -88,6 +88,7 @@ func (d *Datasource) query(ctx context.Context, _ backend.PluginContext, query b
 		settings.HTTPMethod = http.MethodPost
 	}
 
+	q.TimeRange = TimeRange(query.TimeRange)
 	reqURL, err := q.getQueryURL(d.settings.URL, settings.QueryParams)
 	if err != nil {
 		err = fmt.Errorf("failed to create request URL: %w", err)

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"time"
 )
 
 const (
@@ -18,7 +19,14 @@ type Query struct {
 	Expr         string `json:"expr"`
 	LegendFormat string `json:"legendFormat"`
 	MaxLines     int    `json:"maxLines"`
+	TimeRange    TimeRange
 	url          *url.URL
+}
+
+// TimeRange represents time range backend object
+type TimeRange struct {
+	From time.Time
+	To   time.Time
 }
 
 // GetQueryURL calculates step and clear expression from template variables,
@@ -58,6 +66,8 @@ func (q *Query) queryInstantURL(queryParams url.Values) string {
 
 	values.Set("query", q.Expr)
 	values.Set("limit", strconv.Itoa(q.MaxLines))
+	values.Set("start", strconv.FormatInt(q.TimeRange.From.Unix(), 10))
+	values.Set("end", strconv.FormatInt(q.TimeRange.To.Unix(), 10))
 
 	q.url.RawQuery = values.Encode()
 	return q.url.String()

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -64,6 +64,14 @@ func (q *Query) queryInstantURL(queryParams url.Values) string {
 		q.MaxLines = defaultMaxLines
 	}
 
+	now := time.Now()
+	if q.TimeRange.From.IsZero() {
+		q.TimeRange.From = now.Add(-time.Minute * 5)
+	}
+	if q.TimeRange.To.IsZero() {
+		q.TimeRange.To = now
+	}
+
 	values.Set("query", q.Expr)
 	values.Set("limit", strconv.Itoa(q.MaxLines))
 	values.Set("start", strconv.FormatInt(q.TimeRange.From.Unix(), 10))

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -2,13 +2,15 @@ package plugin
 
 import (
 	"testing"
+	"time"
 )
 
 func TestQuery_getQueryURL(t *testing.T) {
 	type fields struct {
-		RefID    string
-		Expr     string
-		MaxLines int
+		RefID     string
+		Expr      string
+		MaxLines  int
+		TimeRange TimeRange
 	}
 	type args struct {
 		rawURL      string
@@ -24,9 +26,10 @@ func TestQuery_getQueryURL(t *testing.T) {
 		{
 			name: "empty values",
 			fields: fields{
-				RefID:    "1",
-				Expr:     "",
-				MaxLines: 0,
+				RefID:     "1",
+				Expr:      "",
+				MaxLines:  0,
+				TimeRange: TimeRange{},
 			},
 			args: args{
 				rawURL:      "",
@@ -41,12 +44,16 @@ func TestQuery_getQueryURL(t *testing.T) {
 				RefID:    "1",
 				Expr:     "",
 				MaxLines: 0,
+				TimeRange: TimeRange{
+					From: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					To:   time.Date(2021, 1, 1, 1, 0, 0, 0, time.UTC),
+				},
 			},
 			args: args{
 				rawURL:      "http://127.0.0.1:9428",
 				queryParams: "",
 			},
-			want:    "http://127.0.0.1:9428/select/logsql/query?limit=1000&query=",
+			want:    "http://127.0.0.1:9428/select/logsql/query?end=1609462800&limit=1000&query=&start=1609459200",
 			wantErr: false,
 		},
 		{
@@ -55,12 +62,16 @@ func TestQuery_getQueryURL(t *testing.T) {
 				RefID:    "1",
 				Expr:     "_time:1s",
 				MaxLines: 10,
+				TimeRange: TimeRange{
+					From: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					To:   time.Date(2021, 1, 1, 1, 0, 0, 0, time.UTC),
+				},
 			},
 			args: args{
 				rawURL:      "http://127.0.0.1:9428",
 				queryParams: "",
 			},
-			want:    "http://127.0.0.1:9428/select/logsql/query?limit=10&query=_time%3A1s",
+			want:    "http://127.0.0.1:9428/select/logsql/query?end=1609462800&limit=10&query=_time%3A1s&start=1609459200",
 			wantErr: false,
 		},
 		{
@@ -69,21 +80,26 @@ func TestQuery_getQueryURL(t *testing.T) {
 				RefID:    "1",
 				Expr:     "_time:1s and syslog",
 				MaxLines: 10,
+				TimeRange: TimeRange{
+					From: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					To:   time.Date(2021, 1, 1, 1, 0, 0, 0, time.UTC),
+				},
 			},
 			args: args{
 				rawURL:      "http://127.0.0.1:9428",
 				queryParams: "a=1&b=2",
 			},
-			want:    "http://127.0.0.1:9428/select/logsql/query?a=1&b=2&limit=10&query=_time%3A1s+and+syslog",
+			want:    "http://127.0.0.1:9428/select/logsql/query?a=1&b=2&end=1609462800&limit=10&query=_time%3A1s+and+syslog&start=1609459200",
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			q := &Query{
-				RefID:    tt.fields.RefID,
-				Expr:     tt.fields.Expr,
-				MaxLines: tt.fields.MaxLines,
+				RefID:     tt.fields.RefID,
+				Expr:      tt.fields.Expr,
+				MaxLines:  tt.fields.MaxLines,
+				TimeRange: tt.fields.TimeRange,
 			}
 			got, err := q.getQueryURL(tt.args.rawURL, tt.args.queryParams)
 			if (err != nil) != tt.wantErr {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -37,11 +37,6 @@ export class VictoriaLogsDatasource
 
   query(request: DataQueryRequest<Query>): Observable<DataQueryResponse> {
     const queries = request.targets.filter(q => q.expr).map((q) => {
-      // include time range in query if not already present
-      if (!/_time/.test(q.expr)) {
-        const timerange = `_time:[${request.range.from.toISOString()}, ${request.range.to.toISOString()}]`
-        q.expr = `${timerange} AND (${q.expr})`;
-      }
       return { ...q, maxLines: q.maxLines ?? this.maxLines }
     });
 


### PR DESCRIPTION
change time range limitation from `_time` in the expression to `start` and `end` query args.

#22