### PR TITLE
fix: log context in dashboard view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## tip
 
+## v0.16.1
+
+* BUGFIX: fix log context in dashboard view.
+
 ## v0.16.0
 
 * FEATURE: implements the getLogRowContext method. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/41).

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -10,7 +10,7 @@ import {
   DataQueryResponse,
   DataSourceInstanceSettings,
   DataSourceWithLogsContextSupport,
-  dateTime,
+  Labels,
   LegacyMetricFindQueryOptions,
   LiveChannelScope,
   LoadingState,
@@ -426,7 +426,23 @@ export class VictoriaLogsDatasource
   };
 
   private prepareLogContextQueryExpr = (row: LogRowModel): string => {
-    return addLabelToQuery('', LABEL_STREAM_ID, row.labels[LABEL_STREAM_ID],'');
+    let streamId = "";
+
+    if (row.labels[LABEL_STREAM_ID]) {
+      // Explore View
+      streamId = row.labels[LABEL_STREAM_ID]
+    } else {
+      // Dashboard View
+      const transformedLabels: Labels = {};
+      Object.values(row.labels).forEach((label) => {
+        const [key, value] = label.split(':');
+        const cleanedKey = key.trim();
+        transformedLabels[cleanedKey] = value.trim().replace(/"/g, '');
+      });
+      streamId = transformedLabels[LABEL_STREAM_ID];
+    }
+
+    return addLabelToQuery('', LABEL_STREAM_ID, streamId,'');
   };
 
   private makeLogContextDataRequest = (row: LogRowModel, options?: LogRowContextOptions): DataQueryRequest<Query> => {


### PR DESCRIPTION
Here's a fix for the problem of the log context not working in the dashboard view.

The label structure has changed and so my way of retrieving the stream_id value no longer works.

I'm a big fan of what I've done. If you have a better idea, I'd love to hear from you.