### PR TITLE
add support for the `$__range` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: Add support for the `$__range` variable in queries.  It will be transformed to the `[time_from, time_to]` in the Unix format. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/112).
+
 ## v0.8.0
 
 * FEATURE: add support for the `/select/logsql/stats_query` and `/select/logsql/stats_query_range` API calls. This feature helps to build different panels with statistic data. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/61).

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -108,7 +108,7 @@ func (q *Query) queryTailURL(rawURL string, queryParams string) (string, error) 
 		}
 	}
 
-	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs)
+	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs, q.TimeRange)
 	values.Set("query", q.Expr)
 
 	q.url.RawQuery = values.Encode()
@@ -138,7 +138,7 @@ func (q *Query) queryInstantURL(queryParams url.Values) string {
 		q.TimeRange.To = now
 	}
 
-	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs)
+	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs, q.TimeRange)
 	values.Set("query", q.Expr)
 	values.Set("limit", strconv.Itoa(q.MaxLines))
 	values.Set("start", strconv.FormatInt(q.TimeRange.From.Unix(), 10))
@@ -164,7 +164,7 @@ func (q *Query) statsQueryURL(queryParams url.Values) string {
 		q.TimeRange.From = now.Add(-time.Minute * 5)
 	}
 
-	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs)
+	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs, q.TimeRange)
 	values.Set("query", q.Expr)
 	values.Set("time", strconv.FormatInt(q.TimeRange.To.Unix(), 10))
 
@@ -187,9 +187,6 @@ func (q *Query) statsQueryRangeURL(queryParams url.Values, minInterval time.Dura
 		q.MaxLines = defaultMaxLines
 	}
 
-	from := q.TimeRange.From
-	to := q.TimeRange.To
-
 	now := time.Now()
 	if q.TimeRange.From.IsZero() {
 		q.TimeRange.From = now.Add(-time.Minute * 5)
@@ -198,8 +195,8 @@ func (q *Query) statsQueryRangeURL(queryParams url.Values, minInterval time.Dura
 		q.TimeRange.To = now
 	}
 
-	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs)
-	step := utils.CalculateStep(minInterval, from, to, q.MaxDataPoints)
+	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs, q.TimeRange)
+	step := utils.CalculateStep(minInterval, q.TimeRange, q.MaxDataPoints)
 
 	values.Set("query", q.Expr)
 	values.Set("start", strconv.FormatInt(q.TimeRange.From.Unix(), 10))


### PR DESCRIPTION
Added support for the `$__range` variable. It will be transformed to the `[time_from, time_to]` in the Unix format. 
For example Grafana from: `now-1h`, to: `now` will be transformed `[1732546325, 1732549925]`. 
It is necessary to use `_time:` token with this Grafana variable to build correct requests.

Query example:
1.  `_time:$__range | stats count()` will be transformed to `_time:[1732320000, 1732492800] | stats count()`
2. `* _time:$__range` will be transformed to `* _time:[1732320000, 1732492800] | stats count()`

Related issues: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/112, https://github.com/VictoriaMetrics/victorialogs-datasource/issues/119

Variable `$__from, $__to` works as is, so we do not need to add support