### PR TITLE
Enable freebsd amd64 build

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -22,7 +22,10 @@ func Build() {
 	linuxS390 := func () error {
 		return b.Custom("linux", "s390x")
 	}
-	mg.Deps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM, linuxS390)
+	freebsdAMD64 := func () error {
+		return b.Custom("freebsd", "amd64")
+	}
+	mg.Deps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM, freebsdAMD64, linuxS390)
 }
 
 // Default configures the default target.


### PR DESCRIPTION
The build works for freebsd amd64 so it should be enabled so that the plugin can be used under FreeBSD AMD64. 