### PR TITLE
add support for alerting and toggle between request types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## tip
 
+* FEATURE: add alerting support. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/98).
+* FEATURE: implement a toggle to switch between instant and range requests. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/111).
+
 ## v0.9.0
 
 * FEATURE: Add support for the `$__range` variable in queries.  It will be transformed to the `[time_from, time_to]` in the Unix format. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/112).

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -242,7 +242,7 @@ func (d *Datasource) query(ctx context.Context, _ backend.PluginContext, q *Quer
 		}
 	}()
 
-	switch QueryType(q.QueryType) {
+	switch q.QueryType {
 	case QueryTypeStats:
 		return parseStatsResponse(r, q)
 	case QueryTypeStatsRange:

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"path"
 	"regexp"
@@ -43,12 +44,13 @@ const (
 type Query struct {
 	backend.DataQuery `json:"inline"`
 
-	Expr         string `json:"expr"`
-	LegendFormat string `json:"legendFormat"`
-	TimeInterval string `json:"timeInterval"`
-	Interval     string `json:"interval"`
-	IntervalMs   int64  `json:"intervalMs"`
-	MaxLines     int    `json:"maxLines"`
+	Expr         string    `json:"expr"`
+	LegendFormat string    `json:"legendFormat"`
+	TimeInterval string    `json:"timeInterval"`
+	Interval     string    `json:"interval"`
+	IntervalMs   int64     `json:"intervalMs"`
+	MaxLines     int       `json:"maxLines"`
+	QueryType    QueryType `json:"queryType"`
 	url          *url.URL
 }
 
@@ -69,7 +71,8 @@ func (q *Query) getQueryURL(rawURL string, queryParams string) (string, error) {
 
 	q.url = u
 
-	switch QueryType(q.QueryType) {
+	log.Printf("QueryType: %s", q.QueryType)
+	switch q.QueryType {
 	case QueryTypeStats:
 		return q.statsQueryURL(params), nil
 	case QueryTypeStatsRange:

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"fmt"
-	"log"
 	"net/url"
 	"path"
 	"regexp"
@@ -71,7 +70,6 @@ func (q *Query) getQueryURL(rawURL string, queryParams string) (string, error) {
 
 	q.url = u
 
-	log.Printf("QueryType: %s", q.QueryType)
 	switch q.QueryType {
 	case QueryTypeStats:
 		return q.statsQueryURL(params), nil

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -251,14 +251,13 @@ func TestQuery_getQueryURL(t *testing.T) {
 			q := &Query{
 				DataQuery: backend.DataQuery{
 					RefID:     tt.fields.RefID,
-					QueryType: string(tt.fields.QueryType),
 					TimeRange: tt.fields.TimeRange,
 				},
 				// RefID:     tt.fields.RefID,
 				Expr:     tt.fields.Expr,
 				MaxLines: tt.fields.MaxLines,
 
-				// QueryType: tt.fields.QueryType,
+				QueryType: tt.fields.QueryType,
 			}
 			got, err := q.getQueryURL(tt.args.rawURL, tt.args.queryParams)
 			if (err != nil) != tt.wantErr {

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -253,7 +253,6 @@ func TestQuery_getQueryURL(t *testing.T) {
 					RefID:     tt.fields.RefID,
 					TimeRange: tt.fields.TimeRange,
 				},
-				// RefID:     tt.fields.RefID,
 				Expr:     tt.fields.Expr,
 				MaxLines: tt.fields.MaxLines,
 

--- a/src/components/QueryEditor/EditorField.tsx
+++ b/src/components/QueryEditor/EditorField.tsx
@@ -1,0 +1,74 @@
+import { css } from '@emotion/css';
+import React, { ComponentProps, FC } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useTheme2, ReactUtils, Field, Icon, PopoverContent, Tooltip } from '@grafana/ui';
+
+interface EditorFieldProps extends ComponentProps<typeof Field> {
+  label: string;
+  children: React.ReactElement;
+  width?: number | string;
+  optional?: boolean;
+  tooltip?: PopoverContent;
+}
+
+const EditorField: FC<EditorFieldProps> = (props) => {
+  const { label, optional, tooltip, children, width, ...fieldProps } = props;
+
+  const theme = useTheme2();
+  const styles = getStyles(theme, width);
+
+  // Null check for backward compatibility
+  const childInputId = fieldProps?.htmlFor || ReactUtils?.getChildId(children);
+
+  const labelEl = (
+    <>
+      <label className={styles.label} htmlFor={childInputId}>
+        {label}
+        {optional && <span className={styles.optional}> - optional</span>}
+        {tooltip && (
+          <Tooltip placement="top" content={tooltip} theme="info">
+            <Icon name="info-circle" size="sm" className={styles.icon} />
+          </Tooltip>
+        )}
+      </label>
+    </>
+  );
+
+  return (
+    <div className={styles.root}>
+      <Field className={styles.field} label={labelEl} {...fieldProps}>
+        {children}
+      </Field>
+    </div>
+  );
+};
+
+export default EditorField;
+
+const getStyles = (theme: GrafanaTheme2, width?: number | string) => {
+  return {
+    root: css({
+      paddingLeft: theme.spacing(1),
+      minWidth: theme.spacing(width ?? 0),
+    }),
+    label: css({
+      fontSize: 12,
+      fontWeight: theme.typography.fontWeightMedium,
+    }),
+    optional: css({
+      fontStyle: 'italic',
+      color: theme.colors.text.secondary,
+    }),
+    field: css({
+      marginBottom: 0, // GrafanaUI/Field has a bottom margin which we must remove
+    }),
+    icon: css({
+      color: theme.colors.text.secondary,
+      marginLeft: theme.spacing(1),
+      ':hover': {
+        color: theme.colors.text.primary,
+      },
+    }),
+  };
+};

--- a/src/components/QueryEditor/EditorRow.tsx
+++ b/src/components/QueryEditor/EditorRow.tsx
@@ -1,0 +1,30 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+interface EditorRowProps {
+  children: React.ReactNode;
+}
+
+export const EditorRow: React.FC<EditorRowProps> = ({ children }) => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.root}>
+      {children}
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    root: css({
+      marginTop: theme.spacing(0.5),
+      padding: theme.spacing(1),
+      backgroundColor: theme.colors.background.secondary,
+      borderRadius: theme.shape.radius.default,
+    })
+  };
+};

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -12,16 +12,17 @@ import { QueryBuilderContainer } from "./QueryBuilder/QueryBuilderContainer";
 import { QueryEditorModeToggle } from "./QueryBuilder/QueryEditorModeToggle";
 import { buildVisualQueryFromString } from "./QueryBuilder/utils/parseFromString";
 import QueryCodeEditor from "./QueryCodeEditor";
+import { QueryEditorOptions } from "./QueryEditorOptions";
 import { changeEditorMode, getQueryWithDefaults } from "./state";
 
 const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
   const styles = useStyles2(getStyles);
 
-  const { onChange, onRunQuery, data, app, queries, range: timeRange } = props;
+  const { onChange, onRunQuery, data, app, queries, datasource, range: timeRange } = props;
   const [dataIsStale, setDataIsStale] = useState(false);
   const [parseModalOpen, setParseModalOpen] = useState(false);
 
-  const query = getQueryWithDefaults(props.query);
+  const query = getQueryWithDefaults(props.query, app, data?.request?.panelPluginId);
   const editorMode = query.editorMode!;
 
   const onEditorModeChange = useCallback((newEditorMode: QueryEditorMode) => {
@@ -88,6 +89,13 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
           ) : (
             <QueryCodeEditor {...props} query={query} onChange={onChangeInternal} showExplain={true}/>
           )}
+          <QueryEditorOptions
+            query={query}
+            onChange={onChange}
+            onRunQuery={onRunQuery}
+            app={app}
+            maxLines={datasource.maxLines}
+          />
         </div>
       </div>
     </>

--- a/src/components/QueryEditor/QueryEditorForAlerting.tsx
+++ b/src/components/QueryEditor/QueryEditorForAlerting.tsx
@@ -2,11 +2,26 @@ import React from 'react';
 
 import { VictoriaLogsQueryEditorProps } from "../../types";
 
+import QueryField from "./QueryField";
+
 const QueryEditorForAlerting = (props: VictoriaLogsQueryEditorProps) => {
+  const { query, data, datasource, onChange, onRunQuery, history } = props;
 
   return (
-    <div>QueryEditorForAlerting</div>
+    <QueryField
+      datasource={datasource}
+      query={query}
+      onChange={onChange}
+      onRunQuery={onRunQuery}
+      history={history}
+      data={data}
+      data-testid={testIds.editor}
+    />
   );
 }
 
 export default QueryEditorForAlerting
+
+export const testIds = {
+  editor: 'victorialogs-editor-cloud-alerting',
+};

--- a/src/components/QueryEditor/QueryEditorOptions.tsx
+++ b/src/components/QueryEditor/QueryEditorOptions.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import { CoreApp, SelectableValue } from '@grafana/data';
+import { RadioButtonGroup } from '@grafana/ui';
+
+import { Query, QueryType } from "../../types";
+
+import EditorField from "./EditorField";
+import { EditorRow } from "./EditorRow";
+import QueryEditorOptionsGroup from "./QueryEditorOptionsGroup";
+
+export interface Props {
+  query: Query;
+  onChange: (update: Query) => void;
+  onRunQuery: () => void;
+  maxLines: number;
+  app?: CoreApp;
+}
+
+export const queryTypeOptions: Array<SelectableValue<QueryType>> = [
+  {
+    value: QueryType.Instant,
+    label: 'Raw',
+    filter: ({ app }: Props) => app !== CoreApp.UnifiedAlerting && app !== CoreApp.CloudAlerting,
+  },
+  {
+    value: QueryType.StatsRange,
+    label: 'Range',
+  },
+  {
+    value: QueryType.Stats,
+    label: 'Instant',
+  },
+];
+
+export const QueryEditorOptions = React.memo<Props>(({ app, query, onChange, onRunQuery }) => {
+    const filteredOptions = queryTypeOptions.filter(option => option.filter?.({ app }) ?? true);
+    const queryType = query.queryType;
+
+    const collapsedInfo = getCollapsedInfo({
+      queryType: query.queryType
+    });
+
+    const onQueryTypeChange = (value: QueryType) => {
+      onChange({ ...query, queryType: value });
+      onRunQuery();
+    };
+
+    return (
+      <EditorRow>
+        <QueryEditorOptionsGroup
+          title="Options"
+          collapsedInfo={collapsedInfo}
+        >
+          <EditorField label="Type">
+            <RadioButtonGroup options={filteredOptions} value={queryType} onChange={onQueryTypeChange}/>
+          </EditorField>
+        </QueryEditorOptionsGroup>
+      </EditorRow>
+    );
+  }
+);
+
+QueryEditorOptions.displayName = 'QueryEditorOptions';
+
+interface CollapsedInfoProps {
+  queryType?: string;
+}
+
+function getCollapsedInfo({ queryType }: CollapsedInfoProps): string[] {
+  const items: string[] = [];
+
+  const queryTypeLabel = queryTypeOptions.find(option => option.value === queryType)?.label || "Unknown";
+
+  items.push(`Type: ${queryTypeLabel}`);
+  return items;
+}

--- a/src/components/QueryEditor/QueryEditorOptionsGroup.tsx
+++ b/src/components/QueryEditor/QueryEditorOptionsGroup.tsx
@@ -1,0 +1,83 @@
+import { css } from '@emotion/css';
+import React from 'react';
+import { useToggle } from 'react-use';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, useStyles2 } from '@grafana/ui';
+
+export interface Props {
+  title: string;
+  collapsedInfo: string[];
+  children: React.ReactNode;
+}
+
+const QueryEditorOptionsGroup = ({ title, children, collapsedInfo }: Props)  => {
+  const [isOpen, toggleOpen] = useToggle(false);
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div>
+      <div className={styles.header} onClick={toggleOpen} title="Click to edit options">
+        <div className={styles.toggle}>
+          <Icon name={isOpen ? 'angle-down' : 'angle-right'} />
+        </div>
+        <h6 className={styles.title}>{title}</h6>
+        {!isOpen && (
+          <div className={styles.description}>
+            {collapsedInfo.map((x, i) => (
+              <span key={i}>{x}</span>
+            ))}
+          </div>
+        )}
+      </div>
+      {isOpen && <div className={styles.body}>{children}</div>}
+    </div>
+  );
+}
+
+export default QueryEditorOptionsGroup;
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    switchLabel: css({
+      color: theme.colors.text.secondary,
+      cursor: 'pointer',
+      fontSize: theme.typography.bodySmall.fontSize,
+      '&:hover': {
+        color: theme.colors.text.primary,
+      },
+    }),
+    header: css({
+      display: 'flex',
+      cursor: 'pointer',
+      alignItems: 'baseline',
+      color: theme.colors.text.primary,
+      '&:hover': {
+        background: theme.colors.emphasize(theme.colors.background.primary, 0.03),
+      },
+    }),
+    title: css({
+      overflow: 'hidden',
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      margin: 0,
+    }),
+    description: css({
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      paddingLeft: theme.spacing(2),
+      gap: theme.spacing(2),
+      display: 'flex',
+    }),
+    body: css({
+      display: 'flex',
+      paddingTop: theme.spacing(2),
+      gap: theme.spacing(2),
+      flexWrap: 'wrap',
+    }),
+    toggle: css({
+      color: theme.colors.text.secondary,
+      marginRight: `${theme.spacing(1)}`,
+    }),
+  };
+};

--- a/src/components/QueryEditor/QueryField.tsx
+++ b/src/components/QueryEditor/QueryField.tsx
@@ -11,30 +11,18 @@ export interface QueryFieldProps extends QueryEditorProps<VictoriaLogsDatasource
   'data-testid'?: string;
 }
 
-const QueryField: React.FC<QueryFieldProps> = (props) => {
-  const {
+const QueryField: React.FC<QueryFieldProps> = (
+  {
     ExtraFieldElement,
     query,
-    // datasource,
     history,
     onRunQuery,
-    // range,
     onChange,
     'data-testid': dataTestId
-  } = props;
-  // const [labelsLoaded, setLabelsLoaded] = useState(false);
-
-  // Replace componentDidUpdate logic if needed
+  }) => {
 
   const onChangeQuery = (value: string) => {
-    if (onChange) {
-      const nextQuery = { ...query, expr: value };
-      onChange(nextQuery);
-
-      // if (override && onRunQuery) {
-      //   onRunQuery();
-      // }
-    }
+    onChange && onChange({ ...query, expr: value });
   };
 
   return (

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -38,7 +38,6 @@ import {
   Query,
   QueryBuilderLimits,
   QueryFilterOptions,
-  QueryType,
   RequestArguments,
   ToggleFilterAction,
   VariableQuery,
@@ -86,7 +85,6 @@ export class VictoriaLogsDatasource
     const queries = request.targets.filter(q => q.expr).map((q) => {
       return {
         ...q,
-        queryType: determineQueryType(request.panelPluginId),
         maxLines: q.maxLines ?? this.maxLines,
       }
     });
@@ -277,7 +275,7 @@ export class VictoriaLogsDatasource
   }
 
   private runLiveQueryThroughBackend(request: DataQueryRequest<Query>): Observable<DataQueryResponse> {
-    const observables = request.targets.map((query, index) => {
+    const observables = request.targets.map((query) => {
       return getGrafanaLiveSrv().getDataStream({
         addr: {
           scope: LiveChannelScope.DataSource,
@@ -297,18 +295,5 @@ export class VictoriaLogsDatasource
     });
 
     return merge(...observables);
-  }
-}
-
-function determineQueryType(panelPluginId?: string) {
-  switch (panelPluginId) {
-    case 'logs':
-    case 'table':
-    case undefined:
-      return QueryType.Instant;
-    case 'timeseries':
-      return QueryType.StatsRange;
-    default:
-      return QueryType.Stats;
   }
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -5,7 +5,7 @@
   "category": "logging",
   "logs": true,
   "metrics": true,
-  "alerting": false,
+  "alerting": true,
   "annotations": true,
   "streaming": true,
   "backend": true,


### PR DESCRIPTION
- Added support for creating and managing alerts.  
- Implemented a toggle to switch between different request types.  

Related issues: #98, #111 and #124

<details>
  <summary>Demo UI</summary>
  
<img src="https://github.com/user-attachments/assets/03e16274-6e51-446c-94f9-9c66c27ec415"/>
<img src="https://github.com/user-attachments/assets/b7f6d7cb-1ff5-410b-90ae-b55f9863252e"/>
<img src="https://github.com/user-attachments/assets/7286a9f9-0db7-4dfb-9716-4446bdb80a01"/>
<img src="https://github.com/user-attachments/assets/10d96fc4-bdae-4a14-8adb-9379e58c4f91"/>
  
</details>

