### PR TITLE
language_provider: fix query time params names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * FEATURE: add support of the `$__interval` variable in queries. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/61).
   Thanks to @yincongcyincong for [the pull request](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/69).
 
+* BUGFIX: correctly pass time range filter when querying variable values. Before, time filter wasn't applied for `/field_values` and `/field_names` API calls. See [this](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/71) and [this](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/72) issues.
+
 ## v0.4.0
 
 * FEATURE: make retry attempt for datasource requests if returned error is a temporary network error. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/193)

--- a/src/language_provider.ts
+++ b/src/language_provider.ts
@@ -82,8 +82,8 @@ export default class LogsQlLanguageProvider extends LanguageProvider {
   getTimeRangeParams(timeRange?: TimeRange) {
     const range = timeRange ?? getDefaultTimeRange();
     return {
-      from: range.from.startOf('day').valueOf(),
-      to: range.to.endOf('day').valueOf(),
+      start: range.from.startOf('day').valueOf(),
+      end: range.to.endOf('day').valueOf()
     }
   }
 }


### PR DESCRIPTION
The correct query param names for /field_values are `start` `end`. See https://docs.victoriametrics.com/victorialogs/querying/#querying-field-values

Sending `from` and `to` params meant time range filter wasn't applied at all. This made VictoriaLogs make the full data scan.
Which probably caused the following issues:
* https://github.com/VictoriaMetrics/victorialogs-datasource/issues/71
* https://github.com/VictoriaMetrics/victorialogs-datasource/issues/72