### PR TITLE
Improve query builder: narrow field/value options based on previous filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: improve query builder – when using AND operator, field and value selection is now narrowed. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/244).
+
 ## v0.17.0
 
 * FEATURE: add support for configuring log level using custom rules. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/294).

--- a/src/components/QueryEditor/QueryBuilder/components/QueryBuilderFilters/QueryBuilderFieldFilter.tsx
+++ b/src/components/QueryEditor/QueryBuilder/components/QueryBuilderFilters/QueryBuilderFieldFilter.tsx
@@ -9,7 +9,7 @@ import { escapeLabelValueInExactSelector } from "../../../../../languageUtils";
 import { FilterFieldType, VisualQuery } from "../../../../../types";
 import { deleteByIndexPath } from "../../utils/modifyFilterVisualQuery/deleteByIndexPath";
 import { updateValueByIndexPath } from "../../utils/modifyFilterVisualQuery/updateByIndexPath";
-import { DEFAULT_FIELD } from "../../utils/parseToString";
+import { DEFAULT_FIELD, filterVisualQueryToString } from "../../utils/parseToString";
 
 interface Props {
   datasource: VictoriaLogsDatasource;
@@ -69,7 +69,10 @@ const QueryBuilderFieldFilter = ({ datasource, filter, query, indexPath, timeRan
 
     setterLoading(true)
     const limit = datasource.getQueryBuilderLimits(type)
-    const list = await datasource.languageProvider?.getFieldList({ type, timeRange, field, limit })
+    const filtersWithoutCurrent = deleteByIndexPath(query.filters, indexPath)
+    const currentOperator = query.filters.operators[indexPath[0] - 1] || "AND"
+    const filters = currentOperator === "AND" ? filterVisualQueryToString(filtersWithoutCurrent, true) : ""
+    const list = await datasource.languageProvider?.getFieldList({ type, timeRange, field, limit, query: filters });
     const result = list ? list.map(({ value, hits }) => ({
       value,
       label: value || " ",

--- a/src/components/QueryEditor/QueryBuilder/utils/parseToString.ts
+++ b/src/components/QueryEditor/QueryBuilder/utils/parseToString.ts
@@ -3,25 +3,34 @@ import { FilterVisualQuery, VisualQuery } from "../../../../types";
 export const DEFAULT_FILTER_OPERATOR = "AND";
 export const DEFAULT_FIELD = "_msg";
 
-const filterVisualQueryToString = (query: FilterVisualQuery): string => {
-  const valueStrings: string[] = [];
-
-  for (let i = 0; i < query.values.length; i++) {
-    const value = query.values[i];
-    if (typeof value === 'string') {
-      valueStrings.push(value);
-    } else {
-      valueStrings.push(`(${filterVisualQueryToString(value)})`);
-    }
-  }
+export const filterVisualQueryToString = (
+  query: FilterVisualQuery,
+  finishedOnly = false
+): string => {
+  // Convert every value (recursively for nested queries)
+  const valueStrings = query.values.map(v =>
+    typeof v === 'string' ? v.trim() : `(${filterVisualQueryToString(v, finishedOnly)})`
+  );
 
   const operatorStrings = query.operators.map(op => op.trim());
 
-  return valueStrings.reduce((acc, val, index) => {
-    const operator = operatorStrings[index - 1] || DEFAULT_FILTER_OPERATOR;
-    return acc + (index === 0 ? '' : ` ${operator} `) + val;
-  }, '');
-}
+  let output = '';
+  for (let i = 0; i < valueStrings.length; i++) {
+    const val = valueStrings[i];
+    const isValidValue = /^.+:.+$/.test(val); // something on both sides of ':'
+
+    if (finishedOnly && !isValidValue) {break;}
+    if (!val) {continue;} // ignore empty strings from nested calls
+
+    if (i > 0) {
+      const op = operatorStrings[i - 1] || DEFAULT_FILTER_OPERATOR;
+      output += ` ${op} `;
+    }
+    output += val;
+  }
+
+  return output;
+};
 
 export const parseVisualQueryToString = (query: VisualQuery): string => {
   const pipesPart = query.pipes?.length ? ` | ${query.pipes.join(' | ')}` : ''


### PR DESCRIPTION
When using the `AND` operator in the query builder, the list of available fields and values is now dynamically narrowed based on the previously selected filters.

Related issue: #244

![image](https://github.com/user-attachments/assets/2a072493-abb7-4831-bd81-61e5be479749)
![image](https://github.com/user-attachments/assets/269c6525-e57c-4bc9-80fd-d6a09ffdb46a)