### PR TITLE
add beta version of the query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: add beta version of the query builder. The builder allows selecting `field names` and `field value`. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/48)
+
 ## v0.2.6
 
 * BUGFIX: fix issue with forwarding headers from datasource to the backend or proxy. 

--- a/src/components/QueryEditor/EditorHeader.tsx
+++ b/src/components/QueryEditor/EditorHeader.tsx
@@ -1,0 +1,26 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+interface EditorHeaderProps {
+  children: React.ReactNode;
+}
+
+export const EditorHeader: React.FC<EditorHeaderProps> = ({ children }) => {
+  const styles = useStyles2(getStyles);
+
+  return <div className={styles.root}>{children}</div>
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  root: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(1),
+    minHeight: theme.spacing(4),
+  }),
+});

--- a/src/components/QueryEditor/QueryBuilder/QueryBuilder.tsx
+++ b/src/components/QueryEditor/QueryBuilder/QueryBuilder.tsx
@@ -1,0 +1,133 @@
+import { css } from "@emotion/css";
+import React, { Fragment, memo } from 'react';
+
+import { GrafanaTheme2, TimeRange } from "@grafana/data";
+import { useStyles2 } from "@grafana/ui";
+
+import { VictoriaLogsDatasource } from "../../../datasource";
+import { FilterVisualQuery, VisualQuery } from "../../../types";
+
+import QueryBuilderAddFilter from "./components/QueryBuilderAddFilter";
+import QueryBuilderFieldFilter from "./components/QueryBuilderFilters/QueryBuilderFieldFilter";
+import QueryBuilderSelectOperator from "./components/QueryBuilderOperators/QueryBuilderSelectOperator";
+import { DEFAULT_FILTER_OPERATOR } from "./utils/parseToString";
+
+interface Props {
+  query: VisualQuery;
+  datasource: VictoriaLogsDatasource;
+  timeRange?: TimeRange;
+  onChange: (update: VisualQuery) => void;
+  onRunQuery: () => void;
+}
+
+const QueryBuilder = memo<Props>(({ datasource, query, onChange, timeRange }) => {
+  const styles = useStyles2(getStyles);
+  const { filters } = query
+
+  return (
+    <div className={styles.builderWrapper}>
+      <QueryBuilderFilter
+        datasource={datasource}
+        filters={filters}
+        onChange={onChange}
+        query={query}
+        timeRange={timeRange}
+        indexPath={[]}
+      />
+    </div>
+  )
+});
+
+interface QueryBuilderFilterProps {
+  datasource: VictoriaLogsDatasource;
+  query: VisualQuery;
+  filters: FilterVisualQuery;
+  indexPath: number[];
+  timeRange?: TimeRange;
+  onChange: (query: VisualQuery) => void;
+}
+
+const QueryBuilderFilter = (props: QueryBuilderFilterProps) => {
+  const styles = useStyles2(getStyles);
+  const { datasource, filters, query, indexPath, timeRange, onChange } = props
+  const isRoot = !indexPath.length
+  return (
+    <div className={isRoot ? styles.builderWrapper : styles.filterWrapper}>
+      {filters.values.map((filter, index) => (
+          <Fragment key={index}>
+            <div className={styles.filterItem}>
+              {typeof filter === 'string'
+                ? <QueryBuilderFieldFilter
+                  datasource={datasource}
+                  indexPath={[...indexPath, index]}
+                  filter={filter}
+                  query={query}
+                  timeRange={timeRange}
+                  onChange={onChange}
+                />
+                : <QueryBuilderFilter
+                  datasource={datasource}
+                  indexPath={[...indexPath, index]}
+                  filters={filter}
+                  query={query}
+                  timeRange={timeRange}
+                  onChange={onChange}
+                />
+              }
+            </div>
+            {index !== filters.values.length - 1 && (
+              <QueryBuilderSelectOperator
+                query={query}
+                operator={filters.operators[index] || DEFAULT_FILTER_OPERATOR}
+                indexPath={[...indexPath, index]}
+                onChange={onChange}
+              />
+            )}
+          </Fragment>
+        )
+      )}
+      {/* for new filters*/}
+      {!filters.values.length && (
+        <QueryBuilderFieldFilter
+          datasource={datasource}
+          indexPath={[...indexPath, filters.values.length]}
+          filter={''}
+          query={query}
+          timeRange={timeRange}
+          onChange={onChange}
+        />
+      )}
+      <QueryBuilderAddFilter query={query} onAddFilter={onChange}/>
+    </div>
+  )
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    builderWrapper: css`
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: ${theme.spacing(1)};
+    `,
+    filterWrapper: css`
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: ${theme.spacing(1)};
+      border: 1px solid ${theme.colors.border.strong};
+      background-color: ${theme.colors.border.weak};
+      padding: ${theme.spacing(1)};
+    `,
+    filterItem: css`
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      gap: ${theme.spacing(1)};
+    `
+  };
+};
+
+QueryBuilder.displayName = 'QueryBuilder';
+
+export default QueryBuilder;

--- a/src/components/QueryEditor/QueryBuilder/QueryBuilderContainer.tsx
+++ b/src/components/QueryEditor/QueryBuilder/QueryBuilderContainer.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+
+import { TimeRange } from '@grafana/data';
+import { Text } from '@grafana/ui';
+
+import { VictoriaLogsDatasource } from "../../../datasource";
+import { Query, VisualQuery } from "../../../types";
+
+import QueryBuilder from "./QueryBuilder";
+import { buildVisualQueryFromString } from "./utils/parseFromString";
+import { parseVisualQueryToString } from "./utils/parseToString";
+
+
+export interface Props {
+  query: Query;
+  datasource: VictoriaLogsDatasource;
+  onChange: (update: Query) => void;
+  onRunQuery: () => void;
+  timeRange?: TimeRange;
+}
+
+export function QueryBuilderContainer(props: Props) {
+  const { query, onChange, onRunQuery, datasource, timeRange } = props
+
+  const [state, setState] = useState<{expr: string, visQuery: VisualQuery}>({
+    expr: query.expr,
+    visQuery: buildVisualQueryFromString(query.expr).query
+  })
+
+  const onVisQueryChange = (visQuery: VisualQuery) => {
+    const expr = parseVisualQueryToString(visQuery);
+    setState({ expr, visQuery })
+    onChange({ ...props.query, expr: expr });
+  };
+
+  return (
+    <>
+      <QueryBuilder
+        query={state.visQuery}
+        datasource={datasource}
+        onChange={onVisQueryChange}
+        onRunQuery={onRunQuery}
+        timeRange={timeRange}
+      />
+      <hr/>
+
+      <Text element="p" variant="bodySmall">
+        {query.expr !== '' && query.expr}
+      </Text>
+    </>
+  );
+}

