### PR TITLE
fix: incorrect log display due to array indices in messages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: fix parsing of `_stream` field with other than alpha-numeric characters in stream keys. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/265).
+* BUGFIX: fix a bug where array indices were appended to log messages, resulting in incorrect log display on the dashboard. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/269).
 
 ## v0.16.0
 

--- a/src/backendResultTransformer.ts
+++ b/src/backendResultTransformer.ts
@@ -1,5 +1,4 @@
 import {
-  CoreApp,
   DataFrame,
   DataQueryError,
   DataQueryRequest,
@@ -34,11 +33,10 @@ function processStreamsFrames(
   frames: DataFrame[],
   queryMap: Map<string, Query>,
   derivedFieldConfigs: DerivedFieldConfig[],
-  app: string
 ): DataFrame[] {
   return frames.map((frame) => {
     const query = frame.refId !== undefined ? queryMap.get(frame.refId) : undefined;
-    if (app === CoreApp.Dashboard) return processDashboardStreamFrame(frame, query, derivedFieldConfigs);
+    if (query?.refId === "Anno") {return processDashboardStreamFrame(frame, query, derivedFieldConfigs);}
     return processStreamFrame(frame, query, derivedFieldConfigs);
   });
 }
@@ -186,7 +184,6 @@ export function transformBackendResult(
 ): DataQueryResponse {
   const { data, errors, ...rest } = response;
   const queries = request.targets;
-  const { app } = request;
 
   // in the typescript type, data is an array of basically anything.
   // we do know that they have to be dataframes, so we make a quick check,
@@ -211,7 +208,7 @@ export function transformBackendResult(
     data: [
       ...processMetricRangeFrames(metricRangeFrames),
       ...processMetricInstantFrames(metricInstantFrames),
-      ...processStreamsFrames(streamsFrames, queryMap, derivedFieldConfigs, app),
+      ...processStreamsFrames(streamsFrames, queryMap, derivedFieldConfigs),
     ],
   };
 }


### PR DESCRIPTION
Fixed incorrect log display where array indices were appended to messages.

In [PR #253](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/253/files#diff-3c550b5074445756acc4c8616b586e6b6e79036c66d43133cd4814683f01e780R33-R45), the `processStreamFrames` logic was changed, which unintentionally affected how all dashboard queries were processed. This PR restores the correct behavior, applying the modified logic **only to annotation queries**.

---

Related issue: #269, #270 and #264

![Image](https://github.com/user-attachments/assets/388e8aea-bdad-4bd8-b7cb-2eae430334ce)