### PR TITLE
fix issue with doubled labels in the response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * FEATURE: add support of the `$__interval` variable in queries. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/61).
   Thanks to @yincongcyincong for [the pull request](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/69).
 
+* BUGFIX: fix issue collecting labels in different log lines. Removed duplicated labels from previous log lines. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/60). 
+
 ## v0.4.0
 
 * FEATURE: make retry attempt for datasource requests if returned error is a temporary network error. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/193)

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -98,6 +98,7 @@ func parseStreamResponse(reader io.Reader) backend.DataResponse {
 			return newResponseError(err, backend.StatusInternal)
 		}
 		labelsField.Append(d)
+		labels = data.Labels{}
 	}
 
 	// Grafana expects lineFields to be always non-empty.


### PR DESCRIPTION
Fixed issue with doubled labels from previous log lines

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/60