### PR TITLE
fix plugin loading issue in Grafana `v10.x.x`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix plugin loading issue in Grafana `v10.x.x`. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/149).
+
 ## v0.11.0
 
 * FEATURE: add tooltips and info messages for query types. Now, plugin will warn about correct usage of `stats` panels and will provide more info about different query types.

--- a/src/modifyQuery.ts
+++ b/src/modifyQuery.ts
@@ -1,10 +1,8 @@
-import { scopeFilterOperatorMap } from "@grafana/data";
-
 import { buildVisualQueryFromString, splitExpression } from "./components/QueryEditor/QueryBuilder/utils/parseFromString";
 import { parseVisualQueryToString } from "./components/QueryEditor/QueryBuilder/utils/parseToString";
 import { FilterVisualQuery } from "./types";
 
-const operators = Object.keys(scopeFilterOperatorMap);
+const operators = ["=", "!=", "=~", "!~", "<", ">"]
 
 export function queryHasFilter(query: string, key: string, value: string, operator?: string): boolean {
   const applicableOperators = operator ? [operator] : operators;


### PR DESCRIPTION
Fixed the plugin loading issue in Grafana `v10.x.x`.  
_Cause: The `scopeFilterOperatorMap` object is not available in Grafana `v10.x.x`._  

Related issue: #149
