### PR TITLE
filter out empty variable values in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: filter out empty variable values in queries. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/159).
+
 ## v0.13.0
 
 ⚠️ **Breaking Change: Plugin ID Updated**  

--- a/src/language_provider.ts
+++ b/src/language_provider.ts
@@ -124,9 +124,10 @@ function getArrayType(data: FieldHits[]): HitsValueType {
 }
 
 function sortFieldHits(data: FieldHits[]): FieldHits[] {
-  const arrayType = getArrayType(data);
+  const filteredData = data.filter(item => item.value !== "");
+  const arrayType = getArrayType(filteredData);
 
-  return data.sort((a, b) => {
+  return filteredData.sort((a, b) => {
     switch (arrayType) {
       case HitsValueType.NUMBER:
         return Number(a.value) - Number(b.value);


### PR DESCRIPTION
Filter out empty variable values.
Related issue: #159 