### PR TITLE
fix the check for the stats pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix the check for the stats pipe functions in expressions.
+
 ## v0.11.0
 
 * FEATURE: add tooltips and info messages for query types. Now, plugin will warn about correct usage of `stats` panels and will provide more info about different query types.

--- a/src/LogsQL/statsPipeFunctions.ts
+++ b/src/LogsQL/statsPipeFunctions.ts
@@ -1,0 +1,25 @@
+export const statsPipeFunctions = [
+  "avg",
+  "count",
+  "count_empty",
+  "count_uniq",
+  "count_uniq_hash",
+  "max",
+  "median",
+  "min",
+  "quantile",
+  "rate",
+  "rate_sum",
+  "row_any",
+  "row_max",
+  "row_min",
+  "sum",
+  "sum_len",
+  "uniq_values",
+  "values"
+];
+
+export const isExprHasStatsPipeFunctions = (expr: string) => {
+  const regex = new RegExp(`.*\\|.*\\b(${statsPipeFunctions.join("|")})\\b`, "mi");
+  return regex.test(expr)
+}

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { CoreApp, GrafanaTheme2, LoadingState } from '@grafana/data';
 import { Button, ConfirmModal, useStyles2 } from '@grafana/ui';
 
+import { isExprHasStatsPipeFunctions } from "../../LogsQL/statsPipeFunctions";
 import { Query, QueryEditorMode, QueryType, VictoriaLogsQueryEditorProps } from "../../types";
 import QueryEditorStatsWarn from "../QueryEditorStatsWarn";
 
@@ -26,7 +27,7 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
   const query = getQueryWithDefaults(props.query, app, data?.request?.panelPluginId);
   const editorMode = query.editorMode!;
   const isStatsQuery = query.queryType === QueryType.Stats || query.queryType === QueryType.StatsRange;
-  const showStatsWarn = isStatsQuery && !query.expr.includes('stats');
+  const showStatsWarn = isStatsQuery && !isExprHasStatsPipeFunctions(query.expr || '');
 
   const onEditorModeChange = useCallback((newEditorMode: QueryEditorMode) => {
       if (newEditorMode === QueryEditorMode.Builder) {


### PR DESCRIPTION
Fix the check for stats pipe functions in expressions.  
This resolves unnecessary warnings for `Range` and `Instant` queries.