### PR TITLE
issue-126: show full error from the datasource if it response with 422 status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * FEATURE: Add support for the `$__range` variable in queries.  It will be transformed to the `[time_from, time_to]` in the Unix format. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/112).
 
+* BUGFIX: show to the user original error message from the VictoriaLogs. It helps to understand the real problem with query or syntax. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/126).
+
 ## v0.8.0
 
 * FEATURE: add support for the `/select/logsql/stats_query` and `/select/logsql/stats_query_range` API calls. This feature helps to build different panels with statistic data. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/61).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * FEATURE: Add support for the `$__range` variable in queries.  It will be transformed to the `[time_from, time_to]` in the Unix format. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/112).
 
-* BUGFIX: show to the user original error message from the VictoriaLogs. It helps to understand the real problem with query or syntax. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/126).
+* BUGFIX: show the original error message returned from the VictoriaLogs backend. It should help to troubleshoot problems with query or syntax. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/126).
 
 ## v0.8.0
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -220,6 +220,9 @@ func (d *Datasource) datasourceQuery(ctx context.Context, q *Query, isStream boo
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnprocessableEntity {
+			return nil, parseErrorResponse(resp.Body)
+		}
 		return nil, fmt.Errorf("got unexpected response status code: %d", resp.StatusCode)
 	}
 

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -288,6 +288,25 @@ func parseStatsResponse(reader io.Reader, q *Query) backend.DataResponse {
 	return backend.DataResponse{Frames: frames}
 }
 
+// parseErrorResponse reads data from the reader and returns error
+func parseErrorResponse(reader io.Reader) error {
+	var rs Response
+	if err := json.NewDecoder(reader).Decode(&rs); err != nil {
+		err = fmt.Errorf("failed to decode body response: %w", err)
+		return err
+	}
+
+	if rs.Status == "error" {
+		return fmt.Errorf("error: %s", rs.Error)
+	}
+
+	if rs.Error == "" {
+		return fmt.Errorf("got unexpected error from the datasource")
+	}
+
+	return nil
+}
+
 // labelsToJSON converts labels to json representation
 // data.Labels when converted to JSON keep the fields sorted
 func labelsToJSON(labels data.Labels) (json.RawMessage, error) {
@@ -328,6 +347,7 @@ type Data struct {
 type Response struct {
 	Status string `json:"status"`
 	Data   Data   `json:"data"`
+	Error  string `json:"error"`
 }
 
 // logStats represents response result from the


### PR DESCRIPTION
Show the original error from the data source. It will help user to understand the real problem with requests or with syntax.

This PR partially fixes the problem described in the related issue.
<img width="1210" alt="Screenshot 2024-12-02 at 23 47 02" src="https://github.com/user-attachments/assets/ac35c08a-9e54-4eb5-92f9-daadacaf205a">

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/126