### PR TITLE
fix the bug with incorrect bar display on the Logs Volume chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## tip
 
 * FEATURE: add support for build the linux/s390x. Extend backend build process to add more architectures. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/250).
+* FEATURE: add configuration screen for Custom query parameters. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/252).
 
 * BUGFIX: fix build annotation from the label field. All labels transforms to the string representation. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/188).
-* FEATURE: add configuration screen for Custom query parameters. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/252).
+* BUGFIX: fix the bug with incorrect bar display on the Logs Volume chart. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/249).
 
 ## v0.15.0
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -30,7 +30,7 @@ import { transformBackendResult } from "./backendResultTransformer";
 import QueryEditor from "./components/QueryEditor/QueryEditor";
 import { escapeLabelValueInSelector, isRegexSelector } from "./languageUtils";
 import LogsQlLanguageProvider from "./language_provider";
-import { queryLogsVolume } from "./logsVolumeLegacy";
+import { LOGS_VOLUME_BARS, queryLogsVolume } from "./logsVolumeLegacy";
 import { addLabelToQuery, queryHasFilter, removeLabelFromQuery } from "./modifyQuery";
 import { replaceVariables, returnVariables } from "./parsingUtils";
 import { regularEscape } from "./regexUtils";
@@ -353,7 +353,7 @@ export class VictoriaLogsDatasource
       case SupplementaryQueryType.LogsVolume:
         const HITS_BY_FIELD = '_stream'
         const totalSeconds = request.range.to.diff(request.range.from, "second");
-        const step = Math.ceil(totalSeconds / 100) || "";
+        const step = Math.ceil(totalSeconds / LOGS_VOLUME_BARS) || "";
 
         return {
           ...query,


### PR DESCRIPTION
Fixed bar rendering on the Logs Volume chart. The chart is now generated for each timestep, adding bars with zero values if no data is available. This prevents bar stretching.

Related issue: #249 

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/d440dcda-9c8c-4b04-bf62-1c6b2061554d) | ![image](https://github.com/user-attachments/assets/59131025-7b24-4720-9782-50e4bee0cecc) |
