### PR TITLE
fix time range reset with query variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix a bug where the time range was reset when using query variables. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/118).
+
 ## v0.10.0
 
 * FEATURE: add alerting support. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/98).

--- a/src/language_provider.ts
+++ b/src/language_provider.ts
@@ -94,9 +94,16 @@ export default class LogsQlLanguageProvider extends LanguageProvider {
 
   getTimeRangeParams(timeRange?: TimeRange) {
     const range = timeRange ?? getDefaultTimeRange();
+
+    const start = new Date(range.from.valueOf());
+    start.setHours(0, 0, 0, 0); // set start of day
+
+    const end = new Date(range.to.valueOf());
+    end.setHours(23, 59, 59, 999); // set end of day
+
     return {
-      start: range.from.startOf('day').valueOf(),
-      end: range.to.endOf('day').valueOf()
+      start: start.valueOf(),
+      end: end.valueOf()
     }
   }
 }


### PR DESCRIPTION
This PR fixes a bug where the time range reset when using query variables.  

Cause:
The issue was caused by using `startOf` and `endOf` on `TimeRange` objects, which led to mutations.

Related Issue: #118  