### PR TITLE
add tooltips for query types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: add tooltips for query types and a warning to include `| stats` pipe.
+
 ## v0.10.0
 
 * FEATURE: add alerting support. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/98).

--- a/src/components/QueryEditor/EditorField.tsx
+++ b/src/components/QueryEditor/EditorField.tsx
@@ -49,12 +49,12 @@ export default EditorField;
 const getStyles = (theme: GrafanaTheme2, width?: number | string) => {
   return {
     root: css({
-      paddingLeft: theme.spacing(1),
       minWidth: theme.spacing(width ?? 0),
     }),
     label: css({
       fontSize: 12,
       fontWeight: theme.typography.fontWeightMedium,
+      paddingBottom: theme.spacing(0.5),
     }),
     optional: css({
       fontStyle: 'italic',

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -5,7 +5,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { CoreApp, GrafanaTheme2, LoadingState } from '@grafana/data';
 import { Button, ConfirmModal, useStyles2 } from '@grafana/ui';
 
-import { Query, QueryEditorMode, VictoriaLogsQueryEditorProps } from "../../types";
+import { Query, QueryEditorMode, QueryType, VictoriaLogsQueryEditorProps } from "../../types";
+import QueryEditorStatsWarn from "../QueryEditorStatsWarn";
 
 import { EditorHeader } from "./EditorHeader";
 import { QueryBuilderContainer } from "./QueryBuilder/QueryBuilderContainer";
@@ -24,6 +25,8 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
 
   const query = getQueryWithDefaults(props.query, app, data?.request?.panelPluginId);
   const editorMode = query.editorMode!;
+  const isStatsQuery = query.queryType === QueryType.Stats || query.queryType === QueryType.StatsRange;
+  const showStatsWarn = isStatsQuery && !query.expr.includes('stats');
 
   const onEditorModeChange = useCallback((newEditorMode: QueryEditorMode) => {
       if (newEditorMode === QueryEditorMode.Builder) {
@@ -64,6 +67,7 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
       />
       <div className={styles.wrapper}>
         <EditorHeader>
+          {showStatsWarn && (<QueryEditorStatsWarn queryType={query.queryType}/>)}
           <QueryEditorModeToggle mode={editorMode} onChange={onEditorModeChange}/>
           {app !== CoreApp.Explore && app !== CoreApp.Correlations && (
             <Button

--- a/src/components/QueryEditor/QueryEditorOptions.tsx
+++ b/src/components/QueryEditor/QueryEditorOptions.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { CoreApp, isValidGrafanaDuration, SelectableValue } from '@grafana/data';
-import { AutoSizeInput, RadioButtonGroup } from '@grafana/ui';
+import { AutoSizeInput, RadioButtonGroup, TextLink } from '@grafana/ui';
 
 import { Query, QueryType } from "../../types";
 
@@ -20,16 +20,19 @@ export interface Props {
 export const queryTypeOptions: Array<SelectableValue<QueryType>> = [
   {
     value: QueryType.Instant,
-    label: 'Raw',
+    label: 'Raw Logs',
     filter: ({ app }: Props) => app !== CoreApp.UnifiedAlerting && app !== CoreApp.CloudAlerting,
+    description: "Use `/select/logsql/query` for querying logs.",
   },
   {
     value: QueryType.StatsRange,
     label: 'Range',
+    description: "Use `/select/logsql/stats_query_range` for querying log stats over the given time range."
   },
   {
     value: QueryType.Stats,
     label: 'Instant',
+    description: "Use `/select/logsql/stats_query` for querying log stats at the given time."
   },
 ];
 
@@ -91,9 +94,19 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
               onCommitChange={onLegendFormatChanged}
             />
           </EditorField>
-          <EditorField label="Type">
-            <RadioButtonGroup options={filteredOptions} value={queryType} onChange={onQueryTypeChange}/>
-          </EditorField>
+          <div>
+            <EditorField label="Type">
+              <RadioButtonGroup options={filteredOptions} value={queryType} onChange={onQueryTypeChange}/>
+            </EditorField>
+            <TextLink
+              href="https://docs.victoriametrics.com/victorialogs/querying/"
+              icon="external-link-alt"
+              variant={"bodySmall"}
+              external
+            >
+              Learn more about querying logs
+            </TextLink>
+          </div>
           {queryType === QueryType.Instant && (
             <EditorField label="Line limit" tooltip="Upper limit for number of log lines returned by query.">
               <AutoSizeInput
@@ -109,7 +122,7 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
           {queryType === QueryType.StatsRange && (
             <EditorField
               label="Step"
-              tooltip="Use the step parameter when making metric queries to Loki. If not filled, Grafana's calculated interval will be used. Example valid values: 1s, 5m, 10h, 1d."
+              tooltip="Use the `step` parameter when making metric queries. If not specified, Grafana will use a calculated interval. Example values: 1s, 5m, 10h, 1d."
               invalid={!isValidStep}
               error={'Invalid step. Example valid values: 1s, 5m, 10h, 1d.'}
             >

--- a/src/components/QueryEditor/QueryEditorOptionsGroup.tsx
+++ b/src/components/QueryEditor/QueryEditorOptionsGroup.tsx
@@ -72,6 +72,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     body: css({
       display: 'flex',
       paddingTop: theme.spacing(2),
+      paddingLeft: theme.spacing(1),
       gap: theme.spacing(2),
       flexWrap: 'wrap',
     }),

--- a/src/components/QueryEditorStatsWarn.tsx
+++ b/src/components/QueryEditorStatsWarn.tsx
@@ -1,0 +1,56 @@
+import { css } from "@emotion/css";
+import React from 'react';
+
+import { GrafanaTheme2 } from "@grafana/data";
+import { Badge, TextLink, useTheme2 } from "@grafana/ui";
+
+import { QueryType } from "../types";
+
+import { queryTypeOptions } from "./QueryEditor/QueryEditorOptions";
+
+interface Props {
+  queryType?: QueryType;
+}
+
+const QueryEditorStatsWarn = ({ queryType }: Props) => {
+  const theme = useTheme2();
+  const styles = getStyles(theme);
+  const queryTypeLabel = queryTypeOptions.find(option => option.value === queryType)?.label || "unknown";
+
+  const text = (
+    <div>
+      The query must include the `| stats ...` pipe for the `{queryTypeLabel}` query type to work correctly.
+    </div>
+  )
+
+  return (
+    <div className={styles.root}>
+      <Badge
+        icon={"info-circle"}
+        color={"orange"}
+        text={text}
+      />
+      <TextLink
+        href="https://docs.victoriametrics.com/victorialogs/logsql/#stats-pipe"
+        icon="external-link-alt"
+        variant={"bodySmall"}
+        external
+      >
+        Learn more about stats pipe
+      </TextLink>
+    </div>
+  )
+}
+
+export default QueryEditorStatsWarn;
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    root: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      flexGrow: 1,
+    }),
+  };
+};


### PR DESCRIPTION
1. Added tooltips for the query type switcher.  
2. Renamed "Raw" to "Raw Logs" for clarity.  
3. Added link to the [querying logs documentation](https://docs.victoriametrics.com/victorialogs/querying/).
4. Added a warning for `| stats` pipe usage with links to [stats pipe documentation](https://docs.victoriametrics.com/victorialogs/logsql/#stats-pipe). This warning appears for "Range" (`/select/logsql/stats_query_range`) and "Instant" (`/select/logsql/stats_query`) queries when the expression lacks `| stats`.

<img width="400" src="https://github.com/user-attachments/assets/0095a45f-7358-4c26-914f-8ef5938ffbbd"/>
<img width="400" src="https://github.com/user-attachments/assets/8d3e93c9-5fb1-4851-b395-61eee47b134d"/>
<img width="400" src="https://github.com/user-attachments/assets/d7b63c9d-2fc6-4571-b0d3-d2042a9eb1d9"/>
<img width="400" src="https://github.com/user-attachments/assets/9b1c3cf7-dfa7-439c-b534-b6b554b6822c"/>

