### PR TITLE
mention PDC support in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v0.16.3
 
+* FEATURE: enabled [PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) support. See [VictoriaMetrics#8800](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8800) for details.
 * BUGFIX: fix shows the original error message returned from the VictoriaLogs backend on status code 400. It should help to troubleshoot problems with query or syntax. See [this pull request](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/287).
 * BUGFIX: fix extend the `Custom query parameters` label width to fix the title. See [this pull request](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/284)
   Thanks to @tommysitehost.


### PR DESCRIPTION
PDC was enabled for datasource v0.16.3, mentioning it in a changelog
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/578e9a53-fb88-41a6-9cc1-d757c7d2151f" />
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/f4925eff-5333-47ed-9012-1cfe7ceeec2f" />
