### PR TITLE
makefile: use sha1 instead of sha256

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ vl-plugin-pack: vl-plugin-build
 	tar -czf ../dist/$(PACKAGE_NAME).tar.gz ./$(PLUGIN_ID) && \
 	zip -q -r ../dist/$(PACKAGE_NAME).zip ./$(PLUGIN_ID) && \
 	cd - && \
-	sha256sum dist/$(PACKAGE_NAME).zip > dist/$(PACKAGE_NAME)_checksums_zip.txt && \
-	sha256sum dist/$(PACKAGE_NAME).tar.gz > dist/$(PACKAGE_NAME)_checksums_tar.gz.txt
+	sha1sum dist/$(PACKAGE_NAME).zip > dist/$(PACKAGE_NAME)_checksums_zip.txt && \
+	sha1sum dist/$(PACKAGE_NAME).tar.gz > dist/$(PACKAGE_NAME)_checksums_tar.gz.txt
 
 vl-plugin-cleanup:
 	rm -rf ./victorialogs-datasource plugins


### PR DESCRIPTION
Fixes Grafana validation error:
```
 * Problem: Invalid checksum format: 294dcc732c15fb3bbf61a11a75b9168c84869998e00def511910a626b6e56328
    Details: Make sure you provide a valid checksum as a string or a valid URL to a checksum. Only MD5 and SHA1 checksums are supported.
```