### PR TITLE
Fix the history card displaying the raw query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## tip
 
-* BUGFIX: fix query display text in query history to show the actual expression instead of the full query object.
+* BUGFIX: fix query display text in query history to show the actual expression instead of the full query object. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/194).
 
 ## v0.13.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix query display text in query history to show the actual expression instead of the full query object.
+
 ## v0.13.2
 
 * SECURITY: bump Go version to 1.23.4. See the list of issues addressed in [Go1.23.4](https://github.com/golang/go/issues?q=milestone%3AGo1.23.4+label%3ACherryPickApproved).

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -395,4 +395,8 @@ export class VictoriaLogsDatasource
         return undefined
     }
   }
+
+  getQueryDisplayText(query: Query): string {
+    return (query.expr || '');
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/VictoriaMetrics/victorialogs-datasource/issues/194

- Add getQueryDisplayText() to datasource.ts