--- a/src/components/QueryEditor/QueryBuilder/QueryEditorModeToggle.tsx
+++ b/src/components/QueryEditor/QueryBuilder/QueryEditorModeToggle.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { RadioButtonGroup } from '@grafana/ui';
+
+import { QueryEditorMode } from "../../../types";
+
+export interface Props {
+  mode: QueryEditorMode;
+  onChange: (mode: QueryEditorMode) => void;
+}
+
+const editorModes = [
+  { label: 'Beta Builder', value: QueryEditorMode.Builder },
+  { label: 'Code', value: QueryEditorMode.Code },
+];
+
+export function QueryEditorModeToggle({ mode, onChange }: Props) {
+  return (
+    <div>
+      <RadioButtonGroup options={editorModes} size="sm" value={mode} onChange={onChange} />
+    </div>
+  );
+}

--- a/src/components/QueryEditor/QueryBuilder/components/QueryBuilderAddFilter.tsx
+++ b/src/components/QueryEditor/QueryBuilder/components/QueryBuilderAddFilter.tsx
@@ -1,0 +1,52 @@
+import { css } from "@emotion/css";
+import React, { useCallback } from 'react';
+
+import { GrafanaTheme2 } from "@grafana/data";
+import { Button, useStyles2 } from "@grafana/ui";
+
+import { VisualQuery } from "../../../../types";
+import { DEFAULT_FILTER_OPERATOR } from "../utils/parseToString";
+
+interface Props {
+  query: VisualQuery;
+  onAddFilter: (query: VisualQuery) => void;
+}
+
+const QueryBuilderAddFilter = ({ query, onAddFilter }: Props) => {
+  const styles = useStyles2(getStyles);
+
+  const handleAddFilter = useCallback(() => {
+    onAddFilter({
+      ...query, filters: {
+        ...query.filters,
+        values: [...query.filters.values, ''],
+        operators: [...query.filters.operators, DEFAULT_FILTER_OPERATOR]
+      }
+    })
+  }, [onAddFilter, query])
+
+  return (
+    <div className={styles.wrapper}>
+      <Button
+        variant={'secondary'}
+        onClick={handleAddFilter}
+        icon={'plus'}
+      >
+        {`Filter`}
+      </Button>
+    </div>
+  )
+}
+
+const getStyles = (_theme: GrafanaTheme2) => {
+  return {
+    wrapper: css`
+      align-self: flex-end;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    `,
+  };
+};
+
+export default QueryBuilderAddFilter;

--- a/src/components/QueryEditor/QueryBuilder/components/QueryBuilderFilters/QueryBuilderFieldFilter.tsx
+++ b/src/components/QueryEditor/QueryBuilder/components/QueryBuilderFilters/QueryBuilderFieldFilter.tsx
@@ -1,0 +1,148 @@
+import { css } from "@emotion/css";
+import React, { useMemo, useState } from "react";
+
+import { GrafanaTheme2, SelectableValue, TimeRange } from "@grafana/data";
+import { IconButton, Label, Select, useStyles2 } from "@grafana/ui";
+
+import { VictoriaLogsDatasource } from "../../../../../datasource";
+import { escapeLabelValueInExactSelector } from "../../../../../languageUtils";
+import { FilterFieldType, VisualQuery } from "../../../../../types";
+import { deleteByIndexPath } from "../../utils/modifyFilterVisualQuery/deleteByIndexPath";
+import { updateValueByIndexPath } from "../../utils/modifyFilterVisualQuery/updateByIndexPath";
+import { DEFAULT_FIELD } from "../../utils/parseToString";
+
+interface Props {
+  datasource: VictoriaLogsDatasource;
+  filter: string;
+  query: VisualQuery;
+  indexPath: number[];
+  timeRange?: TimeRange;
+  onChange: (query: VisualQuery) => void;
+}
+
+const QueryBuilderFieldFilter = ({ datasource, filter, query, indexPath, timeRange, onChange }: Props) => {
+  const styles = useStyles2(getStyles);
+
+  const [fieldNames, setFieldNames] = useState<SelectableValue<string>[]>([])
+  const [isLoadingFieldNames, setIsLoadingFieldNames] = useState(false)
+
+  const [fieldValues, setFieldValues] = useState<SelectableValue<string>[]>([])
+  const [isLoadingFieldValues, setIsLoadingFieldValues] = useState(false)
+
+  const { field, fieldValue } = useMemo(() => {
+    const regex = /("[^"]*"|'[^']*'|\S+)\s*:\s*("[^"]*"|'[^']*'|\S+)?|\S+/i
+    const matches = filter.match(regex);
+    if (!matches || matches.length < 1) {
+      return {};
+    }
+    const field = matches[1] || DEFAULT_FIELD
+    const fieldValue = matches[2] ?? (matches[1] ? "" : matches[0])
+
+    return { field, fieldValue }
+  }, [filter])
+
+  const handleRemoveFilter = () => {
+    onChange({
+      ...query,
+      filters: deleteByIndexPath(query.filters, indexPath)
+    })
+  }
+
+  const handleSelect = (type: FilterFieldType) => ({ value: selected }: SelectableValue<string>) => {
+    const fullFilter = type === FilterFieldType.Name
+      ? `${selected}: ${fieldValue || ''}`
+      : `${field || ''}: ${field === '_stream' ? selected : `"${escapeLabelValueInExactSelector(selected || "")}"`} `
+
+    onChange({
+      ...query,
+      filters: updateValueByIndexPath(query.filters, indexPath, fullFilter)
+    })
+  }
+
+  const handleCreate = (type: FilterFieldType) => (customValue: string) => {
+    handleSelect(type)({ value: customValue })
+  }
+
+  const handleOpenMenu = (type: FilterFieldType) => async () => {
+    const setterLoading = type === FilterFieldType.Name ? setIsLoadingFieldNames : setIsLoadingFieldValues
+    const setterValues = type === FilterFieldType.Name ? setFieldNames : setFieldValues
+
+    setterLoading(true)
+    const list = await datasource.languageProvider?.getFieldList({ type, timeRange, field, })
+    const result = list ? list.map(({ value, hits }) => ({
+      value,
+      label: value || " ",
+      description: `hits: ${hits}`,
+    })) : []
+    setterValues(result)
+    setterLoading(false)
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.header}>
+        <Label>Filter</Label>
+        <IconButton
+          name={"times"}
+          tooltip={"Remove filter"}
+          size="sm"
+          onClick={handleRemoveFilter}
+        />
+      </div>
+      <div className={styles.content}>
+        <Select
+          placeholder="Select field"
+          width="auto"
+          options={fieldNames.length ? fieldNames : [{ label: field, value: field }]}
+          value={field}
+          isLoading={isLoadingFieldNames}
+          loadingMessage={"Loading fields names..."}
+          allowCustomValue
+          onCreateOption={handleCreate(FilterFieldType.Name)}
+          onChange={handleSelect(FilterFieldType.Name)}
+          onOpenMenu={handleOpenMenu(FilterFieldType.Name)}
+        />
+        <span>:</span>
+        <Select
+          placeholder="Select value"
+          width="auto"
+          options={fieldValues.length ? fieldValues : fieldValue ? [{ label: fieldValue, value: fieldValue }] : []}
+          value={fieldValue}
+          isLoading={isLoadingFieldValues}
+          loadingMessage={"Loading fields values..."}
+          noOptionsMessage={field ? "No values found" : "Select field first"}
+          allowCustomValue
+          onCreateOption={handleCreate(FilterFieldType.Value)}
+          onChange={handleSelect(FilterFieldType.Value)}
+          onOpenMenu={handleOpenMenu(FilterFieldType.Value)}
+        />
+      </div>
+    </div>
+  )
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    wrapper: css`
+      display: grid;
+      gap: ${theme.spacing(0.5)};
+      width: max-content;
+      border: 1px solid ${theme.colors.border.strong};
+      background-color: ${theme.colors.background.secondary};
+      padding: ${theme.spacing(1)};
+    `,
+    header: css`
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    `,
+    content: css`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: ${theme.spacing(0.5)};
+    `,
+  };
+};
+
+export default QueryBuilderFieldFilter

