### PR TITLE
fix incomplete time series rendering issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## tip
 
-* BUGFIX: fix an issue where charts, including timeseries, might not be fully displayed.
+* BUGFIX: fix bug with incomplete rendering of time series panels when selecting bigger time intervals.
 
 ## v0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue where charts, including timeseries, might not be fully displayed.
+
 ## v0.10.0
 
 * FEATURE: add alerting support. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/98).

--- a/src/backendResultTransformer.ts
+++ b/src/backendResultTransformer.ts
@@ -128,7 +128,6 @@ export function transformBackendResult(
   response: DataQueryResponse,
   queries: Query[],
   derivedFieldConfigs: DerivedFieldConfig[],
-  maxLines: number
 ): DataQueryResponse {
   const { data, errors, ...rest } = response;
 
@@ -138,16 +137,6 @@ export function transformBackendResult(
   const dataFrames = data.map((d) => {
     if (!isDataFrame(d)) {
       throw new Error('transformation only supports dataframe responses');
-    }
-
-    // for VictoriaLogs < v0.5.0, no "limit" for `/select/logsql/query`.
-    const limitExceeded = d.fields.some(f => f.values.length > maxLines)
-    if (limitExceeded) {
-      return {
-        ...d,
-        length: maxLines,
-        fields: d.fields.map(f => ({ ...f, values:  f.values.slice(0, maxLines) }))
-      }
     }
 
     return d;

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -106,7 +106,7 @@ export class VictoriaLogsDatasource
       .query(fixedRequest)
       .pipe(
         map((response) =>
-          transformBackendResult(response, fixedRequest.targets, [], this.maxLines)
+          transformBackendResult(response, fixedRequest.targets, [])
         )
       );
   }


### PR DESCRIPTION
This PR addresses an issue where timeseries were not fully rendered due to data limits, causing the right side to appear empty.  

The cause was data truncation on the frontend when reaching the limit. This behavior originated from earlier code designed for VictoriaLogs below `v0.5.0`.  

| before | after     |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/c8a072fb-cd3f-46e4-9c2b-8e76cbd98760"/> | <img src="https://github.com/user-attachments/assets/abe64dfa-5d8a-419a-b934-b614aacae068"/> |
