### PR TITLE
fix double line response to show only numbers from the response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## tip
 
+* BUGFIX: fix bug with parsing response when time field is empty but message and labels are present.
+  It happens when the user tries to show only stats number. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/45).
+
 ## v0.2.4
 
 * BUGFIX: fix bug with parsing response when one of the field contains ANSI escape sequences. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/24).

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -98,11 +98,6 @@ func parseStreamResponse(reader io.Reader) backend.DataResponse {
 			return newResponseError(err, backend.StatusInternal)
 		}
 		labelsField.Append(d)
-
-		// Grafana expects lineField to be always non-empty.
-		if timeFd.Len() == 0 {
-			lineField.Append(string(d))
-		}
 	}
 
 	// Grafana expects lineFields to be always non-empty.

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -322,6 +322,37 @@ func Test_parseStreamResponse(t *testing.T) {
 				return rsp
 			},
 		},
+		{
+			name:     "response has",
+			response: `{"count":"507","_msg":"507"}`,
+			want: func() backend.DataResponse {
+				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+				labelsField.Name = gLabelsField
+
+				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+				timeFd.Name = gTimeField
+
+				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+				lineField.Name = gLineField
+
+				lineField.Append("507")
+
+				labels := data.Labels{
+					"count": "507",
+				}
+
+				b, _ := labelsToJSON(labels)
+				labelsField.Append(b)
+
+				frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+				rsp := backend.DataResponse{}
+				frame.Meta = &data.FrameMeta{}
+				rsp.Frames = append(rsp.Frames, frame)
+
+				return rsp
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -323,7 +323,7 @@ func Test_parseStreamResponse(t *testing.T) {
 			},
 		},
 		{
-			name:     "response has",
+			name:     "response has labels and message, time field is empty",
 			response: `{"count":"507","_msg":"507"}`,
 			want: func() backend.DataResponse {
 				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)


### PR DESCRIPTION
I removed double-adding lines from the data source response. It produced a problem when the user tries to count some values.

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/45