--- a/src/components/QueryEditor/QueryBuilder/components/QueryBuilderOperators/QueryBuilderSelectOperator.tsx
+++ b/src/components/QueryEditor/QueryBuilder/components/QueryBuilderOperators/QueryBuilderSelectOperator.tsx
@@ -1,0 +1,66 @@
+import { css } from "@emotion/css";
+import React from 'react';
+
+import { GrafanaTheme2, SelectableValue } from "@grafana/data";
+import { Label, Select, useStyles2 } from "@grafana/ui";
+
+import { VisualQuery } from "../../../../../types";
+import { updateOperatorByIndexPath } from "../../utils/modifyFilterVisualQuery/updateByIndexPath";
+import { DEFAULT_FILTER_OPERATOR } from "../../utils/parseToString";
+import { BUILDER_OPERATORS } from "../../utils/parsing";
+
+interface Props {
+  query: VisualQuery;
+  operator: string;
+  indexPath: number[];
+  onChange: (query: VisualQuery) => void;
+}
+
+const QueryBuilderSelectOperator: React.FC<Props> = ({ query, operator, indexPath, onChange }) => {
+  const styles = useStyles2(getStyles);
+
+  const handleOperatorChange = ({ value }: SelectableValue<string>) => {
+    onChange({
+      ...query,
+      filters: updateOperatorByIndexPath(query.filters, indexPath, value || DEFAULT_FILTER_OPERATOR)
+    })
+  }
+
+  const handleCreateOption = (customValue: string) => {
+    handleOperatorChange({ value: customValue });
+  }
+
+  const options = BUILDER_OPERATORS.map((op) => ({ label: op, value: op }))
+
+  return (
+    <div className={styles.wrapper}>
+      <Label>Operator</Label>
+      <Select
+        width="auto"
+        options={options}
+        value={operator.toUpperCase()}
+        allowCustomValue
+        onCreateOption={handleCreateOption}
+        onChange={handleOperatorChange}
+      />
+    </div>
+  )
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    wrapper: css`
+      display: flex;
+      flex-direction: column;
+      gap: ${theme.spacing(0.5)};
+      width: max-content;
+      min-width: 100px;
+      height: max-content;
+      border: 1px solid ${theme.colors.border.medium};
+      background-color: ${theme.colors.background.secondary};
+      padding: ${theme.spacing(1)};
+    `
+  };
+};
+
+export default QueryBuilderSelectOperator;

--- a/src/components/QueryEditor/QueryBuilder/utils/modifyFilterVisualQuery/deleteByIndexPath.test.ts
+++ b/src/components/QueryEditor/QueryBuilder/utils/modifyFilterVisualQuery/deleteByIndexPath.test.ts
@@ -1,0 +1,99 @@
+import { FilterVisualQuery } from "../../../../../types";
+
+import { deleteByIndexPath } from './deleteByIndexPath';
+
+describe('deleteByIndexPath', () => {
+  let obj: FilterVisualQuery;
+
+  beforeEach(() => {
+    obj = {
+      operators: ['and'],
+      values: [
+        { operators: ['or', 'or'], values: ['_msg:error', '_msg:warn', '_msg:info'] },
+        { operators: ['and', 'and', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd', '_msg:ssd'] }
+      ]
+    };
+  });
+
+  it('should delete _msg:error and the corresponding operator', () => {
+    const indexPath = [0, 0];
+    const newObj = deleteByIndexPath(obj, indexPath);
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        { operators: ['or'], values: ['_msg:warn', '_msg:info'] },
+        { operators: ['and', 'and', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd', '_msg:ssd'] }
+      ]
+    });
+  });
+
+  it('should delete _msg:info and the corresponding operator', () => {
+    const indexPath = [0, 2];
+    const newObj = deleteByIndexPath(obj, indexPath);
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        { operators: ['or'], values: ['_msg:error', '_msg:warn'] },
+        { operators: ['and', 'and', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd', '_msg:ssd'] }
+      ]
+    });
+  });
+
+  it('should delete _msg:ssd and the corresponding operator', () => {
+    const indexPath = [1, 3];
+    const newObj = deleteByIndexPath(obj, indexPath);
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        { operators: ['or', 'or'], values: ['_msg:error', '_msg:warn', '_msg:info'] },
+        { operators: ['and', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd'] }
+      ]
+    });
+  });
+
+  it('should handle deleting from flat structures', () => {
+    obj = {
+      operators: ['or', 'or'],
+      values: ['_msg:error', '_msg:warn', '_msg:info']
+    };
+
+    const indexPath = [1];
+    const newObj = deleteByIndexPath(obj, indexPath);
+    expect(newObj).toEqual({
+      operators: ['or'],
+      values: ['_msg:error', '_msg:info']
+    });
+  });
+
+  it('should handle deleting from nested structures', () => {
+    obj = {
+      operators: ['and'],
+      values: [
+        {
+          operators: ['or'],
+          values: [
+            { operators: ['and'], values: ['_msg:error', '_msg:warn'] },
+            '_msg:info'
+          ]
+        },
+        "_msg:cpu"
+      ]
+    };
+
+    const indexPath = [0, 0, 0];
+    const newObj = deleteByIndexPath(obj, indexPath);
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        {
+          operators: ['or'],
+          values: [
+            { operators: [], values: ['_msg:warn'] },
+            '_msg:info'
+          ]
+        },
+        "_msg:cpu"
+      ]
+    });
+  });
+});

