### PR TITLE
fix issue with forwarding headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## tip
 
+* BUGFIX: fix issue with forwarding headers from datasource to the backend or proxy. 
+  It might be helpful if a user wants to use some kind of authentication. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/54)
+
 ## v0.2.5
 
 * BUGFIX: fix bug with parsing response when time field is empty but message and labels are present.

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -23,6 +23,8 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 	if err != nil {
 		return nil, fmt.Errorf("error create httpclient.Options based on settings: %w", err)
 	}
+	opts.ForwardHTTPHeaders = true
+
 	cl, err := httpclient.New(opts)
 	if err != nil {
 		return nil, fmt.Errorf("error create a new http.Client: %w", err)


### PR DESCRIPTION
If the user wants to use some OAuth and set the `Forward OAuth Identity` flag, headers with bearer tokens are not sent to the proxy server. This PR fixed this problem

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/54