### PR TITLE
add support for loading data for variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: Added support for loading data for variables, including log field names and values. This feature allows querying `/select/logsql/field_names` for field names and `/select/logsql/field_values` for field values. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/40).
+
 ## v0.2.6
 
 * BUGFIX: fix issue with forwarding headers from datasource to the backend or proxy. 

--- a/src/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -1,0 +1,128 @@
+import React, { FormEvent, useEffect, useState } from 'react';
+import { usePrevious } from 'react-use';
+
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { InlineField, InlineFieldRow, Input, Select } from "@grafana/ui";
+
+import { VictoriaLogsDatasource } from "../../datasource";
+import { FilterFieldType, Options, Query, VariableQuery } from '../../types';
+
+const variableOptions = [
+  { label: 'Field names', value: FilterFieldType.Name },
+  { label: 'Field values', value: FilterFieldType.Value },
+];
+
+const refId = 'VictoriaLogsVariableQueryEditor-VariableQuery'
+
+export type Props = QueryEditorProps<VictoriaLogsDatasource, Query, Options, VariableQuery>;
+
+export const LokiVariableQueryEditor = ({ onChange, query, datasource, range }: Props) => {
+  const [type, setType] = useState<FilterFieldType>();
+  const [queryFilter, setQueryFilter] = useState<string>('');
+  const [field, setField] = useState<string>('');
+  const [fieldNames, setFieldNames] = useState<SelectableValue<string>[]>([])
+
+  const previousType = usePrevious(type);
+
+  const handleTypeChange = (newType: SelectableValue<FilterFieldType>) => {
+    if (!newType.value) {
+      return;
+    }
+    setType(newType.value);
+    onChange({ refId, type: newType.value, field, query: queryFilter });
+  };
+
+  const handleFieldChange = (newField: SelectableValue<string>) => {
+    setField(newField.value || "");
+  }
+
+  const handleBlur = () => {
+    if (!type) {
+      return;
+    }
+    onChange({ refId, type, field, query: queryFilter });
+  };
+
+  const handleQueryFilterChange = (e: FormEvent<HTMLInputElement>) => {
+    setQueryFilter(e.currentTarget.value);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    e.key === 'Enter' && handleBlur()
+  }
+
+  useEffect(() => {
+    if (!query) {
+      return;
+    }
+
+    setType(query.type);
+    setField(query.field || '');
+    setQueryFilter(query.query || '');
+  }, [query]);
+
+  useEffect(() => {
+    if (type !== FilterFieldType.Value || previousType === type) {
+      return;
+    }
+
+    const getFiledNames = async () => {
+      const list = await datasource.languageProvider?.getFieldList({ type: FilterFieldType.Name, timeRange: range })
+      const result = list ? list.map(({ value, hits }) => ({
+        value,
+        label: value || " ",
+        description: `hits: ${hits}`,
+      })) : []
+      setFieldNames(result)
+    }
+
+    getFiledNames().catch(console.error)
+  }, [datasource, type, range, previousType]);
+
+  return (
+    <div>
+      <InlineFieldRow>
+        <InlineField label="Query type" labelWidth={20}>
+          <Select
+            aria-label="Query type"
+            onChange={handleTypeChange}
+            onBlur={handleBlur}
+            value={type}
+            options={variableOptions}
+            width={20}
+          />
+        </InlineField>
+        {type === FilterFieldType.Value && (
+            <InlineField label="Field" labelWidth={20}>
+              <Select
+                aria-label="Field value"
+                onChange={handleFieldChange}
+                onBlur={handleBlur}
+                value={field}
+                options={fieldNames}
+                width={20}
+              />
+            </InlineField>
+          )}
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField
+          label="Query"
+          labelWidth={20}
+          grow={true}
+          tooltip={'Optional. If defined, this filters the logs based on the specified query and returns the corresponding field names.'}
+        >
+          <Input
+            type="text"
+            aria-label="Query Filter"
+            placeholder="Optional query filter"
+            value={queryFilter}
+            onChange={handleQueryFilterChange}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+          />
+        </InlineField>
+      </InlineFieldRow>
+    </div>
+  )
+};

