### PR TITLE
add options for legend template, max lines, and step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * FEATURE: add alerting support. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/98).
 * FEATURE: implement a toggle to switch between instant and range requests. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/111).
+* FEATURE: add options to configure the legend template, limit for number of log lines, and step. See [this](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/114) and [this](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/124) issues.
 
 ## v0.9.0
 

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -199,10 +199,10 @@ func (q *Query) statsQueryRangeURL(queryParams url.Values, minInterval time.Dura
 
 	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs, q.TimeRange)
 
-    step := q.Step
-    if step == "" {
-        step = utils.CalculateStep(minInterval, q.TimeRange, q.MaxDataPoints).String()
-    }
+	step := q.Step
+	if step == "" {
+		step = utils.CalculateStep(minInterval, q.TimeRange, q.MaxDataPoints).String()
+	}
 
 	values.Set("query", q.Expr)
 	values.Set("start", strconv.FormatInt(q.TimeRange.From.Unix(), 10))

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -49,6 +49,7 @@ type Query struct {
 	Interval     string    `json:"interval"`
 	IntervalMs   int64     `json:"intervalMs"`
 	MaxLines     int       `json:"maxLines"`
+	Step         string    `json:"step"`
 	QueryType    QueryType `json:"queryType"`
 	url          *url.URL
 }
@@ -197,12 +198,16 @@ func (q *Query) statsQueryRangeURL(queryParams url.Values, minInterval time.Dura
 	}
 
 	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs, q.TimeRange)
-	step := utils.CalculateStep(minInterval, q.TimeRange, q.MaxDataPoints)
+
+    step := q.Step
+    if step == "" {
+        step = utils.CalculateStep(minInterval, q.TimeRange, q.MaxDataPoints).String()
+    }
 
 	values.Set("query", q.Expr)
 	values.Set("start", strconv.FormatInt(q.TimeRange.From.Unix(), 10))
 	values.Set("end", strconv.FormatInt(q.TimeRange.To.Unix(), 10))
-	values.Set("step", step.String())
+	values.Set("step", step)
 
 	q.url.RawQuery = values.Encode()
 	return q.url.String()


### PR DESCRIPTION
- Added an option to set the legend template.
- Added an option to set the maximum number of returned rows.
- Added an option to set the step size for data range queries.

Related Issues:
- #114
- #124

	
<details>
  <summary>Demo UI</summary>
  
<img src="https://github.com/user-attachments/assets/43fa21f0-775d-413b-adfa-9c850947bfe1"/>
<img src="https://github.com/user-attachments/assets/90ce3dc9-1106-499b-bea8-0ee5b2b6a22b"/>
  
</details>

> [!NOTE]
> This pull request is based on the [issue-98/support-alerting](https://github.com/VictoriaMetrics/victorialogs-datasource/tree/issue-98/support-alerting) branch because it already contains part of the necessary functionality.