### PR TITLE
fixbug, stream field filter, syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * BUGFIX: fix options sorting in variables for numerical data type. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/97).
 
+
 ## v0.7.0
 
 * FEATURE: add support to display live logs by querying the tail endpoint in the datasource. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/83)

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -113,6 +113,21 @@ describe('VictoriaLogsDatasource', () => {
       expect(replacedQuery.expr).toBe('foo: "bar"');
     });
 
+    it('should replace $var with an | expression for stream field when given an array of values', () => {
+      const scopedVars = {
+        var: { text: 'foo,bar', value: ['foo', 'bar'] },
+      };
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a?.replace('$var', '("foo" OR "bar")')),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_stream{val=~"$var"}', refId: 'A' },
+        scopedVars
+      );
+      expect(replacedQuery.expr).toBe('_stream{val=~"("foo"|"bar")"}');
+    });
+
     it('should replace $var with an OR expression when given an array of values', () => {
       const scopedVars = {
         var: { text: 'foo,bar', value: ['foo', 'bar'] },

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -158,7 +158,7 @@ export class VictoriaLogsDatasource
     return {
       ...target,
       legendFormat: this.templateSrv.replace(target.legendFormat, rest),
-      expr: this.templateSrv.replace(exprWithAdHoc, variables, this.interpolateQueryExpr),
+      expr: this.interpolateString(exprWithAdHoc, variables),
     };
   }
 
@@ -258,7 +258,18 @@ export class VictoriaLogsDatasource
   }
 
   interpolateString(string: string, scopedVars?: ScopedVars) {
-    return this.templateSrv.replace(string, scopedVars, this.interpolateQueryExpr);
+    let expr: string = this.templateSrv.replace(string, scopedVars, this.interpolateQueryExpr);
+    if (expr) {
+      // Replace "OR" with "|" inside parentheses
+      // The stream field filter, uses "|" as the operator for multiple values.
+      // expr => {k="v", k2=~"(v2 OR v3 OR v4)"} Test
+      // newExpr => {k="v", k2=~"(v2|v3|v4)"} Test
+      expr = expr.replace(/\(([^)]+)\)/g, (match, content) => {
+        const replaced = content.replace(/\s*OR\s*/g, '|'); // delete OR and Spaces
+        return `(${replaced})`;
+      });
+    }
+    return expr;
   }
 
   private async processMetricFindQuery(query: VariableQuery, timeRange?: TimeRange): Promise<MetricFindValue[]> {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -264,9 +264,12 @@ export class VictoriaLogsDatasource
       // The stream field filter, uses "|" as the operator for multiple values.
       // expr => {k="v", k2=~"(v2 OR v3 OR v4)"} Test
       // newExpr => {k="v", k2=~"(v2|v3|v4)"} Test
-      expr = expr.replace(/\(([^)]+)\)/g, (match, content) => {
-        const replaced = content.replace(/\s*OR\s*/g, '|'); // delete OR and Spaces
-        return `(${replaced})`;
+      expr = expr.replace(/\{([^}]+)\}/g, (outerMatch, outerContent) => {
+        const replacedContent = outerContent.replace(/\(([^)]+)\)/g, (match: string, content: string) => {
+          const replaced = content.replace(/\s*OR\s*/g, '|');
+          return `(${replaced})`;
+        });
+        return `{${replacedContent}}`;
       });
     }
     return expr;


### PR DESCRIPTION
FixBug: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/109

Replace ` OR ` to `|` When stream field filter.
