### PR TITLE
bump Grafana minimum supported version to 10.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BREAKING: increase minimum required Grafana version to `>=10.4.0` to ensure compatibility with [`@grafana/plugin-ui`](https://github.com/grafana/plugin-ui). This drops support for older Grafana versions.
+
 * BUGFIX: fix an issue with missing `_msg` field in the response. If `_msg` field is missed in the response now always returned as an empty string. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/330).
 
 ## v0.18.1

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -60,7 +60,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=10.0.3",
+    "grafanaDependency": ">=10.4.0",
     "plugins": []
   }
 }


### PR DESCRIPTION
Updates `grafanaDependency` to `>=10.4.0` for compatibility with [@grafana/plugin-ui](https://github.com/grafana/plugin-ui).

This change drops support for Grafana versions earlier than `10.4.0`, so a major version bump of the plugin is recommended.
