### PR TITLE
fix issue with empty `_msg` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue with missing `_msg` field in the response. If `_msg` field is missed in the response now always returned as an empty string. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/330).
+
 ## v0.18.1
 
 * BUGFIX: fix an issue when the additional `level` label was added if the logs level rules aren't configured. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/319).

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -96,6 +96,9 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 			for _, field := range stf {
 				labels[field.Label] = field.Value
 			}
+			if !value.Exists(messageField) && len(stf) > 0 {
+				lineField.Append("")
+			}
 		}
 
 		obj, err := value.Object()

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -557,6 +557,59 @@ func Test_parseStreamResponse(t *testing.T) {
 				return rsp
 			},
 		},
+		{
+			name:     "testing bug with empty message field",
+			filename: "test-data/bug_with_empty_message_field",
+			want: func() backend.DataResponse {
+				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+				labelsField.Name = gLabelsField
+
+				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+				timeFd.Name = gTimeField
+
+				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+				lineField.Name = gLineField
+
+				timeFd.Append(time.Date(2025, 7, 8, 9, 16, 54, 721000000, time.UTC))
+				timeFd.Append(time.Date(2025, 7, 8, 9, 16, 54, 734000000, time.UTC))
+
+				lineField.Append("some new message")
+
+				labels := data.Labels{
+					"_stream_id":     "1",
+					"container.id":   "1",
+					"container.name": "1",
+					"fluent.tag":     "2fa06040a011",
+					"severity":       "Unspecified",
+					"source":         "stdout",
+				}
+
+				b, _ := labelsToJSON(labels)
+				labelsField.Append(b)
+
+				lineField.Append("")
+
+				labels = data.Labels{
+					"_stream_id":     "2",
+					"container.id":   "2",
+					"container.name": "2",
+					"fluent.tag":     "2fa06040a011",
+					"severity":       "Unspecified",
+					"source":         "stdout",
+				}
+
+				b, _ = labelsToJSON(labels)
+				labelsField.Append(b)
+
+				frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+				rsp := backend.DataResponse{}
+				frame.Meta = &data.FrameMeta{}
+				rsp.Frames = append(rsp.Frames, frame)
+
+				return rsp
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/plugin/test-data/bug_with_empty_message_field
+++ b/pkg/plugin/test-data/bug_with_empty_message_field
@@ -1,0 +1,2 @@
+{"_time": "2025-07-08T09:16:54.721591656Z","_stream_id": "1","_stream": "{container.id=\"1\",container.name=\"1\"}","_msg": "some new message","container.id": "1","container.name": "1","fluent.tag": "2fa06040a011","severity": "Unspecified","source": "stdout"}
+{"_time": "2025-07-08T09:16:54.734626217Z","_stream_id": "2","_stream": "{container.id=\"2\",container.name=\"2\"}","container.id": "2","container.name": "2","fluent.tag": "2fa06040a011","severity": "Unspecified","source": "stdout"}


### PR DESCRIPTION
Fix issue when `_msg` field is not present in the response. Used default behavior to show the empty line. 
It will prevent the error like described in the bug and can help to verify the problem before the datasource

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/330