--- a/src/components/QueryEditor/QueryBuilder/utils/modifyFilterVisualQuery/deleteByIndexPath.ts
+++ b/src/components/QueryEditor/QueryBuilder/utils/modifyFilterVisualQuery/deleteByIndexPath.ts
@@ -1,0 +1,43 @@
+import { FilterVisualQuery } from "../../../../../types";
+
+export function deleteByIndexPath(obj: FilterVisualQuery, indexPath: number[]): FilterVisualQuery {
+  // Helper function to recursively navigate the object and create a new copy
+  function recursiveDelete(currentObj: FilterVisualQuery, path: number[], level: number): FilterVisualQuery {
+    if (level === path.length - 1) {
+      // If we are at the last index, create a new array without the target element and operator
+      const newValues = [
+        ...currentObj.values.slice(0, path[level]),
+        ...currentObj.values.slice(path[level] + 1)
+      ];
+
+      let newOperators;
+      if (path[level] === 0) {
+        newOperators = currentObj.operators.slice(1); // Remove the first operator
+      } else {
+        newOperators = [
+          ...currentObj.operators.slice(0, path[level] - 1),
+          ...currentObj.operators.slice(path[level])
+        ];
+      }
+
+      return {
+        ...currentObj,
+        values: newValues,
+        operators: newOperators
+      };
+    } else {
+      // Otherwise, continue recursively and copy current level
+      return {
+        ...currentObj,
+        values: currentObj.values.map((item, index) => {
+          if (index === path[level] && typeof item !== 'string') {
+            return recursiveDelete(item, path, level + 1);
+          }
+          return item;
+        })
+      };
+    }
+  }
+
+  return recursiveDelete(obj, indexPath, 0);
+}

--- a/src/components/QueryEditor/QueryBuilder/utils/modifyFilterVisualQuery/updateByIndexPath.test.ts
+++ b/src/components/QueryEditor/QueryBuilder/utils/modifyFilterVisualQuery/updateByIndexPath.test.ts
@@ -1,0 +1,165 @@
+import { FilterVisualQuery } from "../../../../../types";
+
+import { updateValueByIndexPath, updateOperatorByIndexPath } from './updateByIndexPath';
+
+describe('updateValueByIndexPath', () => {
+  let obj: FilterVisualQuery;
+
+  beforeEach(() => {
+    obj = {
+      operators: ['and'],
+      values: [
+        { operators: ['or', 'or'], values: ['_msg:error', '_msg:warn', '_msg:info'] },
+        { operators: ['and', 'and', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd', '_msg:ssd'] }
+      ]
+    };
+  });
+
+  it('should update _msg:error to _msg:critical', () => {
+    const indexPath = [0, 0];
+    const newObj = updateValueByIndexPath(obj, indexPath, '_msg:critical');
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        { operators: ['or', 'or'], values: ['_msg:critical', '_msg:warn', '_msg:info'] },
+        { operators: ['and', 'and', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd', '_msg:ssd'] }
+      ]
+    });
+  });
+
+  it('should update _msg:info to _msg:notification', () => {
+    const indexPath = [0, 2];
+    const newObj = updateValueByIndexPath(obj, indexPath, '_msg:notification');
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        { operators: ['or', 'or'], values: ['_msg:error', '_msg:warn', '_msg:notification'] },
+        { operators: ['and', 'and', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd', '_msg:ssd'] }
+      ]
+    });
+  });
+
+  it('should update _msg:ssd to _msg:nvme', () => {
+    const indexPath = [1, 3];
+    const newObj = updateValueByIndexPath(obj, indexPath, '_msg:nvme');
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        { operators: ['or', 'or'], values: ['_msg:error', '_msg:warn', '_msg:info'] },
+        { operators: ['and', 'and', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd', '_msg:nvme'] }
+      ]
+    });
+  });
+
+  it('should handle updating in flat structures', () => {
+    obj = {
+      operators: ['or', 'or'],
+      values: ['_msg:error', '_msg:warn', '_msg:info']
+    };
+
+    const indexPath = [1];
+    const newObj = updateValueByIndexPath(obj, indexPath, '_msg:alert');
+    expect(newObj).toEqual({
+      operators: ['or', 'or'],
+      values: ['_msg:error', '_msg:alert', '_msg:info']
+    });
+  });
+
+  it('should handle updating in nested structures', () => {
+    obj = {
+      operators: ['and'],
+      values: [
+        {
+          operators: ['or'],
+          values: [
+            { operators: ['and'], values: ['_msg:error', '_msg:warn'] },
+            '_msg:info'
+          ]
+        }
+      ]
+    };
+
+    const indexPath = [0, 0, 0];
+    const newObj = updateValueByIndexPath(obj, indexPath, '_msg:critical');
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        {
+          operators: ['or'],
+          values: [
+            { operators: ['and'], values: ['_msg:critical', '_msg:warn'] },
+            '_msg:info'
+          ]
+        }
+      ]
+    });
+  });
+});
+
+describe('updateOperatorByIndexPath', () => {
+  let obj: FilterVisualQuery;
+
+  beforeEach(() => {
+    obj = {
+      operators: ['and'],
+      values: [
+        { operators: ['or', 'or'], values: ['_msg:error', '_msg:warn', '_msg:info'] },
+        { operators: ['and', 'and', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd', '_msg:ssd'] }
+      ]
+    };
+  });
+
+  it('should update operator or to and between _msg:error and _msg:warn', () => {
+    const indexPath = [0, 0];
+    const newObj = updateOperatorByIndexPath(obj, indexPath, 'and');
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        { operators: ['and', 'or'], values: ['_msg:error', '_msg:warn', '_msg:info'] },
+        { operators: ['and', 'and', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd', '_msg:ssd'] }
+      ]
+    });
+  });
+
+  it('should update operator and to or between _msg:cpu and _msg:gpu', () => {
+    const indexPath = [1, 1];
+    const newObj = updateOperatorByIndexPath(obj, indexPath, 'or');
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        { operators: ['or', 'or'], values: ['_msg:error', '_msg:warn', '_msg:info'] },
+        { operators: ['and', 'or', 'and'], values: ['_msg:cpu', '_msg:gpu', '_msg:hdd', '_msg:ssd'] }
+      ]
+    });
+  });
+
+  it('should handle updating operators in nested structures', () => {
+    obj = {
+      operators: ['and'],
+      values: [
+        {
+          operators: ['or'],
+          values: [
+            { operators: ['and'], values: ['_msg:error', '_msg:warn'] },
+            '_msg:info'
+          ]
+        }
+      ]
+    };
+
+    const indexPath = [0, 0, 0];
+    const newObj = updateOperatorByIndexPath(obj, indexPath, 'or');
+    expect(newObj).toEqual({
+      operators: ['and'],
+      values: [
+        {
+          operators: ['or'],
+          values: [
+            { operators: ['or'], values: ['_msg:error', '_msg:warn'] },
+            '_msg:info'
+          ]
+        }
+      ]
+    });
+  });
+});

