### PR TITLE
fix live mode shows the first query result instead of separately requested two different results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: fix image links in public readme.
+* BUGFIX: fix live mode shows the first query result instead of separately requested two different results. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/229).
 
 ## v0.14.2
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -306,7 +306,7 @@ export class VictoriaLogsDatasource
         addr: {
           scope: LiveChannelScope.DataSource,
           namespace: this.uid,
-          path: `vl/${query.refId}`, // this will allow each new query to create a new connection
+          path: `${request.requestId}/${query.refId}`, // this will allow each new query to create a new connection
           data: {
             ...query,
           },
@@ -314,7 +314,7 @@ export class VictoriaLogsDatasource
       }).pipe(map((response) => {
         return {
           data: response.data || [],
-          key: `victorialogs-datasource-${query.refId}`,
+          key: `victorialogs-datasource-${request.requestId}-${query.refId}`,
           state: LoadingState.Streaming,
         };
       }));


### PR DESCRIPTION
Fixed issue when live mode shows the first query result instead of separately requesting two different results.
This issue happens because in the first realization, one global channel handles requests.

![live_stream_2](https://github.com/user-attachments/assets/c4a2b8e1-3bc6-428e-ba49-0fba2da04923)


Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/229