--- a/src/language_provider.ts
+++ b/src/language_provider.ts
@@ -1,0 +1,89 @@
+import { getDefaultTimeRange, LanguageProvider, TimeRange, } from '@grafana/data';
+import { BackendSrvRequest } from '@grafana/runtime';
+
+import { VictoriaLogsDatasource } from './datasource';
+import { FiledHits, FilterFieldType } from "./types";
+
+interface FetchFieldsOptions {
+  type: FilterFieldType;
+  query?: string;
+  field?: string;
+  timeRange?: TimeRange;
+}
+
+interface FieldsRequestParams {
+  query: string;
+  from: number;
+  to: number;
+  field?: string;
+}
+
+export default class LogsQlLanguageProvider extends LanguageProvider {
+  declare startTask: Promise<any>;
+  datasource: VictoriaLogsDatasource;
+  cacheSize: number;
+  cacheValues: Map<string, FiledHits[]>
+
+  constructor(datasource: VictoriaLogsDatasource, initialValues?: Partial<LogsQlLanguageProvider>) {
+    super();
+
+    this.datasource = datasource;
+    this.cacheSize = 100;
+    this.cacheValues = new Map<string, FiledHits[]>();
+
+    Object.assign(this, initialValues);
+  }
+
+  request = async (url: string, defaultValue: any, params = {}, options?: Partial<BackendSrvRequest>): Promise<any> => {
+    try {
+      const res = await this.datasource.metadataRequest({ url, params, options });
+      return res.data?.values;
+    } catch (error) {
+      console.error(error);
+    }
+
+    return defaultValue;
+  };
+
+  start = async (): Promise<any[]> => {
+    return Promise.all([]);
+  };
+
+  async getFieldList(options: FetchFieldsOptions): Promise<FiledHits[]> {
+    if (options.type === FilterFieldType.Value && !options.field) {
+      return [];
+    }
+
+    const params: FieldsRequestParams = {
+      query: options.query || "*",
+      ...this.getTimeRangeParams(options.timeRange),
+    };
+    if (options.type === FilterFieldType.Value) {
+      params.field = options.field;
+    }
+
+    const url = options.type === FilterFieldType.Name ? 'select/logsql/field_names' : `select/logsql/field_values`;
+    const key = `${url}/${Object.values(params).join('/')}`;
+
+    if (this.cacheValues.has(key)) {
+      return this.cacheValues.get(key)!;
+    }
+
+    if (this.cacheValues.size >= this.cacheSize) {
+      const firstKey = this.cacheValues.keys().next().value;
+      this.cacheValues.delete(firstKey);
+    }
+
+    const result = await this.request(url, [], params, { method: 'POST' });
+    this.cacheValues.set(key, result);
+    return result;
+  }
+
+  getTimeRangeParams(timeRange?: TimeRange) {
+    const range = timeRange ?? getDefaultTimeRange();
+    return {
+      from: range.from.startOf('day').valueOf(),
+      to: range.to.endOf('day').valueOf(),
+    }
+  }
+}

--- a/src/regexUtils.ts
+++ b/src/regexUtils.ts
@@ -1,0 +1,13 @@
+export function regularEscape(value: any) {
+  if (typeof value === 'string') {
+    return value.replace(/'/g, "\\\\'");
+  }
+  return value;
+}
+
+export function specialRegexEscape(value: any) {
+  if (typeof value === 'string') {
+    return regularEscape(value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]+?.()|]/g, '\\\\$&'));
+  }
+  return value;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,13 @@
 import { DataFrame, DataSourceJsonData, KeyValue, QueryEditorProps } from '@grafana/data';
+import { BackendSrvRequest } from "@grafana/runtime";
 import { DataQuery } from '@grafana/schema';
 
 import { VictoriaLogsDatasource } from "./datasource";
 
 export interface Options extends DataSourceJsonData {
   maxLines?: string;
+  httpMethod?: string;
+  customQueryParameters?: string;
   // derivedFields?: DerivedFieldConfig[];
   // alertmanager?: string;
   // keepCookies?: string[];
@@ -28,7 +31,13 @@ export enum QueryType {
   Stream = 'stream',
 }
 
+export enum QueryEditorMode {
+  Builder = 'builder',
+  Code = 'code',
+}
+
 export interface QueryFromSchema extends DataQuery {
+  editorMode?: QueryEditorMode;
   expr: string;
   legendFormat?: string;
   maxLines?: number;
@@ -66,3 +75,39 @@ export interface ToggleFilterAction {
   frame?: DataFrame;
 }
 
+export interface FilterVisualQuery {
+  values: (string | FilterVisualQuery)[];
+  operators: string[];
+}
+
+export interface PipeVisualQuery {
+  type: string;
+  args: string[];
+}
+
+export interface VisualQuery {
+  filters: FilterVisualQuery;
+  pipes: string[]//PipeVisualQuery[];
+}
+
+export interface RequestArguments {
+  url: string;
+  params?: Record<string, string>;
+  options?: Partial<BackendSrvRequest>;
+}
+
+export interface FiledHits {
+  value: string;
+  hits: number;
+}
+
+export enum FilterFieldType {
+  Name = 'name',
+  Value = 'value'
+}
+
+export interface VariableQuery extends DataQuery {
+  type: FilterFieldType;
+  query?: string;
+  field?: string;
+}

--- a/src/variableSupport/VariableSupport.ts
+++ b/src/variableSupport/VariableSupport.ts
@@ -1,0 +1,26 @@
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { CustomVariableSupport, DataQueryRequest, MetricFindValue, ScopedVars, TimeRange } from '@grafana/data';
+
+import { LokiVariableQueryEditor } from '../components/VariableQueryEditor/VariableQueryEditor';
+import { VictoriaLogsDatasource } from "../datasource";
+import { VariableQuery } from '../types';
+
+export class VariableSupport extends CustomVariableSupport<VictoriaLogsDatasource, VariableQuery> {
+  editor = LokiVariableQueryEditor;
+
+  constructor(private datasource: VictoriaLogsDatasource) {
+    super();
+  }
+
+  async execute(query: VariableQuery, scopedVars: ScopedVars, range: TimeRange) {
+    return this.datasource.metricFindQuery(query, { scopedVars, range });
+  }
+
+  query(request: DataQueryRequest<VariableQuery>): Observable<{ data: MetricFindValue[] }> {
+    const result = this.execute(request.targets[0], request.scopedVars, request.range);
+
+    return from(result).pipe(map((data) => ({ data })));
+  }
+}


### PR DESCRIPTION
Added support for loading data for variables, including log field names and values. This feature allows querying `/select/logsql/field_names` for field names and `/select/logsql/field_values` for field values. 
See [issue #40](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/40).
