### PR TITLE
backend: change INFO severity to DEBUG

### DIFF
--- a/pkg/main.go
+++ b/pkg/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	backend.Logger.Info("Starting VictoriaLogs datasource backend ...")
+	backend.Logger.Debug("Starting VictoriaLogs datasource backend ...")
 
 	if err := datasource.Manage("victoriametrics-logs-datasource", plugin.NewDatasource, datasource.ManageOpts{}); err != nil {
 		log.DefaultLogger.Error("Failed to process VictoriaLogs datasource backend: %s", err.Error())

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -143,7 +143,7 @@ func (d *Datasource) RunStream(ctx context.Context, request *backend.RunStreamRe
 				// TODO I can't find any of this error in the code
 				// so just check the error message
 				if strings.Contains(err.Error(), "rpc error: code = Canceled desc = context canceled") {
-					backend.Logger.Info("Client has canceled the request")
+					backend.Logger.Debug("Client has canceled the request")
 					break
 				}
 				backend.Logger.Error("Failed send frame", "error", err)

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -53,7 +53,7 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 		b, err := br.ReadBytes('\n')
 		if err != nil {
 			if errors.Is(err, bufio.ErrBufferFull) {
-				backend.Logger.Info("skipping line number #%d: line too long", n)
+				backend.Logger.Debug("skipping line number #%d: line too long", n)
 				continue
 			}
 			if errors.Is(err, io.EOF) {
@@ -172,7 +172,7 @@ func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
 		b, err := br.ReadBytes('\n')
 		if err != nil {
 			if errors.Is(err, bufio.ErrBufferFull) {
-				backend.Logger.Info("skipping line number #%d: line too long", n)
+				backend.Logger.Debug("skipping line number #%d: line too long", n)
 				continue
 			}
 			if errors.Is(err, io.EOF) {


### PR DESCRIPTION
With this change we reduce amount of logs printed by Grafana. If needed, user can switch to DEBUG level to get everything logged by the plugin.

Based on plugin review recommendations.