--- a/src/components/QueryEditor/QueryBuilder/utils/modifyFilterVisualQuery/updateByIndexPath.ts
+++ b/src/components/QueryEditor/QueryBuilder/utils/modifyFilterVisualQuery/updateByIndexPath.ts
@@ -1,0 +1,58 @@
+import { FilterVisualQuery } from "../../../../../types";
+
+export function updateValueByIndexPath(obj: FilterVisualQuery, indexPath: number[], newValue: string): FilterVisualQuery {
+  // Helper function to recursively navigate the object and create a new copy
+  function recursiveUpdateValue(currentObj: FilterVisualQuery, path: number[], level: number): FilterVisualQuery {
+    if (level === path.length - 1) {
+      // If we are at the last index, update the value
+      const newValues = [...currentObj.values];
+      newValues[path[level]] = newValue;
+      return {
+        ...currentObj,
+        values: newValues,
+      };
+    } else {
+      // Otherwise, continue recursively and copy current level
+      const newValues = [...currentObj.values];
+      if (typeof newValues[path[level]] !== 'object' || newValues[path[level]] === null) {
+        newValues[path[level]] = { values: [], operators: currentObj.operators }; // Create a new valid FilterVisualQuery object
+      }
+      newValues[path[level]] = recursiveUpdateValue(newValues[path[level]] as FilterVisualQuery, path, level + 1);
+      return {
+        ...currentObj,
+        values: newValues,
+      };
+    }
+  }
+
+  return recursiveUpdateValue(obj, indexPath, 0);
+}
+
+export function updateOperatorByIndexPath(obj: FilterVisualQuery, indexPath: number[], newOperator: string): FilterVisualQuery {
+  // Helper function to recursively navigate the object and create a new copy
+  function recursiveUpdateOperator(currentObj: FilterVisualQuery, path: number[], level: number): FilterVisualQuery {
+    if (level === path.length - 1) {
+      // If we are at the last index, update the operator
+      const newOperators = [...currentObj.operators];
+      newOperators[path[level]] = newOperator;
+      return {
+        ...currentObj,
+        operators: newOperators,
+      };
+    } else {
+      // Otherwise, continue recursively and copy current level
+      const newValues = [...currentObj.values];
+      if (typeof newValues[path[level]] !== 'object' || newValues[path[level]] === null) {
+        newValues[path[level]] = { values: [], operators: [] }; // Create a new valid FilterVisualQuery object
+      }
+      newValues[path[level]] = recursiveUpdateOperator(newValues[path[level]] as FilterVisualQuery, path, level + 1);
+      return {
+        ...currentObj,
+        values: newValues,
+      };
+    }
+  }
+
+  return recursiveUpdateOperator(obj, indexPath, 0);
+}
+

--- a/src/components/QueryEditor/QueryBuilder/utils/parseFromString.ts
+++ b/src/components/QueryEditor/QueryBuilder/utils/parseFromString.ts
@@ -1,0 +1,129 @@
+import { FilterVisualQuery, VisualQuery } from "../../../../types";
+
+import { BUILDER_OPERATORS, isEmptyQuery } from "./parsing";
+
+interface Context {
+  query: VisualQuery;
+  errors: string[];
+}
+
+type ParsedExpression = string | ParsedExpression[];
+
+export const buildVisualQueryFromString = (expr: string): Context => {
+  // This will be modified in the handleExpression
+  const visQuery: VisualQuery = {
+    filters: { operators: [], values: [] },
+    pipes: []
+  };
+
+  const context: Context = {
+    query: visQuery,
+    errors: [],
+  };
+
+  try {
+    const { filters, pipes } = handleExpression(expr);
+    visQuery.filters = filters
+    visQuery.pipes = pipes
+  } catch (err) {
+    console.error(err);
+    if (err instanceof Error) {
+      context.errors.push(err.message);
+    }
+  }
+
+  // If we have empty query, we want to reset errors
+  if (isEmptyQuery(context.query)) {
+    context.errors = [];
+  }
+
+  return context;
+}
+
+const handleExpression = (expr: string) => {
+  const [filterStrPart, ...pipeParts] = expr.split('|').map(part => part.trim());
+  const filters = parseStringToFilterVisualQuery(filterStrPart)
+  return { filters, pipes: pipeParts };
+}
+
+const parseStringToFilterVisualQuery = (expression: string): FilterVisualQuery => {
+  const parsedExpressions = parseExpression(expression)
+
+  const groupFilterQuery = (parts: ParsedExpression[]): FilterVisualQuery => {
+    const filter: FilterVisualQuery = {
+      values: [],
+      operators: [],
+    }
+
+    const parsePart = (part: ParsedExpression, _index: number) => {
+      if (!part) {
+        return
+      }
+      if (typeof part === 'string') {
+        if (BUILDER_OPERATORS.includes(part.toUpperCase())) {
+          filter.operators.push(part);
+        } else {
+          filter.values.push(...parseStringPart(part));
+        }
+      } else {
+        filter.values.push(groupFilterQuery(part));
+      }
+    }
+    parts.forEach(parsePart);
+
+    return filter;
+  }
+
+  return groupFilterQuery(parsedExpressions)
+}
+
+const splitByTopLevelParentheses = (input: string) => {
+  const result = [];
+  let level = 0;
+  let current = '';
+
+  for (let char of input) {
+    if (char === '(') {
+      if (level === 0 && current.trim() !== '') {
+        result.push(current.trim());
+        current = '';
+      }
+      level++;
+      current += char;
+    } else if (char === ')') {
+      level--;
+      current += char;
+      if (level === 0) {
+        result.push(current.trim());
+        current = '';
+      }
+    } else {
+      current += char;
+    }
+  }
+
+  if (current.trim() !== '') {
+    result.push(current.trim());
+  }
+  const regex = new RegExp(`(?:^|\\s)(${BUILDER_OPERATORS.join('|')})\\s*(?:$|\\s+)`, 'i')
+  return result.map(part => part.includes('(') ? part : part.split(regex)).flat(1)
+}
+
+const parseExpression = (input: string): ParsedExpression[] => {
+  const parts = splitByTopLevelParentheses(input);
+
+  return parts.map(part => {
+    if (part.startsWith('(') && part.endsWith(')')) {
+      // Recursively parse the inner expression
+      return parseExpression(part.slice(1, -1));
+    } else {
+      return part.trim();
+    }
+  });
+}
+
+const parseStringPart = (expression: string) => {
+  const regex = /("[^"]*"|'[^']*'|\S+)\s*:\s*("[^"]*"|'[^']*'|\S+)?|\S+/g;
+  const matches = expression.match(regex) || [];
+  return matches.map(match => match.trim());
+}

