### PR TITLE
follow-up after 08b306a5fc44dc126591bd3f45ef5b487d3d592b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## tip
 
+* FEATURE: add support of the `$__interval` variable in queries. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/61).
+  Thanks to @yincongcyincong for [the pull request](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/69).
+
 ## v0.4.0
 
 * FEATURE: make retry attempt for datasource requests if returned error is a temporary network error. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/193)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -177,3 +177,44 @@ func TestGetTime(t *testing.T) {
 		})
 	}
 }
+
+func TestReplaceTemplateVariable(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		interval int
+		want     string
+	}{
+		{
+			name:     "empty string",
+			expr:     "",
+			interval: 0,
+			want:     "",
+		},
+		{
+			name:     "no variable",
+			expr:     "test",
+			interval: 0,
+			want:     "test",
+		},
+		{
+			name:     "variable",
+			expr:     "$__interval",
+			interval: 15,
+			want:     "15ms",
+		},
+		{
+			name:     "variable with text",
+			expr:     "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:$__interval, host) count() logs",
+			interval: 15,
+			want:     "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:15ms, host) count() logs",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ReplaceTemplateVariable(tt.expr, tt.interval); got != tt.want {
+				t.Errorf("ReplaceTemplateVariable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Made follow-up after the [PR](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/69) 