### PR TITLE
fix an issue where line charts were incorrectly connecting data points across missing (null) values despite the "Connect null values" panel setting being set to "Never"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * FEATURE: improve query builder – when using AND operator, field and value selection is now narrowed. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/244).
 * FEATURE: add a section to the datasource settings for tenant configuration. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/307).
 
+* BUGFIX: fix an issue where line charts were incorrectly connecting data points across missing (null) values despite the "Connect null values" panel setting being set to "Never". See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/311).
+
 ## v0.17.0
 
 * FEATURE: add support for configuring log level using custom rules. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/294).

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -277,6 +277,15 @@ func (q *Query) addMetadataToMultiFrame(frame *data.Frame) {
 	frame.Name = customName
 }
 
+func (q *Query) addIntervalToFrame(frame *data.Frame) {
+	if len(frame.Fields) > 0 && q.IntervalMs > 0 {
+		if frame.Fields[0].Config == nil {
+			frame.Fields[0].Config = &data.FieldConfig{}
+		}
+		frame.Fields[0].Config.Interval = float64(q.IntervalMs)
+	}
+}
+
 var legendReplacer = regexp.MustCompile(`\{\{\s*(.+?)\s*\}\}`)
 
 func (q *Query) parseLegend(labels data.Labels) string {

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -276,6 +276,7 @@ func parseStatsResponse(reader io.Reader, q *Query) backend.DataResponse {
 
 	for i := range frames {
 		q.addMetadataToMultiFrame(frames[i])
+		q.addIntervalToFrame(frames[i])
 	}
 
 	return backend.DataResponse{Frames: frames}

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -737,6 +737,33 @@ func Test_getStatsResponse(t *testing.T) {
 				return rsp
 			},
 		},
+		{
+			name:     "add interval to config",
+			filename: "test-data/stats_response",
+			q: &Query{
+				DataQuery: backend.DataQuery{
+					RefID: "A",
+				},
+				LegendFormat: "legend {{app}}",
+				IntervalMs:   1000,
+			},
+			want: func() backend.DataResponse {
+				frames := []*data.Frame{
+					data.NewFrame("legend ",
+						data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1730937600, 0)}).SetConfig(&data.FieldConfig{Interval: 1000}),
+						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": "message"}, []float64{13377}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
+					),
+					data.NewFrame("legend ",
+						data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1730937600, 0)}).SetConfig(&data.FieldConfig{Interval: 1000}),
+						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{2078793288}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
+					),
+				}
+
+				rsp := backend.DataResponse{}
+				rsp.Frames = append(rsp.Frames, frames...)
+				return rsp
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
1. Added an `interval` config param to time field to fix an issue where line charts were incorrectly connecting data points across missing (null) values despite the "Connect null values" panel setting being set to "Never"

Connect null values: never
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/0bda8ce6-1933-491d-95de-f41b82d80e93" />


Connect null values: always
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/a57050a3-be95-4af1-8b6b-0c66b379de7f" />


2. Updated readme with instructions how to run backend plugin in debug mode.