### PR TITLE
fix issue when one of the stream field is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix bug with displaying response when one of the stream field is defined and lines are not collected. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/34).
+
 ## v0.2.2
 
 * BUGFIX: fix bug with displaying responses with a custom set of fields. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/23).

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -92,6 +92,14 @@ func parseStreamResponse(reader io.Reader) backend.DataResponse {
 		}
 	}
 
+	// Grafana expects lineFields to be always non-empty.
+	if lineField.Len() == 0 {
+		for i := 0; i < labelsField.Len(); i++ {
+			label := labelsField.At(i)
+			lineField.Append(fmt.Sprintf("%s", label))
+		}
+	}
+
 	// Grafana expects time field to be always non-empty.
 	if timeFd.Len() == 0 {
 		now := time.Now()


### PR DESCRIPTION
Some requests can send time fields with another set of different fields. In that case, we do not collect line fields, and the plugin shows the error described in the issue.

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/34