### PR TITLE
fix loading of field names when using variable or regexp in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## tip
 
-* BUGFIX: fix and issue when the additional `level` label was added if the logs level rules aren't configured. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/319).
+* BUGFIX: fix an issue when the additional `level` label was added if the logs level rules aren't configured. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/319).
+* BUGFIX: fix an issue with loading field names when creating a variable using a variable or a regexp operator in the query. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/312).
 
 ## v0.18.0
 

--- a/src/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -2,6 +2,7 @@ import { debounce } from "lodash";
 import React, { FormEvent, useEffect, useState } from 'react';
 
 import { DEFAULT_FIELD_DISPLAY_VALUES_LIMIT, QueryEditorProps, SelectableValue } from '@grafana/data';
+import { getTemplateSrv } from "@grafana/runtime";
 import { InlineField, InlineFieldRow, Input, Select } from "@grafana/ui";
 
 import { VictoriaLogsDatasource } from "../../datasource";
@@ -81,7 +82,7 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
           type: FilterFieldType.FieldName,
           timeRange: range,
           limit,
-          query: queryFilter,
+          query: getTemplateSrv().replace(queryFilter),
         });
 
         const result = list


### PR DESCRIPTION
This PR fixes an issue where field names failed to load when creating a variable using another variable or a regexp operator in the query.

Related issue: #312 