### PR TITLE
fix replacement of multi-variables in expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * BUGFIX: fix bug with incomplete rendering of time series panels when selecting bigger time intervals.
 * BUGFIX: fix a bug where the time range was reset when using query variables. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/118).
 * BUGFIX: fix incorrect application of ad-hoc filters in panels. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/135).
+* BUGFIX: fix replacement of multi-variables in expressions. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/109).
 
 ## v0.10.0
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -117,15 +117,16 @@ describe('VictoriaLogsDatasource', () => {
       const scopedVars = {
         var: { text: 'foo,bar', value: ['foo', 'bar'] },
       };
+      const replaceValue = `$_StartMultiVariable_${scopedVars.var.value.join("_separator_")}_EndMultiVariable`
       const templateSrvMock = {
-        replace: jest.fn((a: string) => a?.replace('$var', '("foo" OR "bar")')),
+        replace: jest.fn((a: string) => a?.replace('$var', replaceValue)),
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
       const replacedQuery = ds.applyTemplateVariables(
         { expr: '_stream{val=~"$var"}', refId: 'A' },
         scopedVars
       );
-      expect(replacedQuery.expr).toBe('_stream{val=~"("foo"|"bar")"}');
+      expect(replacedQuery.expr).toBe('_stream{val=~"(foo|bar)"}');
     });
 
     it('should replace $var with an OR expression when given an array of values', () => {


### PR DESCRIPTION
Fix the issue with replacing multi-variables in expressions
Related issue: #109

Expression with multi-variables:
![Screenshot 2024-12-08 at 16 49 52](https://github.com/user-attachments/assets/cb49973f-da0c-4183-9c56-1b97de254542)

Query sent to VictoriaLogs:
![Screenshot 2024-12-08 at 16 49 47](https://github.com/user-attachments/assets/a0fb7685-2c52-4689-b4c8-bbbfff2b28e9)