### PR TITLE
bump go to 1.23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* SECURITY: bump Go version to 1.23.4. See the list of issues addressed in [Go1.23.4](https://github.com/golang/go/issues?q=milestone%3AGo1.23.4+label%3ACherryPickApproved).
+
 ## v0.13.2
 
 * SECURITY: bump golang.org/x/net to 0.33.0. See https://github.com/advisories/GHSA-w32m-9786-jp63

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/VictoriaMetrics/victorialogs-datasource
 
-go 1.23.1
+go 1.23.4
 
 require (
 	github.com/VictoriaMetrics/metricsql v0.76.0


### PR DESCRIPTION
See the list of issues addressed https://github.com/golang/go/issues?q=milestone%3AGo1.23.4+label%3ACherryPickApproved