### PR TITLE
fix error when response detected as not a wide series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue when Grafana decides that the response is not a wide series and shows the error "input data must be a wide series but got type not (input refid)" . See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/302).
+
 ## v0.16.3
 
 * FEATURE: enabled [PDC](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) support. See [VictoriaMetrics#8800](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8800) for details.

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -411,7 +411,13 @@ func (ls logStats) alertingDataFrames() (data.Frames, error) {
 		}
 
 		frames[i] = data.NewFrame("",
-			data.NewField(data.TimeSeriesValueFieldName, data.Labels(res.Labels), []float64{f}))
+			data.NewField(data.TimeSeriesValueFieldName, data.Labels(res.Labels), []float64{f})).
+			// to show instant alert response with the table we need to define the type of the frame
+			// and it should be [0, 1] like it set in the Grafana
+			SetMeta(&data.FrameMeta{
+				Type:        data.FrameTypeNumericMulti,
+				TypeVersion: data.FrameTypeVersion{0, 1},
+			})
 	}
 
 	return frames, nil

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -726,10 +726,10 @@ func Test_getStatsResponse(t *testing.T) {
 				frames := []*data.Frame{
 					data.NewFrame("",
 						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": "message"}, []float64{13377}),
-					),
+					).SetMeta(&data.FrameMeta{Type: data.FrameTypeNumericMulti, TypeVersion: data.FrameTypeVersion{0, 1}}),
 					data.NewFrame("",
 						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{2078793288}),
-					),
+					).SetMeta(&data.FrameMeta{Type: data.FrameTypeNumericMulti, TypeVersion: data.FrameTypeVersion{0, 1}}),
 				}
 
 				rsp := backend.DataResponse{}


### PR DESCRIPTION
Grafana tries to detect the type of the frame, and we need to specify that type for the instant queries in the alerting tab

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/302