### PR TITLE
issue-199: fix issue with parsing settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * BUGFIX: fix query display text in query history to show the actual expression instead of the full query object. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/194).
 * BUGFIX: fix query type switching when creating alerts in Grafana. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/237)
+* BUGFIX: fix parsings of the datasource settings in the plugin. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/199).
 
 ## v0.13.2
 

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -17,7 +17,13 @@ import (
 )
 
 func TestQueryData(t *testing.T) {
-	ds := Datasource{}
+	ds := Datasource{
+		grafanaSettings: &GrafanaSettings{
+			HTTPMethod:    "",
+			QueryParams:   "",
+			CustomHeaders: nil,
+		},
+	}
 
 	resp, err := ds.QueryData(
 		context.Background(),


### PR DESCRIPTION
Fixed problem with settings parsing. 
This PR https://github.com/VictoriaMetrics/victorialogs-datasource/pull/183 introduced the issue

Now, all settings should be parsed in the data source initialization and used in the queries if it needed.

Related issue: #199 