### PR TITLE
issue-237: fix query type switching when creating alerts in Grafana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: fix query display text in query history to show the actual expression instead of the full query object. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/194).
+* BUGFIX: fix query type switching when creating alerts in Grafana. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/237)
 
 ## v0.13.2
 

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -916,3 +916,56 @@ func TestDatasourceStreamTailProcess(t *testing.T) {
 		t.Fatalf("expected 2 got %d", len(got))
 	}
 }
+
+func TestDatasource_checkAlertingRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "no alerting header",
+			headers: map[string]string{},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "alerting header",
+			headers: map[string]string{"FromAlert": "true"},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "invalid alerting header",
+			headers: map[string]string{"FromAlert": "invalid"},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "false alerting header",
+			headers: map[string]string{"FromAlert": "false"},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "irrelevant header",
+			headers: map[string]string{"SomeOtherHeader": "true"},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Datasource{}
+			got, err := d.checkAlertingRequest(tt.headers)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkAlertingRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("checkAlertingRequest() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -56,6 +56,7 @@ type Query struct {
 	Field        string    `json:"field"`
 	QueryType    QueryType `json:"queryType"`
 	url          *url.URL
+	ForAlerting  bool `json:"-"`
 }
 
 // GetQueryURL calculates step and clear expression from template variables,

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -526,6 +526,7 @@ func Test_getStatsResponse(t *testing.T) {
 
 				return rsp
 			},
+			q: &Query{},
 		},
 		{
 			name:     "incorrect response",
@@ -533,6 +534,7 @@ func Test_getStatsResponse(t *testing.T) {
 			want: func() backend.DataResponse {
 				return newResponseError(fmt.Errorf("failed to prepare data from response: unmarshal err json: cannot unmarshal string into Go value of type []plugin.Result; \n \"\\\"abc\\\"\""), backend.StatusInternal)
 			},
+			q: &Query{},
 		},
 		{
 			name:     "correct stats response",

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -607,6 +607,31 @@ func Test_getStatsResponse(t *testing.T) {
 				return rsp
 			},
 		},
+		{
+			name:     "correct stats response for alerting",
+			filename: "test-data/stats_response",
+			q: &Query{
+				DataQuery: backend.DataQuery{
+					RefID: "A",
+				},
+				LegendFormat: "legend {{app}}",
+				ForAlerting:  true,
+			},
+			want: func() backend.DataResponse {
+				frames := []*data.Frame{
+					data.NewFrame("",
+						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": "message"}, []float64{13377}),
+					),
+					data.NewFrame("",
+						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{2078793288}),
+					),
+				}
+
+				rsp := backend.DataResponse{}
+				rsp.Frames = append(rsp.Frames, frames...)
+				return rsp
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Made a port of this PR: https://github.com/VictoriaMetrics/victoriametrics-datasource/pull/246

Should fix the issue with the alerting panel in the Grafana