### PR TITLE
Transform labels to string for annotations in the dashboard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
       packages: write
       contents: write
       pages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -68,6 +70,12 @@ jobs:
             git tag ${TAG}
             git push origin ${TAG}
           fi
+      - name: Generate artifact attestation
+        if: ${{ hashFiles('NOTES.md') != '' }}
+        id: attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/victoriametrics-logs-datasource-${{ env.PKG_TAG }}.zip
       - name: Prapare binary cache
         if: ${{ hashFiles('NOTES.md') != '' }}
         uses: actions/cache@v4
@@ -79,6 +87,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "Check attestation details at: ${{ steps.attestation.outputs.attestation-url }}"
           gh release create ${{ env.PKG_TAG }} \
             --title=${{ env.PKG_TAG }} \
             --notes-file=NOTES.md ./dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix build annotation from the label field. All labels transforms to the string representation. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/188).
+
 ## v0.15.0
 
 * FEATURE: add configuration screen for derived fields. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/202).

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -117,7 +117,7 @@ export class VictoriaLogsDatasource
       .query(fixedRequest)
       .pipe(
         map((response) =>
-          transformBackendResult(response, fixedRequest.targets, this.derivedFields ?? [])
+          transformBackendResult(response, fixedRequest, this.derivedFields ?? [])
         )
       );
   }


### PR DESCRIPTION
When the user tries to use labels in the annotations, they always transform to the [Object object] because it has Object representation.
Convert those labels to string representation.
Behavior for the Explore app stays the same for any request

<img width="1077" alt="Screenshot 2025-03-07 at 16 13 43" src="https://github.com/user-attachments/assets/a6529676-11d0-4be7-b1f4-18a4aa12b938" />

In the dashboard, we can construct annotations via the labels
<img width="1789" alt="Screenshot 2025-03-07 at 16 14 45" src="https://github.com/user-attachments/assets/7b7b95fd-5a66-4ddf-a9fe-ab099eb4b181" />

<img width="1800" alt="Screenshot 2025-03-07 at 16 15 03" src="https://github.com/user-attachments/assets/120a529b-dbb8-4ee3-b256-4742e747a5c1" />

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/188
