### PR TITLE
enable hits API call type for querying logs

### DIFF
--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -420,15 +420,25 @@ func (ls logStats) matrixDataFrames() (data.Frames, error) {
 		timestamps := make([]time.Time, len(res.Values))
 		values := make([]float64, len(res.Values))
 		for j, value := range res.Values {
-			v, ok := value[0].(float64)
+			t, ok := value[0].(float64)
 			if !ok {
 				return nil, fmt.Errorf("metric %v, value: %v unable to parse timestamp to float64 from %s", res, value, value[0])
 			}
-			seconds := int64(v)                                // get only seconds
-			nanoseconds := int64((v - float64(seconds)) * 1e9) // get only nanoseconds
+			seconds := int64(t)                                // get only seconds
+			nanoseconds := int64((t - float64(seconds)) * 1e9) // get only nanoseconds
 			timestamps[j] = time.Unix(seconds, nanoseconds)
 
-			f, err := strconv.ParseFloat(value[1].(string), 64)
+			v, ok := value[1].(string)
+			if !ok {
+				return nil, fmt.Errorf("metric %v, value: %v unable to convert metrics value to string from %s", res, value, value[1])
+			}
+
+			if v == "" {
+				values[j] = 0
+				continue
+			}
+
+			f, err := strconv.ParseFloat(v, 64)
 			if err != nil {
 				return nil, fmt.Errorf("metric %v, value: %v unable to convert metrics value to float64 from %s", res, value, value[1])
 			}

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -634,6 +634,28 @@ func Test_getStatsResponse(t *testing.T) {
 				return rsp
 			},
 		},
+		{
+			name:     "stats query range response with empty values",
+			filename: "test-data/stats_query_range_with_empty_values",
+			q: &Query{
+				DataQuery: backend.DataQuery{
+					RefID: "A",
+				},
+				LegendFormat: "legend {{app}}",
+			},
+			want: func() backend.DataResponse {
+				frames := []*data.Frame{
+					data.NewFrame("legend ",
+						data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1741254760, 0), time.Unix(1741261900, 0), time.Unix(1741262000, 0)}),
+						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "quantile(0.95, level)", "level": ""}, []float64{0, 0, 0}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
+					),
+				}
+
+				rsp := backend.DataResponse{}
+				rsp.Frames = append(rsp.Frames, frames...)
+				return rsp
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/plugin/test-data/stats_query_range_with_empty_values
+++ b/pkg/plugin/test-data/stats_query_range_with_empty_values
@@ -1,0 +1,1 @@
+{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"quantile(0.95, level)","level":""},"values":[[1741254760,""],[1741261900,""],[1741262000,""]]}]}}

--- a/src/components/QueryEditor/QueryEditorOptions.tsx
+++ b/src/components/QueryEditor/QueryEditorOptions.tsx
@@ -19,6 +19,12 @@ export interface Props {
 
 export const queryTypeOptions: Array<SelectableValue<QueryType>> = [
   {
+    value: QueryType.Hits,
+    label: 'Hits',
+    filter: ({ app }: Props) => app !== CoreApp.UnifiedAlerting && app !== CoreApp.CloudAlerting,
+    description: "Use `/select/logsql/hits` for querying logs.",
+  },
+  {
     value: QueryType.Instant,
     label: 'Raw Logs',
     filter: ({ app }: Props) => app !== CoreApp.UnifiedAlerting && app !== CoreApp.CloudAlerting,


### PR DESCRIPTION
Enabled hits API call type for querying logs. 
In the vmui we show the hits if the values are empty from the query. 
This call hits the API, helps to build some graphs, like it is described in the issue

Fixed problem with the empty values from the stats response. 
For some queries it may return response like it describe below
```
{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"quantile(0.95, level)","level":""},"values":[[1741254760,""],[1741261900,""],[1741262000,""]]}]}}
```

In that case, we should show 0 if we can't convert the value to the `float64`

Related issue: #242 