### PR TITLE
improve response from backend when there are different fields returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix issue when VictoriaLogs returns different fields without stream labels. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/23). 
+
 ## v0.2.1
 
 * BUGFIX: change the `metrics` flag from `false` to `true` in `plugin.json` to ensure the plugin appears in the Grafana datasource selection list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## tip
 
-* BUGFIX: fix issue when VictoriaLogs returns different fields without stream labels. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/23). 
+* BUGFIX: fix bug with displaying responses with a custom set of fields. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/23).
 
 ## v0.2.1
 

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -86,6 +86,9 @@ func parseStreamResponse(reader io.Reader) backend.DataResponse {
 		}
 		labelsField.Append(d)
 
+		// some logsql requests can return only labels or fields without _time field
+		// in that case we need to fill time field with current time value
+		// to avoid empty time field in the response. Please see the test for more details.
 		if timeFd.Len() == 0 {
 			lineField.Append(string(d))
 		}

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/VictoriaMetrics/metricsql"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -84,6 +85,16 @@ func parseStreamResponse(reader io.Reader) backend.DataResponse {
 			return newResponseError(err, backend.StatusInternal)
 		}
 		labelsField.Append(d)
+
+		if timeFd.Len() == 0 {
+			lineField.Append(string(d))
+		}
+	}
+
+	if timeFd.Len() == 0 {
+		for i := 0; i < lineField.Len(); i++ {
+			timeFd.Append(time.Now())
+		}
 	}
 
 	frame := data.NewFrame("", timeFd, lineField, labelsField)

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -86,17 +86,17 @@ func parseStreamResponse(reader io.Reader) backend.DataResponse {
 		}
 		labelsField.Append(d)
 
-		// some logsql requests can return only labels or fields without _time field
-		// in that case we need to fill time field with current time value
-		// to avoid empty time field in the response. Please see the test for more details.
+		// Grafana expects lineField to be always non-empty.
 		if timeFd.Len() == 0 {
 			lineField.Append(string(d))
 		}
 	}
 
+	// Grafana expects time field to be always non-empty.
 	if timeFd.Len() == 0 {
+		now := time.Now()
 		for i := 0; i < lineField.Len(); i++ {
-			timeFd.Append(time.Now())
+			timeFd.Append(now)
 		}
 	}
 

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -130,12 +130,100 @@ func Test_parseStreamResponse(t *testing.T) {
 				return rsp
 			},
 		},
+		{
+			name: "response with different labels and without standard fields",
+			response: `{"stream":"stderr","count(*)":"394"}
+{"stream":"stdout","count(*)":"21"}`,
+			want: func() backend.DataResponse {
+				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+				labelsField.Name = gLabelsField
+
+				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+				timeFd.Name = gTimeField
+
+				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+				lineField.Name = gLineField
+
+				lineField.Append(`{"count(*)":"394","stream":"stderr"}`)
+				lineField.Append(`{"count(*)":"21","stream":"stdout"}`)
+
+				labels := data.Labels{
+					"count(*)": "394",
+					"stream":   "stderr",
+				}
+
+				b, _ := labelsToJSON(labels)
+				labelsField.Append(b)
+
+				labels = data.Labels{
+					"count(*)": "21",
+					"stream":   "stdout",
+				}
+				b, _ = labelsToJSON(labels)
+				labelsField.Append(b)
+				frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+				rsp := backend.DataResponse{}
+				frame.Meta = &data.FrameMeta{}
+				rsp.Frames = append(rsp.Frames, frame)
+
+				return rsp
+			},
+		},
+		{
+			name:     "response with different labels only one label",
+			response: `{"level":""}`,
+			want: func() backend.DataResponse {
+				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+				labelsField.Name = gLabelsField
+
+				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+				timeFd.Name = gTimeField
+
+				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+				lineField.Name = gLineField
+
+				lineField.Append(`{"level":""}`)
+
+				labels := data.Labels{
+					"level": "",
+				}
+
+				b, _ := labelsToJSON(labels)
+				labelsField.Append(b)
+
+				frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+				rsp := backend.DataResponse{}
+				frame.Meta = &data.FrameMeta{}
+				rsp.Frames = append(rsp.Frames, frame)
+
+				return rsp
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := io.NopCloser(bytes.NewBuffer([]byte(tt.response)))
 			w := tt.want()
-			if got := parseStreamResponse(r); !reflect.DeepEqual(got, w) {
+			got := parseStreamResponse(r)
+			// if time field is empty, fill it with the value from the response
+			// because time field in the parseStreamResponse generated as time.Now()
+			for i, frame := range w.Frames {
+				for j, field := range frame.Fields {
+					if field.Name == gTimeField && field.Len() == 0 {
+						for _, f := range got.Frames {
+							for _, f2 := range f.Fields {
+								if f2.Name == gTimeField {
+									w.Frames[i].Fields[j] = f2
+								}
+							}
+						}
+					}
+				}
+			}
+
+			if !reflect.DeepEqual(got, w) {
 				t.Errorf("parseStreamResponse() = %#v, want %#v", got, w)
 			}
 		})


### PR DESCRIPTION
Fixed issue if the response returns different fields. It creates more generic behavior to prepare responses for UI. 
Sometimes, the response can't include a time value and line values, so it should be generated manually from the returned label values


Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/23