### PR TITLE
issue-142: add `_time` field if it doesn't present in the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * FEATURE: add tooltips and info messages for query types. Now, plugin will warn about correct usage of `stats` panels and will provide more info about different query types.
+* FEATURE: automatically add `_time` field if it s not present in the query for the `stats` [API call](https://docs.victoriametrics.com/victorialogs/querying/#querying-log-stats). See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/142).
 
 * BUGFIX: fix bug with incomplete rendering of time series panels when selecting bigger time intervals.
 * BUGFIX: fix a bug where the time range was reset when using query variables. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/118).

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -167,6 +167,8 @@ func (q *Query) statsQueryURL(queryParams url.Values) string {
 	}
 
 	q.Expr = utils.ReplaceTemplateVariable(q.Expr, q.IntervalMs, q.TimeRange)
+	q.Expr = utils.AddTimeFieldWithRange(q.Expr, q.TimeRange)
+
 	values.Set("query", q.Expr)
 	values.Set("time", strconv.FormatInt(q.TimeRange.To.Unix(), 10))
 

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -245,6 +245,25 @@ func TestQuery_getQueryURL(t *testing.T) {
 			want:    "http://127.0.0.1:9428/select/logsql/stats_query_range?a=1&b=2&end=1609462800&query=_time%3A1s+and+syslog+%7C+stats+by%28type%29+count%28%29&start=1609459200&step=15s",
 			wantErr: false,
 		},
+		{
+			name: "stats query without time field",
+			fields: fields{
+				RefID:    "1",
+				Expr:     "* and syslog | stats by(type) count()",
+				MaxLines: 10,
+				TimeRange: backend.TimeRange{
+					From: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+					To:   time.Date(2021, 1, 1, 1, 0, 0, 0, time.UTC),
+				},
+				QueryType: QueryTypeStats,
+			},
+			args: args{
+				rawURL:      "http://127.0.0.1:9428",
+				queryParams: "a=1&b=2",
+			},
+			want:    "http://127.0.0.1:9428/select/logsql/stats_query?a=1&b=2&query=_time%3A%5B1609459200%2C+1609462800%5D+%2A+and+syslog+%7C+stats+by%28type%29+count%28%29&time=1609462800",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -390,7 +390,6 @@ func AddTimeFieldWithRange(expr string, timeRange backend.TimeRange) string {
 	}
 
 	if hasTimeField(expr) {
-		backend.Logger.Info("Time field already exists in the query")
 		return expr
 	}
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -496,8 +496,6 @@ func Test_getIntervalFrom(t *testing.T) {
 }
 
 func TestAddTimeFieldWithRange(t *testing.T) {
-	type args struct {
-	}
 	tests := []struct {
 		name      string
 		expr      string


### PR DESCRIPTION
Automatically add `_time` field before the main query or the first pipe (because we can use _time in the stats by function) for the stats API call. 

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/142