--- a/src/components/QueryEditor/QueryBuilder/utils/parseToString.ts
+++ b/src/components/QueryEditor/QueryBuilder/utils/parseToString.ts
@@ -1,0 +1,29 @@
+import { FilterVisualQuery, VisualQuery } from "../../../../types";
+
+export const DEFAULT_FILTER_OPERATOR = "AND";
+export const DEFAULT_FIELD = "_msg";
+
+const filterVisualQueryToString = (query: FilterVisualQuery): string => {
+  const valueStrings: string[] = [];
+
+  for (let i = 0; i < query.values.length; i++) {
+    const value = query.values[i];
+    if (typeof value === 'string') {
+      valueStrings.push(value);
+    } else {
+      valueStrings.push(`(${filterVisualQueryToString(value)})`);
+    }
+  }
+
+  const operatorStrings = query.operators.map(op => op.trim());
+
+  return valueStrings.reduce((acc, val, index) => {
+    const operator = operatorStrings[index - 1] || DEFAULT_FILTER_OPERATOR;
+    return acc + (index === 0 ? '' : ` ${operator} `) + val;
+  }, '');
+}
+
+export const parseVisualQueryToString = (query: VisualQuery): string => {
+  // TODO add parse pipes
+  return filterVisualQueryToString(query.filters);
+}

--- a/src/components/QueryEditor/QueryBuilder/utils/parsing.test.ts
+++ b/src/components/QueryEditor/QueryBuilder/utils/parsing.test.ts
@@ -1,0 +1,69 @@
+import { buildVisualQueryFromString } from './parseFromString';
+
+describe('buildVisualQueryFromString', () => {
+  it('should parse a simple expression correctly', () => {
+    const expr = 'field:value';
+    const result = buildVisualQueryFromString(expr);
+    expect(result.errors).toHaveLength(0);
+    expect(result.query.filters.values).toEqual(['field:value']);
+    expect(result.query.pipes).toEqual([]);
+  });
+
+  it('should parse simple field expression', () => {
+    const expr = 'field';
+    const result = buildVisualQueryFromString(expr);
+    expect(result.errors).toHaveLength(0);
+    expect(result.query.filters.values).toEqual(['field']);
+    expect(result.query.pipes).toEqual([]);
+  });
+
+  it('should parse field.subfield with value expression', () => {
+    const expr = 'field.subfield:"value"';
+    const result = buildVisualQueryFromString(expr);
+    expect(result.errors).toHaveLength(0);
+    expect(result.query.filters.values).toEqual(['field.subfield:"value"']);
+    expect(result.query.pipes).toEqual([]);
+  });
+
+  it('should parse expression with quoted field and value', () => {
+    const expr = '"field:subfield": "value"';
+    const result = buildVisualQueryFromString(expr);
+    expect(result.errors).toHaveLength(0);
+    expect(result.query.filters.values).toEqual(['"field:subfield": "value"']);
+    expect(result.query.pipes).toEqual([]);
+  });
+
+  it('should handle complex expressions with nested parentheses', () => {
+    const expr = '(field1:value1 and field2:value2) or field3:value3';
+    const result = buildVisualQueryFromString(expr);
+    expect(result.errors).toHaveLength(0);
+    expect(result.query.filters).toEqual({
+      operators: ['or'],
+      values: [
+        { operators: ['and'], values: ['field1:value1', 'field2:value2'] },
+        "field3:value3"
+      ],
+    });
+    expect(result.query.pipes).toEqual([]);
+  });
+
+  it('should handle expressions with quotes correctly', () => {
+    const expr = 'field: "value with spaces"';
+    const result = buildVisualQueryFromString(expr);
+    expect(result.errors).toHaveLength(0);
+    expect(result.query.filters.values).toEqual(['field: "value with spaces"']);
+    expect(result.query.pipes).toEqual([]);
+  });
+
+  it('should reset errors for empty queries', () => {
+    const expr = '';
+    const result = buildVisualQueryFromString(expr);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should reset errors for empty queries', () => {
+    const expr = '*';
+    const result = buildVisualQueryFromString(expr);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/src/components/QueryEditor/QueryBuilder/utils/parsing.ts
+++ b/src/components/QueryEditor/QueryBuilder/utils/parsing.ts
@@ -1,0 +1,7 @@
+import { VisualQuery } from "../../../../types";
+
+export const BUILDER_OPERATORS = ['OR', 'AND']
+
+export const isEmptyQuery = (query: VisualQuery) => {
+  return query.filters.values?.length === 0 && query.pipes.length === 0;
+}

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -1,22 +1,41 @@
 import { css } from "@emotion/css";
 import { isEqual } from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { CoreApp, GrafanaTheme2, LoadingState } from '@grafana/data';
-import { Button, useStyles2 } from '@grafana/ui';
+import { Button, ConfirmModal, useStyles2 } from '@grafana/ui';
 
-import { Query, VictoriaLogsQueryEditorProps } from "../../types";
+import { Query, QueryEditorMode, VictoriaLogsQueryEditorProps } from "../../types";
 
+import { EditorHeader } from "./EditorHeader";
+import { QueryBuilderContainer } from "./QueryBuilder/QueryBuilderContainer";
+import { QueryEditorModeToggle } from "./QueryBuilder/QueryEditorModeToggle";
+import { buildVisualQueryFromString } from "./QueryBuilder/utils/parseFromString";
 import QueryCodeEditor from "./QueryCodeEditor";
-import { getQueryWithDefaults } from "./state";
+import { changeEditorMode, getQueryWithDefaults } from "./state";
 
 const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
   const styles = useStyles2(getStyles);
 
-  const { onChange, onRunQuery, data, app, queries } = props;
+  const { onChange, onRunQuery, data, app, queries, range: timeRange } = props;
   const [dataIsStale, setDataIsStale] = useState(false);
+  const [parseModalOpen, setParseModalOpen] = useState(false);
 
   const query = getQueryWithDefaults(props.query);
+  const editorMode = query.editorMode!;
+
+  const onEditorModeChange = useCallback((newEditorMode: QueryEditorMode) => {
+      if (newEditorMode === QueryEditorMode.Builder) {
+        const result = buildVisualQueryFromString(query.expr || '');
+        if (result.errors.length) {
+          setParseModalOpen(true);
+          return;
+        }
+      }
+      changeEditorMode(query, newEditorMode, onChange);
+    },
+    [query, onChange]
+  );
 
   useEffect(() => {
     setDataIsStale(false);
@@ -30,33 +49,57 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
   };
 
   return (
-    <div className={styles.wrapper}>
-      <div className="flex-grow-1">
-        <QueryCodeEditor {...props} query={query} onChange={onChangeInternal} showExplain={true}/>
+    <>
+      <ConfirmModal
+        isOpen={parseModalOpen}
+        title="Query parsing"
+        body="There were errors while trying to parse the query. Continuing to visual builder may lose some parts of the query."
+        confirmText="Continue"
+        onConfirm={() => {
+          onChange({ ...query, editorMode: QueryEditorMode.Builder });
+          setParseModalOpen(false);
+        }}
+        onDismiss={() => setParseModalOpen(false)}
+      />
+      <div className={styles.wrapper}>
+        <EditorHeader>
+          <QueryEditorModeToggle mode={editorMode} onChange={onEditorModeChange}/>
+          {app !== CoreApp.Explore && app !== CoreApp.Correlations && (
+            <Button
+              variant={dataIsStale ? 'primary' : 'secondary'}
+              size="sm"
+              onClick={onRunQuery}
+              icon={data?.state === LoadingState.Loading ? 'fa fa-spinner' : undefined}
+              disabled={data?.state === LoadingState.Loading}
+            >
+              {queries && queries.length > 1 ? `Run queries` : `Run query`}
+            </Button>
+          )}
+        </EditorHeader>
+        <div className="flex-grow-1">
+          {editorMode === QueryEditorMode.Builder ? (
+            <QueryBuilderContainer
+              datasource={props.datasource}
+              query={query}
+              onChange={onChangeInternal}
+              onRunQuery={props.onRunQuery}
+              timeRange={timeRange}
+            />
+          ) : (
+            <QueryCodeEditor {...props} query={query} onChange={onChangeInternal} showExplain={true}/>
+          )}
+        </div>
       </div>
-      <div>
-        {app !== CoreApp.Explore && app !== CoreApp.Correlations && (
-          <Button
-            variant={dataIsStale ? 'primary' : 'secondary'}
-            size="sm"
-            onClick={onRunQuery}
-            icon={data?.state === LoadingState.Loading ? 'fa fa-spinner' : undefined}
-            disabled={data?.state === LoadingState.Loading}
-          >
-            {queries && queries.length > 1 ? `Run queries` : `Run query`}
-          </Button>
-        )}
-      </div>
-    </div>
-  );
+    </>
+  )
 });
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     wrapper: css`
-      display: flex;
+      display: grid;
       align-items: flex-start;
-      gap: ${theme.spacing(1)};
+      gap: ${theme.spacing(0.5)};
     `
   };
 };

--- a/src/components/QueryEditor/state.ts
+++ b/src/components/QueryEditor/state.ts
@@ -1,15 +1,38 @@
-import { Query, QueryType } from "../../types";
+import { Query, QueryEditorMode, QueryType } from "../../types";
+
+const queryEditorModeDefaultLocalStorageKey = 'VictoriaLogsQueryEditorModeDefault';
 
 export function getQueryWithDefaults(query: Query): Query {
   let result = query;
 
-  if (query.expr == null) {
-    result = { ...result, expr: '' };
+  if (!query.editorMode) {
+    result.editorMode = getDefaultEditorMode(query.expr);
   }
 
-  if (query.queryType == null) {
-    result = { ...result, queryType: QueryType.Range };
+  if (!query.expr) {
+    result.expr = ''
+  }
+
+  if (!query.queryType) {
+    result.queryType = QueryType.Range;
   }
 
   return result;
+}
+
+export function changeEditorMode(query: Query, editorMode: QueryEditorMode, onChange: (query: Query) => void) {
+  if (query.expr === '') {
+    window.localStorage.setItem(queryEditorModeDefaultLocalStorageKey, editorMode);
+  }
+
+  onChange({ ...query, editorMode });
+}
+
+export function getDefaultEditorMode(expr: string) {
+  if (expr != null && expr !== '') {
+    return QueryEditorMode.Code;
+  }
+
+  const value = window.localStorage.getItem(queryEditorModeDefaultLocalStorageKey);
+  return value === QueryEditorMode.Builder ? QueryEditorMode.Builder : QueryEditorMode.Code;
 }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,5 +1,5 @@
-import { map as lodashMap } from 'lodash';
-import { Observable } from "rxjs";
+import { defaults, map as lodashMap } from 'lodash';
+import { Observable, lastValueFrom } from "rxjs";
 import { map } from 'rxjs/operators';
 
 import {
@@ -7,29 +7,53 @@ import {
   DataQueryRequest,
   DataQueryResponse,
   DataSourceInstanceSettings,
-  ScopedVars
+  ScopedVars,
 } from '@grafana/data';
-import { DataSourceWithBackend, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
+import {
+  BackendSrvRequest,
+  DataSourceWithBackend,
+  FetchResponse,
+  getBackendSrv,
+  getTemplateSrv,
+  TemplateSrv
+} from '@grafana/runtime';
 
 import { transformBackendResult } from "./backendResultTransformer";
 import QueryEditor from "./components/QueryEditor/QueryEditor";
 import { escapeLabelValueInSelector, isRegexSelector } from "./languageUtils";
+import LogsQlLanguageProvider from "./language_provider";
 import { addLabelToQuery, queryHasFilter, removeLabelFromQuery } from "./modifyQuery";
 import { replaceVariables, returnVariables } from "./parsingUtils";
-import { Query, Options, ToggleFilterAction, QueryFilterOptions, FilterActionType } from './types';
+import { regularEscape, specialRegexEscape } from "./regexUtils";
+import { Query, Options, ToggleFilterAction, QueryFilterOptions, FilterActionType, RequestArguments } from './types';
 
 export class VictoriaLogsDatasource
   extends DataSourceWithBackend<Query, Options> {
+  id: number;
+  url: string;
   maxLines: number;
+  basicAuth?: string;
+  withCredentials?: boolean;
+  httpMethod: string;
+  customQueryParameters: URLSearchParams;
+  languageProvider?: LogsQlLanguageProvider;
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<Options>,
-    private readonly templateSrv: TemplateSrv = getTemplateSrv()
+    private readonly templateSrv: TemplateSrv = getTemplateSrv(),
+    languageProvider?: LogsQlLanguageProvider,
   ) {
     super(instanceSettings);
 
     const settingsData = instanceSettings.jsonData || {};
+    this.id = instanceSettings.id;
+    this.url = instanceSettings.url!;
+    this.basicAuth = instanceSettings.basicAuth;
+    this.withCredentials = instanceSettings.withCredentials;
+    this.httpMethod = instanceSettings.jsonData.httpMethod || 'POST';
     this.maxLines = parseInt(settingsData.maxLines ?? '0', 10) || 1000;
+    this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
+    this.languageProvider = languageProvider ?? new LogsQlLanguageProvider(this);
     this.annotations = {
       QueryEditor: QueryEditor,
     };
@@ -139,18 +163,48 @@ export class VictoriaLogsDatasource
 
     return lodashMap(value, specialRegexEscape).join('|');
   }
-}
 
-export function regularEscape(value: any) {
-  if (typeof value === 'string') {
-    return value.replace(/'/g, "\\\\'");
+  async metadataRequest({ url, params, options }: RequestArguments) {
+    return await lastValueFrom(
+      this._request({
+        url: `/api/datasources/proxy/${this.id}/${url.replace(/^\//,'')}`,
+        params,
+        options: { method: 'GET', hideFromInspector: true, ...options },
+      })
+    )
   }
-  return value;
-}
 
-export function specialRegexEscape(value: any) {
-  if (typeof value === 'string') {
-    return regularEscape(value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]+?.()|]/g, '\\\\$&'));
+  _request<T = any>({ url, params = {}, options: overrides }: RequestArguments): Observable<FetchResponse<T>> {
+    const queryUrl = url.startsWith(`/api/datasources/proxy/${this.id}`) ? url : `${this.url}/${url}`;
+
+    const options: BackendSrvRequest = defaults(overrides, {
+      url: queryUrl,
+      method: this.httpMethod,
+      headers: {},
+      credentials: this.basicAuth || this.withCredentials ? 'include' : 'same-origin',
+    });
+
+    for (const [key, value] of this.customQueryParameters) {
+      if (params[key] == null) {
+        params[key] = value;
+      }
+    }
+
+    if (options.method === 'GET' && Object.keys(params).length) {
+      const searchParams = new URLSearchParams(params);
+      const separator = options.url.search(/\?/) >= 0 ? '&' : '?'
+      options.url += separator + searchParams.toString()
+    }
+
+    if (options.method !== 'GET') {
+      options.headers!['Content-Type'] = 'application/x-www-form-urlencoded';
+      options.data = params;
+    }
+
+    if (this.basicAuth) {
+      options.headers!.Authorization = this.basicAuth;
+    }
+
+    return getBackendSrv().fetch<T>(options);
   }
-  return value;
 }

--- a/src/language_provider.ts
+++ b/src/language_provider.ts
@@ -1,0 +1,90 @@
+import { getDefaultTimeRange, LanguageProvider, TimeRange, } from '@grafana/data';
+import { BackendSrvRequest } from '@grafana/runtime';
+
+import { VictoriaLogsDatasource } from './datasource';
+import { FiledHits, FilterFieldType } from "./types";
+
+interface FetchFieldsOptions {
+  type: FilterFieldType;
+  query?: string;
+  field?: string;
+  timeRange?: TimeRange;
+}
+
+interface FieldsRequestParams {
+  query: string;
+  from: number;
+  to: number;
+  field?: string;
+}
+
+export default class LogsQlLanguageProvider extends LanguageProvider {
+  declare startTask: Promise<any>;
+  datasource: VictoriaLogsDatasource;
+  cacheSize: number;
+  cacheValues: Map<string, FiledHits[]>
+
+  constructor(datasource: VictoriaLogsDatasource, initialValues?: Partial<LogsQlLanguageProvider>) {
+    super();
+
+    this.datasource = datasource;
+    this.cacheSize = 100;
+    this.cacheValues = new Map<string, FiledHits[]>();
+
+    Object.assign(this, initialValues);
+  }
+
+  request = async (url: string, defaultValue: any, params = {}, options?: Partial<BackendSrvRequest>): Promise<any> => {
+    try {
+      const res = await this.datasource.metadataRequest({ url, params, options });
+      return res.data?.values;
+    } catch (error) {
+      console.error(error);
+    }
+
+    return defaultValue;
+  };
+
+  start = async (): Promise<any[]> => {
+    return Promise.all([]);
+  };
+
+  async getFieldList(options: FetchFieldsOptions): Promise<FiledHits[]> {
+    if (options.type === FilterFieldType.Value && !options.field) {
+      return [];
+    }
+
+    const params: FieldsRequestParams = {
+      query: "*",
+      ...this.getTimeRangeParams(options.timeRange),
+    };
+    if (options.type === FilterFieldType.Value) {
+      params.field = options.field;
+    }
+
+    const url = options.type === FilterFieldType.Name ? 'select/logsql/field_names' : `select/logsql/field_values`;
+    const key = `${url}/${Object.values(params).join('/')}`;
+
+    if (this.cacheValues.has(key)) {
+      return this.cacheValues.get(key)!;
+    }
+
+    if (this.cacheValues.size >= this.cacheSize) {
+      const firstKey = this.cacheValues.keys().next().value;
+      this.cacheValues.delete(firstKey);
+    }
+
+    const result = await this.request(url, [], params, { method: 'POST' });
+    this.cacheValues.set(key, result);
+    return result;
+  }
+
+  getTimeRangeParams(timeRange?: TimeRange) {
+    const range = timeRange ?? getDefaultTimeRange();
+    return {
+      from: range.from.startOf('day').valueOf(),
+      to: range.to.endOf('day').valueOf(),
+    }
+  }
+}
+

--- a/src/regexUtils.ts
+++ b/src/regexUtils.ts
@@ -1,0 +1,13 @@
+export function regularEscape(value: any) {
+  if (typeof value === 'string') {
+    return value.replace(/'/g, "\\\\'");
+  }
+  return value;
+}
+
+export function specialRegexEscape(value: any) {
+  if (typeof value === 'string') {
+    return regularEscape(value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]+?.()|]/g, '\\\\$&'));
+  }
+  return value;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,13 @@
 import { DataFrame, DataSourceJsonData, KeyValue, QueryEditorProps } from '@grafana/data';
+import { BackendSrvRequest } from "@grafana/runtime";
 import { DataQuery } from '@grafana/schema';
 
 import { VictoriaLogsDatasource } from "./datasource";
 
 export interface Options extends DataSourceJsonData {
   maxLines?: string;
+  httpMethod?: string;
+  customQueryParameters?: string;
   // derivedFields?: DerivedFieldConfig[];
   // alertmanager?: string;
   // keepCookies?: string[];
@@ -28,7 +31,13 @@ export enum QueryType {
   Stream = 'stream',
 }
 
+export enum QueryEditorMode {
+  Builder = 'builder',
+  Code = 'code',
+}
+
 export interface QueryFromSchema extends DataQuery {
+  editorMode?: QueryEditorMode;
   expr: string;
   legendFormat?: string;
   maxLines?: number;
@@ -64,5 +73,36 @@ export interface ToggleFilterAction {
   type: FilterActionType;
   options: QueryFilterOptions;
   frame?: DataFrame;
+}
+
+export interface FilterVisualQuery {
+  values: (string | FilterVisualQuery)[];
+  operators: string[];
+}
+
+export interface PipeVisualQuery {
+  type: string;
+  args: string[];
+}
+
+export interface VisualQuery {
+  filters: FilterVisualQuery;
+  pipes: string[]//PipeVisualQuery[];
+}
+
+export interface RequestArguments {
+  url: string;
+  params?: Record<string, string>;
+  options?: Partial<BackendSrvRequest>;
+}
+
+export interface FiledHits {
+  value: string;
+  hits: number;
+}
+
+export enum FilterFieldType {
+  Name = 'name',
+  Value = 'value'
 }
 


### PR DESCRIPTION
Added a UI for the query builder.
  - The builder allows creating simple queries based on field names and field values.
  - The list of loaded values is cached for improved performance.
  - The builder can parse nested queries, such as:
    ```
    (foo and foo:bar) or ((foo or bar) and (foo and (foo or bar)))
    ```

See the list of planned improvements in [issue #48](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/48).
![image](https://github.com/user-attachments/assets/58e0c50c-c41d-4e7f-9a82-43af85a99ee8)
