### PR TITLE
refactoring: added client with no timeout for stream, support public dashboards

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,13 @@
 {
   "extends": ["@grafana/eslint-config"],
   "root": true,
-  "plugins": ["@emotion", "lodash", "jest", "import"],
+  "plugins": ["@emotion", "lodash", "jest", "import", "unused-imports"],
   "settings": {
     "import/internal-regex": "^(src/)|(@grafana)",
     "import/external-module-folders": ["node_modules", ".yarn"]
   },
   "rules": {
+    "unused-imports/no-unused-imports": "error",
     "react/prop-types": "off",
     "@emotion/jsx-import": "error",
     "object-curly-spacing": [2, "always"],

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,27 @@
-run:
-  timeout: 2m
+version: "2"
 linters:
   enable:
     - revive
-issues:
-  exclude-dirs:
-    - go
-    - opt
-  exclude-rules:
-    - linters:
-        - staticcheck
-      text: "SA(4003|1019|5011):"
-  include:
-    - EXC0012
-    - EXC0014
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: 'SA(4003|1019|5011):'
+    paths:
+      - go
+      - opt
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 
 PLUGINCHECK2_VERSION = v0.20.3
 MAGE_VERSION = v1.15.0
-GOLANGCI_LINT_VERSION = v1.62.2
+GOLANGCI_LINT_VERSION = v2.2.2
 
 .PHONY: plugincheck2
 plugincheck2: $(PLUGINCHECK2)
@@ -117,7 +117,7 @@ $(MAGE): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,12 +3,14 @@ services:
     image: serjs/go-socks5-proxy
     restart: always
   victorialogs:
-    image: victoriametrics/victoria-logs:v1.17.0-victorialogs
+    image: victoriametrics/victoria-logs:v1.26.0
+    ports:
+     - 9428:9428
   grafana:
     build:
       context: .config
       args:
-        grafana_version: 11.5.2
+        grafana_version: main
         grafana_image: grafana
         development: true
     ports:

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-webpack-plugin": "^4.2.0",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "fork-ts-checker-webpack-plugin": "^9.0.2",
     "glob": "^10.4.2",
     "identity-obj-proxy": "3.0.0",

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -1,20 +1,46 @@
 package main
 
 import (
-	"os"
+	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 
 	"github.com/VictoriaMetrics/victorialogs-datasource/pkg/plugin"
 )
 
-func main() {
-	backend.Logger.Debug("Starting VictoriaLogs datasource backend ...")
+// VL_PLUGIN_ID describes plugin name that matches Grafana plugin naming convention
+const VL_PLUGIN_ID = "victoriametrics-logs-datasource"
 
-	if err := datasource.Manage("victoriametrics-logs-datasource", plugin.NewDatasource, datasource.ManageOpts{}); err != nil {
-		log.DefaultLogger.Error("Failed to process VictoriaLogs datasource backend: %s", err.Error())
-		os.Exit(1)
+func main() {
+	backend.SetupPluginEnvironment(VL_PLUGIN_ID)
+
+	pluginLogger := log.New()
+	mux := http.NewServeMux()
+	ds := Init(mux)
+	httpResourceHandler := httpadapter.New(mux)
+
+	pluginLogger.Debug("Starting VL datasource")
+
+	err := backend.Manage(VL_PLUGIN_ID, backend.ServeOpts{
+		CallResourceHandler: httpResourceHandler,
+		QueryDataHandler:    ds,
+		CheckHealthHandler:  ds,
+		StreamHandler:       ds,
+	})
+	if err != nil {
+		pluginLogger.Error("Error starting VL datasource", "error", err.Error())
 	}
+}
+
+// Init initializes VL datasource plugin service
+func Init(mux *http.ServeMux) *plugin.Datasource {
+	ds := plugin.NewDatasource()
+
+	mux.HandleFunc("/", ds.RootHandler)
+	mux.HandleFunc("/select/logsql/field_values", ds.VLAPIQuery)
+	mux.HandleFunc("/select/logsql/field_names", ds.VLAPIQuery)
+
+	return ds
 }

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -16,945 +16,993 @@ import (
 )
 
 func Test_parseStreamResponse(t *testing.T) {
-	tests := []struct {
-		name     string
+	type opts struct {
 		filename string
 		want     func() backend.DataResponse
-	}{
-		{
-			name:     "empty response",
-			filename: "test-data/empty",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "incorrect response",
-			filename: "test-data/incorrect_response",
-			want: func() backend.DataResponse {
-				return newResponseError(fmt.Errorf("error decode response: cannot parse JSON: cannot parse number: unexpected char: \"a\"; unparsed tail: \"abcd\""), backend.StatusInternal)
-			},
-		},
-		{
-			name:     "incorrect time in the response",
-			filename: "test-data/incorrect_time",
-			want: func() backend.DataResponse {
-				return newResponseError(fmt.Errorf("error parse time from _time field: cannot parse acdf: cannot parse duration \"acdf\""), backend.StatusInternal)
-			},
-		},
-		{
-			name:     "invalid stream in the response",
-			filename: "test-data/invalid_stream",
-			want: func() backend.DataResponse {
-				return newResponseError(fmt.Errorf("_stream field \"hostname=\" must have quoted value"), backend.StatusInternal)
-			},
-		},
-		{
-			name:     "empty stream field in the response",
-			filename: "test-data/empty_stream",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2024, 02, 20, 00, 00, 00, 0, time.UTC))
-
-				lineField.Append("{}")
-
-				labels := data.Labels{}
-
-				b, _ := labelsToJSON(labels)
-
-				labelsField.Append(b)
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "correct response line",
-			filename: "test-data/correct_response",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
-
-				lineField.Append("123")
-
-				labels := data.Labels{
-					"application": "logs-benchmark-Apache.log-1708437847",
-					"hostname":    "e28a622d7792",
-				}
-
-				b, _ := labelsToJSON(labels)
-
-				labelsField.Append(b)
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "response with different labels",
-			filename: "test-data/different_labels",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
-
-				lineField.Append("123")
-
-				labels := data.Labels{
-					"application": "logs-benchmark-Apache.log-1708437847",
-					"hostname":    "e28a622d7792",
-					"job":         "vlogs",
-				}
-
-				b, _ := labelsToJSON(labels)
-
-				labelsField.Append(b)
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "response with different labels and without standard fields",
-			filename: "test-data/no_standard_fields",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				lineField.Append(`{"count(*)":"394","stream":"stderr"}`)
-				lineField.Append(`{"count(*)":"21","stream":"stdout"}`)
-
-				labels := data.Labels{
-					"count(*)": "394",
-					"stream":   "stderr",
-				}
-
-				b, _ := labelsToJSON(labels)
-				labelsField.Append(b)
-
-				labels = data.Labels{
-					"count(*)": "21",
-					"stream":   "stdout",
-				}
-				b, _ = labelsToJSON(labels)
-				labelsField.Append(b)
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "response with different labels only one label",
-			filename: "test-data/only_one_label",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				lineField.Append(`{"level":""}`)
-
-				labels := data.Labels{
-					"level": "",
-				}
-
-				b, _ := labelsToJSON(labels)
-				labelsField.Append(b)
-
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "response when one stream field is defined and other is free fields",
-			filename: "test-data/stream_and_free_field",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2024, 06, 26, 13, 00, 00, 0, time.UTC))
-				timeFd.Append(time.Date(2024, 06, 26, 14, 00, 00, 0, time.UTC))
-
-				lineField.Append(`{"logs":"1400"}`)
-				lineField.Append(`{"logs":"374"}`)
-
-				labels := data.Labels{
-					"logs": "1400",
-				}
-
-				b, _ := labelsToJSON(labels)
-				labelsField.Append(b)
-
-				labels = data.Labels{
-					"logs": "374",
-				}
-
-				b, _ = labelsToJSON(labels)
-				labelsField.Append(b)
-
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "response has ANSI chars",
-			filename: "test-data/ANSI_chars",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2024, 06, 26, 13, 15, 15, 0, time.UTC))
-
-				lineField.Append(`\x1b[2m2024-06-26T13:15:15.004Z\x1b[0;39m \x1b[32mTRACE\x1b[0;39m \x1b[35m1\x1b[0;39m \x1b[2m---\x1b[0;39m \x1b[2m[    parallel-19]\x1b[0;39m \x1b[36mo.s.c.g.f.WeightCalculatorWebFilter     \x1b[0;39m \x1b[2m:\x1b[0;39m Weights attr: {} `)
-
-				labels := data.Labels{
-					"compose_project": "app",
-					"compose_service": "gateway",
-					"_stream_id":      "00000000000000009eaf29866f70976a098adc735393deb1",
-				}
-
-				b, _ := labelsToJSON(labels)
-				labelsField.Append(b)
-
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "response has unicode",
-			filename: "test-data/unicode_present",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2024, 06, 26, 13, 20, 34, 0, time.UTC))
-
-				value, err := fastjson.Parse(`{"_msg":"\u001b[2m2024-06-26T13:20:34.608Z\u001b[0;39m \u001b[33m WARN\u001b[0;39m \u001b[35m1\u001b[0;39m \u001b[2m---\u001b[0;39m \u001b[2m[           main]\u001b[0;39m \u001b[36mjakarta.persistence.spi                 \u001b[0;39m \u001b[2m:\u001b[0;39m jakarta.persistence.spi::No valid providers found. "}`)
-				if err != nil {
-					t.Fatalf("error decode response: %s", err)
-				}
-
-				if value.Exists(messageField) {
-					message := value.GetStringBytes(messageField)
-					lineField.Append(string(message))
-				}
-
-				labels := data.Labels{
-					"compose_project": "app",
-					"compose_service": "gateway",
-				}
-
-				b, _ := labelsToJSON(labels)
-				labelsField.Append(b)
-
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "response has labels and message, time field is empty",
-			filename: "test-data/time_field_empty",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				lineField.Append("507")
-
-				labels := data.Labels{
-					"count": "507",
-				}
-
-				b, _ := labelsToJSON(labels)
-				labelsField.Append(b)
-
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "double labels",
-			filename: "test-data/double_labels",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2024, 9, 10, 12, 24, 38, 124000000, time.UTC))
-				timeFd.Append(time.Date(2024, 9, 10, 12, 36, 10, 664000000, time.UTC))
-				timeFd.Append(time.Date(2024, 9, 10, 13, 06, 56, 451000000, time.UTC))
-
-				lineField.Append("1")
-
-				labels := data.Labels{
-					"_stream_id": "00000000000000002e3bd2bdc376279a6418761ca20c417c",
-					"path":       "/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log",
-					"stream":     "stderr",
-					"time":       "2024-09-10T12:24:38.124811792Z",
-				}
-
-				b, _ := labelsToJSON(labels)
-				labelsField.Append(b)
-
-				lineField.Append("2")
-
-				labels = data.Labels{
-					"_stream_id": "0000000000000000356bfe9e3c71128c750d94c15df6b908",
-					"date":       "0",
-					"stream":     "stream1",
-					"log.level":  "info",
-				}
-
-				b, _ = labelsToJSON(labels)
-				labelsField.Append(b)
-
-				lineField.Append("3")
-
-				labels = data.Labels{
-					"_stream_id": "00000000000000002e3bd2bdc376279a6418761ca20c417c",
-					"path":       "/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log",
-					"stream":     "stderr",
-					"time":       "2024-09-10T13:06:56.451470093Z",
-				}
-
-				b, _ = labelsToJSON(labels)
-				labelsField.Append(b)
-
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "large response more than 1MB",
-			filename: "test-data/large_msg_response_2MB",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2024, 9, 10, 12, 36, 10, 664000000, time.UTC))
-
-				// string with more than 1MB
-				str := strings.Repeat("1", 1024*1024*2)
-
-				lineField.Append(str)
-
-				labels := data.Labels{
-					"_stream_id": "0000000000000000356bfe9e3c71128c750d94c15df6b908",
-					"date":       "0",
-					"stream":     "stream1",
-					"log.level":  "info",
-				}
-
-				b, _ := labelsToJSON(labels)
-				labelsField.Append(b)
-
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "response with empty stream fields includes '/' in the label names",
-			filename: "test-data/stream_fields_with_spaces_in_names",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
-
-				lineField.Append("123")
-
-				labels := data.Labels{
-					"Dino Species": "Stegosaurus",
-					"kubernetes.labels.app.kubernetes.io/instance": "123",
-					"kubernetes.labels.app.kubernetes.io/name":     "vmagent",
-					"kubernetes.namespace_name":                    "monitoring",
-				}
-
-				b, _ := labelsToJSON(labels)
-
-				labelsField.Append(b)
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "response with stream fields includes spaces in the label names",
-			filename: "test-data/stream_fields_with_slashes_names",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
-
-				lineField.Append("123")
-
-				labels := data.Labels{
-					"kubernetes.host": "host1",
-					"kubernetes.labels.app.kubernetes.io/instance": "123",
-					"kubernetes.labels.app.kubernetes.io/name":     "vmagent",
-					"kubernetes.namespace_name":                    "monitoring",
-				}
-
-				b, _ := labelsToJSON(labels)
-
-				labelsField.Append(b)
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
-		{
-			name:     "testing bug with empty message field",
-			filename: "test-data/bug_with_empty_message_field",
-			want: func() backend.DataResponse {
-				labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-				labelsField.Name = gLabelsField
-
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-
-				lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-				lineField.Name = gLineField
-
-				timeFd.Append(time.Date(2025, 7, 8, 9, 16, 54, 721000000, time.UTC))
-				timeFd.Append(time.Date(2025, 7, 8, 9, 16, 54, 734000000, time.UTC))
-
-				lineField.Append("some new message")
-
-				labels := data.Labels{
-					"_stream_id":     "1",
-					"container.id":   "1",
-					"container.name": "1",
-					"fluent.tag":     "2fa06040a011",
-					"severity":       "Unspecified",
-					"source":         "stdout",
-				}
-
-				b, _ := labelsToJSON(labels)
-				labelsField.Append(b)
-
-				lineField.Append("")
-
-				labels = data.Labels{
-					"_stream_id":     "2",
-					"container.id":   "2",
-					"container.name": "2",
-					"fluent.tag":     "2fa06040a011",
-					"severity":       "Unspecified",
-					"source":         "stdout",
-				}
-
-				b, _ = labelsToJSON(labels)
-				labelsField.Append(b)
-
-				frame := data.NewFrame("", timeFd, lineField, labelsField)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			file, err := os.ReadFile(tt.filename)
-			if err != nil {
-				t.Fatalf("error reading file: %s", err)
+	f := func(opts opts) {
+		t.Helper()
+		file, err := os.ReadFile(opts.filename)
+		if err != nil {
+			t.Fatalf("error reading file: %s", err)
+		}
+
+		r := io.NopCloser(bytes.NewBuffer(file))
+		w := opts.want()
+		resp := parseInstantResponse(r)
+
+		if w.Error != nil {
+			if !reflect.DeepEqual(w, resp) {
+				t.Errorf("parseStreamResponse() = %#v, want %#v", resp, w)
 			}
+			return
+		}
 
-			r := io.NopCloser(bytes.NewBuffer(file))
-			w := tt.want()
-			resp := parseInstantResponse(r)
+		if len(resp.Frames) != 1 {
+			t.Fatalf("expected for response to always contain 1 Frame; got %d", len(resp.Frames))
+		}
 
-			if w.Error != nil {
-				if !reflect.DeepEqual(w, resp) {
-					t.Errorf("parseStreamResponse() = %#v, want %#v", resp, w)
-				}
-				return
-			}
-
-			if len(resp.Frames) != 1 {
-				t.Fatalf("expected for response to always contain 1 Frame; got %d", len(resp.Frames))
-			}
-
-			got := resp.Frames[0]
-			want := w.Frames[0]
-			expFieldsLen := got.Fields[0].Len()
-			for j, field := range want.Fields {
-				// if time field is empty, fill it with the value from the response
-				// because time field in the parseStreamResponse generated as time.Now()
-				if field.Name == gTimeField && field.Len() == 0 {
-					for _, f := range got.Fields {
-						if f.Name == gTimeField {
-							want.Fields[j] = f
-						}
+		got := resp.Frames[0]
+		want := w.Frames[0]
+		expFieldsLen := got.Fields[0].Len()
+		for j, field := range want.Fields {
+			// if time field is empty, fill it with the value from the response
+			// because time field in the parseStreamResponse generated as time.Now()
+			if field.Name == gTimeField && field.Len() == 0 {
+				for _, f := range got.Fields {
+					if f.Name == gTimeField {
+						want.Fields[j] = f
 					}
 				}
-
-				// all fields within response should have equal length
-				gf := got.Fields[j]
-				if gf.Len() != expFieldsLen {
-					t.Fatalf("expected all fields to have equal length %d; got %d instead for field %q",
-						expFieldsLen, gf.Len(), gf.Name)
-				}
 			}
 
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("parseStreamResponse() = %#v, want %#v", got, want)
+			// all fields within response should have equal length
+			gf := got.Fields[j]
+			if gf.Len() != expFieldsLen {
+				t.Fatalf("expected all fields to have equal length %d; got %d instead for field %q",
+					expFieldsLen, gf.Len(), gf.Name)
 			}
-		})
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("parseStreamResponse() = %#v, want %#v", got, want)
+		}
 	}
+
+	// empty response
+	o := opts{
+		filename: "test-data/empty",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// incorrect response
+	o = opts{
+		filename: "test-data/incorrect_response",
+		want: func() backend.DataResponse {
+			return newResponseError(fmt.Errorf("error decode response: cannot parse JSON: cannot parse number: unexpected char: \"a\"; unparsed tail: \"abcd\""), backend.StatusInternal)
+		},
+	}
+	f(o)
+
+	// incorrect time in the response
+	o = opts{
+		filename: "test-data/incorrect_time",
+		want: func() backend.DataResponse {
+			return newResponseError(fmt.Errorf("error parse time from _time field: cannot parse acdf: cannot parse duration \"acdf\""), backend.StatusInternal)
+		},
+	}
+	f(o)
+
+	// invalid stream in the response
+	o = opts{
+		filename: "test-data/invalid_stream",
+		want: func() backend.DataResponse {
+			return newResponseError(fmt.Errorf("_stream field \"hostname=\" must have quoted value"), backend.StatusInternal)
+		},
+	}
+	f(o)
+
+	// empty stream field in the response
+	o = opts{
+		filename: "test-data/empty_stream",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2024, 02, 20, 00, 00, 00, 0, time.UTC))
+
+			lineField.Append("{}")
+
+			labels := data.Labels{}
+
+			b, _ := labelsToJSON(labels)
+
+			labelsField.Append(b)
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// correct response line
+	o = opts{
+		filename: "test-data/correct_response",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
+
+			lineField.Append("123")
+
+			labels := data.Labels{
+				"application": "logs-benchmark-Apache.log-1708437847",
+				"hostname":    "e28a622d7792",
+			}
+
+			b, _ := labelsToJSON(labels)
+
+			labelsField.Append(b)
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// response with different labels
+	o = opts{
+		filename: "test-data/different_labels",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
+
+			lineField.Append("123")
+
+			labels := data.Labels{
+				"application": "logs-benchmark-Apache.log-1708437847",
+				"hostname":    "e28a622d7792",
+				"job":         "vlogs",
+			}
+
+			b, _ := labelsToJSON(labels)
+
+			labelsField.Append(b)
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// response with different labels and without standard fields
+	o = opts{
+		filename: "test-data/no_standard_fields",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			lineField.Append(`{"count(*)":"394","stream":"stderr"}`)
+			lineField.Append(`{"count(*)":"21","stream":"stdout"}`)
+
+			labels := data.Labels{
+				"count(*)": "394",
+				"stream":   "stderr",
+			}
+
+			b, _ := labelsToJSON(labels)
+			labelsField.Append(b)
+
+			labels = data.Labels{
+				"count(*)": "21",
+				"stream":   "stdout",
+			}
+			b, _ = labelsToJSON(labels)
+			labelsField.Append(b)
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// response with different labels only one label
+	o = opts{
+		filename: "test-data/only_one_label",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			lineField.Append(`{"level":""}`)
+
+			labels := data.Labels{
+				"level": "",
+			}
+
+			b, _ := labelsToJSON(labels)
+			labelsField.Append(b)
+
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// response when one stream field is defined and other is free fields
+	o = opts{
+		filename: "test-data/stream_and_free_field",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2024, 06, 26, 13, 00, 00, 0, time.UTC))
+			timeFd.Append(time.Date(2024, 06, 26, 14, 00, 00, 0, time.UTC))
+
+			lineField.Append(`{"logs":"1400"}`)
+			lineField.Append(`{"logs":"374"}`)
+
+			labels := data.Labels{
+				"logs": "1400",
+			}
+
+			b, _ := labelsToJSON(labels)
+			labelsField.Append(b)
+
+			labels = data.Labels{
+				"logs": "374",
+			}
+
+			b, _ = labelsToJSON(labels)
+			labelsField.Append(b)
+
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// response has ANSI chars
+	o = opts{
+		filename: "test-data/ANSI_chars",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2024, 06, 26, 13, 15, 15, 0, time.UTC))
+
+			lineField.Append(`\x1b[2m2024-06-26T13:15:15.004Z\x1b[0;39m \x1b[32mTRACE\x1b[0;39m \x1b[35m1\x1b[0;39m \x1b[2m---\x1b[0;39m \x1b[2m[    parallel-19]\x1b[0;39m \x1b[36mo.s.c.g.f.WeightCalculatorWebFilter     \x1b[0;39m \x1b[2m:\x1b[0;39m Weights attr: {} `)
+
+			labels := data.Labels{
+				"compose_project": "app",
+				"compose_service": "gateway",
+				"_stream_id":      "00000000000000009eaf29866f70976a098adc735393deb1",
+			}
+
+			b, _ := labelsToJSON(labels)
+			labelsField.Append(b)
+
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// response has unicode
+	o = opts{
+		filename: "test-data/unicode_present",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2024, 06, 26, 13, 20, 34, 0, time.UTC))
+
+			value, err := fastjson.Parse(`{"_msg":"\u001b[2m2024-06-26T13:20:34.608Z\u001b[0;39m \u001b[33m WARN\u001b[0;39m \u001b[35m1\u001b[0;39m \u001b[2m---\u001b[0;39m \u001b[2m[           main]\u001b[0;39m \u001b[36mjakarta.persistence.spi                 \u001b[0;39m \u001b[2m:\u001b[0;39m jakarta.persistence.spi::No valid providers found. "}`)
+			if err != nil {
+				t.Fatalf("error decode response: %s", err)
+			}
+
+			if value.Exists(messageField) {
+				message := value.GetStringBytes(messageField)
+				lineField.Append(string(message))
+			}
+
+			labels := data.Labels{
+				"compose_project": "app",
+				"compose_service": "gateway",
+			}
+
+			b, _ := labelsToJSON(labels)
+			labelsField.Append(b)
+
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// response has labels and message, time field is empty
+	o = opts{
+		filename: "test-data/time_field_empty",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			lineField.Append("507")
+
+			labels := data.Labels{
+				"count": "507",
+			}
+
+			b, _ := labelsToJSON(labels)
+			labelsField.Append(b)
+
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// double labels
+	o = opts{
+		filename: "test-data/double_labels",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2024, 9, 10, 12, 24, 38, 124000000, time.UTC))
+			timeFd.Append(time.Date(2024, 9, 10, 12, 36, 10, 664000000, time.UTC))
+			timeFd.Append(time.Date(2024, 9, 10, 13, 06, 56, 451000000, time.UTC))
+
+			lineField.Append("1")
+
+			labels := data.Labels{
+				"_stream_id": "00000000000000002e3bd2bdc376279a6418761ca20c417c",
+				"path":       "/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log",
+				"stream":     "stderr",
+				"time":       "2024-09-10T12:24:38.124811792Z",
+			}
+
+			b, _ := labelsToJSON(labels)
+			labelsField.Append(b)
+
+			lineField.Append("2")
+
+			labels = data.Labels{
+				"_stream_id": "0000000000000000356bfe9e3c71128c750d94c15df6b908",
+				"date":       "0",
+				"stream":     "stream1",
+				"log.level":  "info",
+			}
+
+			b, _ = labelsToJSON(labels)
+			labelsField.Append(b)
+
+			lineField.Append("3")
+
+			labels = data.Labels{
+				"_stream_id": "00000000000000002e3bd2bdc376279a6418761ca20c417c",
+				"path":       "/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log",
+				"stream":     "stderr",
+				"time":       "2024-09-10T13:06:56.451470093Z",
+			}
+
+			b, _ = labelsToJSON(labels)
+			labelsField.Append(b)
+
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// large response more than 1MB
+	o = opts{
+		filename: "test-data/large_msg_response_2MB",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2024, 9, 10, 12, 36, 10, 664000000, time.UTC))
+
+			// string with more than 1MB
+			str := strings.Repeat("1", 1024*1024*2)
+
+			lineField.Append(str)
+
+			labels := data.Labels{
+				"_stream_id": "0000000000000000356bfe9e3c71128c750d94c15df6b908",
+				"date":       "0",
+				"stream":     "stream1",
+				"log.level":  "info",
+			}
+
+			b, _ := labelsToJSON(labels)
+			labelsField.Append(b)
+
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// response with empty stream fields includes '/' in the label names
+	o = opts{
+		filename: "test-data/stream_fields_with_spaces_in_names",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
+
+			lineField.Append("123")
+
+			labels := data.Labels{
+				"Dino Species": "Stegosaurus",
+				"kubernetes.labels.app.kubernetes.io/instance": "123",
+				"kubernetes.labels.app.kubernetes.io/name":     "vmagent",
+				"kubernetes.namespace_name":                    "monitoring",
+			}
+
+			b, _ := labelsToJSON(labels)
+
+			labelsField.Append(b)
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// response with stream fields includes spaces in the label names
+	o = opts{
+		filename: "test-data/stream_fields_with_slashes_names",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
+
+			lineField.Append("123")
+
+			labels := data.Labels{
+				"kubernetes.host": "host1",
+				"kubernetes.labels.app.kubernetes.io/instance": "123",
+				"kubernetes.labels.app.kubernetes.io/name":     "vmagent",
+				"kubernetes.namespace_name":                    "monitoring",
+			}
+
+			b, _ := labelsToJSON(labels)
+
+			labelsField.Append(b)
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
+
+	// testing bug with empty message field
+	o = opts{
+		filename: "test-data/bug_with_empty_message_field",
+		want: func() backend.DataResponse {
+			labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
+			labelsField.Name = gLabelsField
+
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+
+			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+			lineField.Name = gLineField
+
+			timeFd.Append(time.Date(2025, 7, 8, 9, 16, 54, 721000000, time.UTC))
+			timeFd.Append(time.Date(2025, 7, 8, 9, 16, 54, 734000000, time.UTC))
+
+			lineField.Append("some new message")
+
+			labels := data.Labels{
+				"_stream_id":     "1",
+				"container.id":   "1",
+				"container.name": "1",
+				"fluent.tag":     "2fa06040a011",
+				"severity":       "Unspecified",
+				"source":         "stdout",
+			}
+
+			b, _ := labelsToJSON(labels)
+			labelsField.Append(b)
+
+			lineField.Append("")
+
+			labels = data.Labels{
+				"_stream_id":     "2",
+				"container.id":   "2",
+				"container.name": "2",
+				"fluent.tag":     "2fa06040a011",
+				"severity":       "Unspecified",
+				"source":         "stdout",
+			}
+
+			b, _ = labelsToJSON(labels)
+			labelsField.Append(b)
+
+			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+	}
+	f(o)
 }
 
 func Test_getStatsResponse(t *testing.T) {
-	tests := []struct {
-		name     string
+	type opts struct {
 		filename string
 		q        *Query
 		want     func() backend.DataResponse
-	}{
-		{
-			name:     "empty response",
-			filename: "test-data/stats_empty",
-			want: func() backend.DataResponse {
-
-				frame := data.NewFrame("", nil)
-
-				rsp := backend.DataResponse{}
-				frame.Meta = &data.FrameMeta{}
-				rsp.Frames = append(rsp.Frames, frame)
-
-				return rsp
-			},
-			q: &Query{},
-		},
-		{
-			name:     "incorrect response",
-			filename: "test-data/stats_incorrect_response",
-			want: func() backend.DataResponse {
-				return newResponseError(fmt.Errorf("failed to prepare data from response: unmarshal err json: cannot unmarshal string into Go value of type []plugin.Result; \n \"\\\"abc\\\"\""), backend.StatusInternal)
-			},
-			q: &Query{},
-		},
-		{
-			name:     "correct stats response",
-			filename: "test-data/stats_response",
-			q: &Query{
-				DataQuery: backend.DataQuery{
-					RefID: "A",
-				},
-				LegendFormat: "legend {{app}}",
-			},
-			want: func() backend.DataResponse {
-				frames := []*data.Frame{
-					data.NewFrame("legend ",
-						data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1730937600, 0)}),
-						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": "message"}, []float64{13377}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
-					),
-					data.NewFrame("legend ",
-						data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1730937600, 0)}),
-						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{2078793288}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
-					),
-				}
-
-				rsp := backend.DataResponse{}
-				rsp.Frames = append(rsp.Frames, frames...)
-				return rsp
-			},
-		},
-		{
-			name:     "correct range response",
-			filename: "test-data/stats_range_response",
-			q: &Query{
-				DataQuery: backend.DataQuery{
-					RefID: "A",
-				},
-				LegendFormat: "legend {{app}}",
-			},
-			want: func() backend.DataResponse {
-				frames := []*data.Frame{
-					data.NewFrame("legend ",
-						data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1704067200, 0), time.Unix(1704088800, 0), time.Unix(1704110400, 0), time.Unix(1704132000, 0)}),
-						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{1311461, 1311601, 1310266, 1310875}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
-					),
-				}
-
-				rsp := backend.DataResponse{}
-				rsp.Frames = append(rsp.Frames, frames...)
-				return rsp
-			},
-		},
-		{
-			name:     "response with milliseconds in timestamps",
-			filename: "test-data/stats_response_milliseconds",
-			q: &Query{
-				DataQuery: backend.DataQuery{
-					RefID: "A",
-				},
-				LegendFormat: "legend {{app}}",
-				Step:         "10ms",
-			},
-			want: func() backend.DataResponse {
-				frames := []*data.Frame{
-					data.NewFrame("legend ",
-						data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{
-							time.Unix(1733187134, 0),
-							time.Unix(1733187134, 449999809),
-						}),
-						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)"}, []float64{58, 1}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
-					),
-				}
-				rsp := backend.DataResponse{}
-				rsp.Frames = append(rsp.Frames, frames...)
-				return rsp
-			},
-		},
-		{
-			name:     "correct stats response for alerting",
-			filename: "test-data/stats_response",
-			q: &Query{
-				DataQuery: backend.DataQuery{
-					RefID: "A",
-				},
-				LegendFormat: "legend {{app}}",
-				ForAlerting:  true,
-			},
-			want: func() backend.DataResponse {
-				frames := []*data.Frame{
-					data.NewFrame("",
-						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": "message"}, []float64{13377}),
-					).SetMeta(&data.FrameMeta{Type: data.FrameTypeNumericMulti, TypeVersion: data.FrameTypeVersion{0, 1}}),
-					data.NewFrame("",
-						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{2078793288}),
-					).SetMeta(&data.FrameMeta{Type: data.FrameTypeNumericMulti, TypeVersion: data.FrameTypeVersion{0, 1}}),
-				}
-
-				rsp := backend.DataResponse{}
-				rsp.Frames = append(rsp.Frames, frames...)
-				return rsp
-			},
-		},
-		{
-			name:     "add interval to config",
-			filename: "test-data/stats_response",
-			q: &Query{
-				DataQuery: backend.DataQuery{
-					RefID: "A",
-				},
-				LegendFormat: "legend {{app}}",
-				IntervalMs:   1000,
-			},
-			want: func() backend.DataResponse {
-				frames := []*data.Frame{
-					data.NewFrame("legend ",
-						data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1730937600, 0)}).SetConfig(&data.FieldConfig{Interval: 1000}),
-						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": "message"}, []float64{13377}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
-					),
-					data.NewFrame("legend ",
-						data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1730937600, 0)}).SetConfig(&data.FieldConfig{Interval: 1000}),
-						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{2078793288}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
-					),
-				}
-
-				rsp := backend.DataResponse{}
-				rsp.Frames = append(rsp.Frames, frames...)
-				return rsp
-			},
-		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			file, err := os.ReadFile(tt.filename)
+	f := func(opts opts) {
+		t.Helper()
+		file, err := os.ReadFile(opts.filename)
+		if err != nil {
+			t.Fatalf("error reading file: %s", err)
+		}
+
+		r := io.NopCloser(bytes.NewBuffer(file))
+		w := opts.want()
+		resp := parseStatsResponse(r, opts.q)
+
+		if w.Error != nil {
+			if w.Error.Error() != resp.Error.Error() {
+				t.Errorf("parseStreamResponse() = %#v, want %#v", resp, w)
+			}
+			return
+		}
+
+		if len(resp.Frames) != 0 && len(w.Frames) != 0 {
+			got, err := resp.MarshalJSON()
 			if err != nil {
-				t.Fatalf("error reading file: %s", err)
+				t.Fatalf("error marshal response: %s", err)
 			}
-
-			r := io.NopCloser(bytes.NewBuffer(file))
-			w := tt.want()
-			resp := parseStatsResponse(r, tt.q)
-
-			if w.Error != nil {
-				if w.Error.Error() != resp.Error.Error() {
-					t.Errorf("parseStreamResponse() = %#v, want %#v", resp, w)
-				}
-				return
+			want, err := w.MarshalJSON()
+			if err != nil {
+				t.Fatalf("error marshal want response: %s", err)
 			}
-
-			if len(resp.Frames) != 0 && len(w.Frames) != 0 {
-				got, err := resp.MarshalJSON()
-				if err != nil {
-					t.Fatalf("error marshal response: %s", err)
-				}
-				want, err := w.MarshalJSON()
-				if err != nil {
-					t.Fatalf("error marshal want response: %s", err)
-				}
-				if !bytes.Equal(got, want) {
-					t.Fatalf("\n got value: %s, \n want value: %s", got, want)
-				}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("\n got value: %s, \n want value: %s", got, want)
 			}
-		})
+		}
 	}
+
+	// empty response
+	o := opts{
+		filename: "test-data/stats_empty",
+		want: func() backend.DataResponse {
+
+			frame := data.NewFrame("", nil)
+
+			rsp := backend.DataResponse{}
+			frame.Meta = &data.FrameMeta{}
+			rsp.Frames = append(rsp.Frames, frame)
+
+			return rsp
+		},
+		q: &Query{},
+	}
+	f(o)
+
+	// incorrect response
+	o = opts{
+		filename: "test-data/stats_incorrect_response",
+		want: func() backend.DataResponse {
+			return newResponseError(fmt.Errorf("failed to prepare data from response: unmarshal err json: cannot unmarshal string into Go value of type []plugin.Result; \n \"\\\"abc\\\"\""), backend.StatusInternal)
+		},
+		q: &Query{},
+	}
+	f(o)
+
+	// correct stats response
+	o = opts{
+		filename: "test-data/stats_response",
+		q: &Query{
+			DataQuery: backend.DataQuery{
+				RefID: "A",
+			},
+			LegendFormat: "legend {{app}}",
+		},
+		want: func() backend.DataResponse {
+			frames := []*data.Frame{
+				data.NewFrame("legend ",
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1730937600, 0)}),
+					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": "message"}, []float64{13377}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
+				),
+				data.NewFrame("legend ",
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1730937600, 0)}),
+					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{2078793288}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
+				),
+			}
+
+			rsp := backend.DataResponse{}
+			rsp.Frames = append(rsp.Frames, frames...)
+			return rsp
+		},
+	}
+	f(o)
+
+	// correct range response
+	o = opts{
+		filename: "test-data/stats_range_response",
+		q: &Query{
+			DataQuery: backend.DataQuery{
+				RefID: "A",
+			},
+			LegendFormat: "legend {{app}}",
+		},
+		want: func() backend.DataResponse {
+			frames := []*data.Frame{
+				data.NewFrame("legend ",
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1704067200, 0), time.Unix(1704088800, 0), time.Unix(1704110400, 0), time.Unix(1704132000, 0)}),
+					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{1311461, 1311601, 1310266, 1310875}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
+				),
+			}
+
+			rsp := backend.DataResponse{}
+			rsp.Frames = append(rsp.Frames, frames...)
+			return rsp
+		},
+	}
+	f(o)
+
+	// response with milliseconds in timestamps
+	o = opts{
+		filename: "test-data/stats_response_milliseconds",
+		q: &Query{
+			DataQuery: backend.DataQuery{
+				RefID: "A",
+			},
+			LegendFormat: "legend {{app}}",
+			Step:         "10ms",
+		},
+		want: func() backend.DataResponse {
+			frames := []*data.Frame{
+				data.NewFrame("legend ",
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{
+						time.Unix(1733187134, 0),
+						time.Unix(1733187134, 449999809),
+					}),
+					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)"}, []float64{58, 1}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
+				),
+			}
+			rsp := backend.DataResponse{}
+			rsp.Frames = append(rsp.Frames, frames...)
+			return rsp
+		},
+	}
+	f(o)
+
+	// correct stats response for alerting
+	o = opts{
+		filename: "test-data/stats_response",
+		q: &Query{
+			DataQuery: backend.DataQuery{
+				RefID: "A",
+			},
+			LegendFormat: "legend {{app}}",
+			ForAlerting:  true,
+		},
+		want: func() backend.DataResponse {
+			frames := []*data.Frame{
+				data.NewFrame("",
+					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": "message"}, []float64{13377}),
+				).SetMeta(&data.FrameMeta{Type: data.FrameTypeNumericMulti, TypeVersion: data.FrameTypeVersion{0, 1}}),
+				data.NewFrame("",
+					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{2078793288}),
+				).SetMeta(&data.FrameMeta{Type: data.FrameTypeNumericMulti, TypeVersion: data.FrameTypeVersion{0, 1}}),
+			}
+
+			rsp := backend.DataResponse{}
+			rsp.Frames = append(rsp.Frames, frames...)
+			return rsp
+		},
+	}
+	f(o)
+
+	// add interval to config
+	o = opts{
+		filename: "test-data/stats_response",
+		q: &Query{
+			DataQuery: backend.DataQuery{
+				RefID: "A",
+			},
+			LegendFormat: "legend {{app}}",
+			IntervalMs:   1000,
+		},
+		want: func() backend.DataResponse {
+			frames := []*data.Frame{
+				data.NewFrame("legend ",
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1730937600, 0)}).SetConfig(&data.FieldConfig{Interval: 1000}),
+					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": "message"}, []float64{13377}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
+				),
+				data.NewFrame("legend ",
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1730937600, 0)}).SetConfig(&data.FieldConfig{Interval: 1000}),
+					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "count(*)", "type": ""}, []float64{2078793288}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "legend "}),
+				),
+			}
+
+			rsp := backend.DataResponse{}
+			rsp.Frames = append(rsp.Frames, frames...)
+			return rsp
+		},
+	}
+	f(o)
 }
 
 func Test_parseHitsResponse(t *testing.T) {
-	tests := []struct {
-		name   string
+	type opts struct {
 		reader io.Reader
 		want   func() backend.DataResponse
-	}{
-		{
-			name:   "empty response",
-			reader: bytes.NewBufferString(`{ "hits": [] }`),
-			want: func() backend.DataResponse {
-				return backend.DataResponse{}
-			},
-		},
-		{
-			name:   "single hit response",
-			reader: bytes.NewBufferString(`{ "hits": [{ "fields": { "field1": "value1" }, "timestamps": ["2024-01-01T00:00:00Z"], "values": [1.23] }] }`),
-			want: func() backend.DataResponse {
-				timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd.Name = gTimeField
-				timeFd.Append(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	}
+	f := func(opts opts) {
+		t.Helper()
+		w := opts.want()
+		resp := parseHitsResponse(opts.reader)
 
-				valueFd := data.NewFieldFromFieldType(data.FieldTypeFloat64, 0)
-				valueFd.Name = gValueField
-				valueFd.Append(1.23)
-				valueFd.Labels = data.Labels{"field1": "value1"}
-				d, _ := labelsToJSON(valueFd.Labels)
+		if w.Error != nil {
+			if w.Error.Error() != resp.Error.Error() {
+				t.Errorf("parseStreamResponse() = %#v, want %#v", resp, w)
+			}
+			return
+		}
 
-				valueFd.Config = &data.FieldConfig{DisplayNameFromDS: string(d)}
+		if len(resp.Frames) != 0 && len(w.Frames) != 0 {
+			got, err := resp.MarshalJSON()
+			if err != nil {
+				t.Fatalf("error marshal response: %s", err)
+			}
+			want, err := w.MarshalJSON()
+			if err != nil {
+				t.Fatalf("error marshal want response: %s", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("\n got value: %s, \n want value: %s", got, want)
+			}
+		}
+	}
 
-				frame := data.NewFrame("", timeFd, valueFd)
-				return backend.DataResponse{Frames: data.Frames{frame}}
-			},
-		},
-		{
-			name:   "multiple hits response",
-			reader: bytes.NewBufferString(`{ "hits": [{ "fields": { "field1": "value1" }, "timestamps": ["2024-01-01T00:00:00Z"], "values": [1.23] }, { "fields": { "field2": "value2" }, "timestamps": ["2024-01-01T01:00:00Z"], "values": [4.56] }] }`),
-			want: func() backend.DataResponse {
-				timeFd1 := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd1.Name = gTimeField
-				timeFd1.Append(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
-
-				valueFd1 := data.NewFieldFromFieldType(data.FieldTypeFloat64, 0)
-				valueFd1.Name = gValueField
-				valueFd1.Append(1.23)
-				valueFd1.Labels = data.Labels{"field1": "value1"}
-				d, _ := labelsToJSON(valueFd1.Labels)
-
-				valueFd1.Config = &data.FieldConfig{DisplayNameFromDS: string(d)}
-
-				frame1 := data.NewFrame("", timeFd1, valueFd1)
-
-				timeFd2 := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-				timeFd2.Name = gTimeField
-				timeFd2.Append(time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC))
-
-				valueFd2 := data.NewFieldFromFieldType(data.FieldTypeFloat64, 0)
-				valueFd2.Name = gValueField
-				valueFd2.Append(4.56)
-				valueFd2.Labels = data.Labels{"field2": "value2"}
-				d, _ = labelsToJSON(valueFd2.Labels)
-
-				valueFd2.Config = &data.FieldConfig{DisplayNameFromDS: string(d)}
-
-				frame2 := data.NewFrame("", timeFd2, valueFd2)
-
-				return backend.DataResponse{Frames: data.Frames{frame1, frame2}}
-			},
-		},
-		{
-			name:   "error in response",
-			reader: bytes.NewBufferString(`{ "hits": [{ "fields": { "field1": "value1" }, "timestamps": ["invalid-time"], "values": [1.23] }] }`),
-			want: func() backend.DataResponse {
-				return newResponseError(fmt.Errorf("failed to prepare data from response: error parse time from _time field: cannot parse invalid-time: cannot parse duration \"invalid-time\""), backend.StatusInternal)
-			},
+	// empty response
+	o := opts{
+		reader: bytes.NewBufferString(`{ "hits": [] }`),
+		want: func() backend.DataResponse {
+			return backend.DataResponse{}
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	f(o)
 
-			w := tt.want()
-			resp := parseHitsResponse(tt.reader)
+	// single hit response
+	o = opts{
+		reader: bytes.NewBufferString(`{ "hits": [{ "fields": { "field1": "value1" }, "timestamps": ["2024-01-01T00:00:00Z"], "values": [1.23] }] }`),
+		want: func() backend.DataResponse {
+			timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd.Name = gTimeField
+			timeFd.Append(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 
-			if w.Error != nil {
-				if w.Error.Error() != resp.Error.Error() {
-					t.Errorf("parseStreamResponse() = %#v, want %#v", resp, w)
-				}
-				return
-			}
+			valueFd := data.NewFieldFromFieldType(data.FieldTypeFloat64, 0)
+			valueFd.Name = gValueField
+			valueFd.Append(1.23)
+			valueFd.Labels = data.Labels{"field1": "value1"}
+			d, _ := labelsToJSON(valueFd.Labels)
 
-			if len(resp.Frames) != 0 && len(w.Frames) != 0 {
-				got, err := resp.MarshalJSON()
-				if err != nil {
-					t.Fatalf("error marshal response: %s", err)
-				}
-				want, err := w.MarshalJSON()
-				if err != nil {
-					t.Fatalf("error marshal want response: %s", err)
-				}
-				if !bytes.Equal(got, want) {
-					t.Fatalf("\n got value: %s, \n want value: %s", got, want)
-				}
-			}
-		})
+			valueFd.Config = &data.FieldConfig{DisplayNameFromDS: string(d)}
+
+			frame := data.NewFrame("", timeFd, valueFd)
+			return backend.DataResponse{Frames: data.Frames{frame}}
+		},
 	}
+	f(o)
+
+	// multiple hits response
+	o = opts{
+		reader: bytes.NewBufferString(`{ "hits": [{ "fields": { "field1": "value1" }, "timestamps": ["2024-01-01T00:00:00Z"], "values": [1.23] }, { "fields": { "field2": "value2" }, "timestamps": ["2024-01-01T01:00:00Z"], "values": [4.56] }] }`),
+		want: func() backend.DataResponse {
+			timeFd1 := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd1.Name = gTimeField
+			timeFd1.Append(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+			valueFd1 := data.NewFieldFromFieldType(data.FieldTypeFloat64, 0)
+			valueFd1.Name = gValueField
+			valueFd1.Append(1.23)
+			valueFd1.Labels = data.Labels{"field1": "value1"}
+			d, _ := labelsToJSON(valueFd1.Labels)
+
+			valueFd1.Config = &data.FieldConfig{DisplayNameFromDS: string(d)}
+
+			frame1 := data.NewFrame("", timeFd1, valueFd1)
+
+			timeFd2 := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			timeFd2.Name = gTimeField
+			timeFd2.Append(time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC))
+
+			valueFd2 := data.NewFieldFromFieldType(data.FieldTypeFloat64, 0)
+			valueFd2.Name = gValueField
+			valueFd2.Append(4.56)
+			valueFd2.Labels = data.Labels{"field2": "value2"}
+			d, _ = labelsToJSON(valueFd2.Labels)
+
+			valueFd2.Config = &data.FieldConfig{DisplayNameFromDS: string(d)}
+
+			frame2 := data.NewFrame("", timeFd2, valueFd2)
+
+			return backend.DataResponse{Frames: data.Frames{frame1, frame2}}
+		},
+	}
+	f(o)
+
+	// error in response
+	o = opts{
+		reader: bytes.NewBufferString(`{ "hits": [{ "fields": { "field1": "value1" }, "timestamps": ["invalid-time"], "values": [1.23] }] }`),
+		want: func() backend.DataResponse {
+			return newResponseError(fmt.Errorf("failed to prepare data from response: error parse time from _time field: cannot parse invalid-time: cannot parse duration \"invalid-time\""), backend.StatusInternal)
+		},
+	}
+	f(o)
 }

--- a/pkg/utils/stream_fields_parser_test.go
+++ b/pkg/utils/stream_fields_parser_test.go
@@ -6,335 +6,366 @@ import (
 )
 
 func TestParseStreamFields(t *testing.T) {
-	tests := []struct {
-		name         string
+	type opts struct {
 		streamFields string
 		want         []StreamField
 		wantErr      bool
-	}{
-		{
-			name:         "empty",
-			streamFields: ``,
-			want:         []StreamField(nil),
-			wantErr:      false,
-		},
-		{
-			name:         "incorrect stream field",
-			streamFields: `{"a":1}`,
-			want:         []StreamField(nil),
-			wantErr:      true,
-		},
-		{
-			name:         "empty value field",
-			streamFields: `{b=""}`,
-			want:         []StreamField(nil),
-			wantErr:      true,
-		},
-		{
-			name:         "incorrect value field without quotes",
-			streamFields: `{b=a}`,
-			want:         []StreamField(nil),
-			wantErr:      true,
-		},
-		{
-			name:         "incorrect label field",
-			streamFields: `{=a"}`,
-			want:         []StreamField(nil),
-			wantErr:      true,
-		},
-		{
-			name:         "both label and value in the quotes",
-			streamFields: `{"a=b"}`,
-			want:         []StreamField(nil),
-			wantErr:      true,
-		},
-		{
-			name:         "correct stream field",
-			streamFields: `{a="b"}`,
-			want: []StreamField{{
+	}
+	f := func(opts opts) {
+		got, err := ParseStreamFields(opts.streamFields)
+		if (err != nil) != opts.wantErr {
+			t.Errorf("ParseStreamFields() error = %#v, wantErr %#v", err, opts.wantErr)
+			return
+		}
+		if !reflect.DeepEqual(got, opts.want) {
+			t.Errorf("ParseStreamFields() got = %#v, want %#v", got, opts.want)
+		}
+	}
+
+	// empty
+	o := opts{
+		want: []StreamField(nil),
+	}
+	f(o)
+
+	// incorrect stream field
+	o = opts{
+		streamFields: `{"a":1}`,
+		want:         []StreamField(nil),
+		wantErr:      true,
+	}
+	f(o)
+
+	// empty value field
+	o = opts{
+		streamFields: `{b=""}`,
+		want:         []StreamField(nil),
+		wantErr:      true,
+	}
+	f(o)
+
+	// incorrect value field without quotes
+	o = opts{
+		streamFields: `{b=a}`,
+		want:         []StreamField(nil),
+		wantErr:      true,
+	}
+	f(o)
+
+	// incorrect label field
+	o = opts{
+		streamFields: `{=a"}`,
+		want:         []StreamField(nil),
+		wantErr:      true,
+	}
+	f(o)
+
+	// both label and value in the quotes
+	o = opts{
+		streamFields: `{"a=b"}`,
+		want:         []StreamField(nil),
+		wantErr:      true,
+	}
+	f(o)
+
+	// correct stream field
+	o = opts{
+		streamFields: `{a="b"}`,
+		want: []StreamField{{
+			Label: "a",
+			Value: "b",
+		}},
+	}
+	f(o)
+
+	// many stream fields correct stream field
+	o = opts{
+		streamFields: `{a="b", c="e"}`,
+		want: []StreamField{
+			{
 				Label: "a",
 				Value: "b",
-			}},
-			wantErr: false,
-		},
-		{
-			name:         "many stream fields correct stream field",
-			streamFields: `{a="b", c="e"}`,
-			want: []StreamField{
-				{
-					Label: "a",
-					Value: "b",
-				},
-				{
-					Label: "c",
-					Value: "e",
-				},
 			},
-			wantErr: false,
-		},
-		{
-			name:         "contains spaces",
-			streamFields: `{ a = "b", c="d"}`,
-			want: []StreamField{
-				{
-					Label: "a",
-					Value: "b",
-				},
-				{
-					Label: "c",
-					Value: "d",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:         "include comma inside value",
-			streamFields: `{a="b,c", d="e"}`,
-			want: []StreamField{
-				{
-					Label: "a",
-					Value: "b,c",
-				},
-				{
-					Label: "d",
-					Value: "e",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:         "include equal sign inside value",
-			streamFields: `{a="b=c", d="e"}`,
-			want: []StreamField{
-				{
-					Label: "a",
-					Value: "b=c",
-				},
-				{
-					Label: "d",
-					Value: "e",
-				},
-			},
-		},
-		{
-			name:         "all labels with dots",
-			streamFields: `{a.b.c="d"}`,
-			want: []StreamField{
-				{
-					Label: "a.b.c",
-					Value: "d",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:         "many labels with dots",
-			streamFields: `{a.b.c="d", e.f.g="h"}`,
-			want: []StreamField{
-				{
-					Label: "a.b.c",
-					Value: "d",
-				},
-				{
-					Label: "e.f.g",
-					Value: "h",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name:         "all labels with dots and comma",
-			streamFields: `{a.b,c,d="e"}`,
-			want: []StreamField{
-				{
-					Label: "a.b,c,d",
-					Value: "e",
-				},
-			},
-		},
-		{
-			name:         "different label values",
-			streamFields: `{a.b,c,d="e", d="f", a,.b.c.d="e"}`,
-			want: []StreamField{
-				{
-					Label: "a.b,c,d",
-					Value: "e",
-				},
-				{
-					Label: "d",
-					Value: "f",
-				},
-				{
-					Label: "a,.b.c.d",
-					Value: "e",
-				},
-			},
-		},
-		{
-			name:         "label contains spaces",
-			streamFields: `{a d="e", d="f", a,.b.c.d="e"}`,
-			want: []StreamField{
-				{
-					Label: "a d",
-					Value: "e",
-				},
-				{
-					Label: "d",
-					Value: "f",
-				},
-				{
-					Label: "a,.b.c.d",
-					Value: "e",
-				},
-			},
-		},
-		{
-			name:         "empty stream field",
-			streamFields: `{}`,
-			want:         []StreamField(nil),
-			wantErr:      false,
-		},
-		{
-			name:         "complex stream fields with the comma inside the value",
-			streamFields: `{a="b", c="d,e,f", g="h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z"}`,
-			want: []StreamField{
-				{
-					Label: "a",
-					Value: "b",
-				},
-				{
-					Label: "c",
-					Value: "d,e,f",
-				},
-				{
-					Label: "g",
-					Value: "h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z",
-				},
-			},
-		},
-		{
-			name:         "real world example",
-			streamFields: `{process.command_args="[\"/opt/java/openjdk/bin/java\",\"-jar\",\"/app.jar\"]"}`,
-			want: []StreamField{
-				{
-					Label: "process.command_args",
-					Value: "[\"/opt/java/openjdk/bin/java\",\"-jar\",\"/app.jar\"]",
-				},
-			},
-		},
-		{
-			name:         "space after the quote and before the comma",
-			streamFields: `{process.command_args="[\"/opt/java/openjdk/bin/java\" ,\"-jar\",\"/app.jar\"]"}`,
-			want: []StreamField{
-				{
-					Label: "process.command_args",
-					Value: "[\"/opt/java/openjdk/bin/java\" ,\"-jar\",\"/app.jar\"]",
-				},
-			},
-		},
-		{
-			name:         "space after the quote and before the comma for the many of them",
-			streamFields: `{process.command_args="[\"/opt/java/openjdk/bin/java\" ,\"-jar\" ,\"/app.jar\"]"}`,
-			want: []StreamField{
-				{
-					Label: "process.command_args",
-					Value: "[\"/opt/java/openjdk/bin/java\" ,\"-jar\" ,\"/app.jar\"]",
-				},
-			},
-		},
-		{
-			name:         "real world example with comma inside the value after the quotes",
-			streamFields: `{deployment.environment="dev",host.arch="amd64",host.name="ip-XXX.compute.internal",os.description="Linux 5.10.XXX.amzn2.x86_64",os.type="linux",process.command_args="[\"/opt/java/openjdk/bin/java\",\"-jar\",\"/app.jar\"]",process.executable.path="/opt/java/openjdk/bin/java",process.pid="1",process.runtime.description="Eclipse Adoptium OpenJDK 64-Bit Server VM XXX",process.runtime.name="OpenJDK Runtime Environment",process.runtime.version="17.0.XXX",service.instance.id="XXX",service.name="XXX",service.version="0.0.1-SNAPSHOT",telemetry.distro.name="opentelemetry-spring-boot-starter",telemetry.distro.version="2.8.0",telemetry.sdk.language="java",telemetry.sdk.name="opentelemetry",telemetry.sdk.version="1.42.1"}`,
-			want: []StreamField{
-				{
-					Label: "deployment.environment",
-					Value: "dev",
-				},
-				{
-					Label: "host.arch",
-					Value: "amd64",
-				},
-				{
-					Label: "host.name",
-					Value: "ip-XXX.compute.internal",
-				},
-				{
-					Label: "os.description",
-					Value: "Linux 5.10.XXX.amzn2.x86_64",
-				},
-				{
-					Label: "os.type",
-					Value: "linux",
-				},
-				{
-					Label: "process.command_args",
-					Value: "[\"/opt/java/openjdk/bin/java\",\"-jar\",\"/app.jar\"]",
-				},
-				{
-					Label: "process.executable.path",
-					Value: "/opt/java/openjdk/bin/java",
-				},
-				{
-					Label: "process.pid",
-					Value: "1",
-				},
-				{
-					Label: "process.runtime.description",
-					Value: "Eclipse Adoptium OpenJDK 64-Bit Server VM XXX",
-				},
-				{
-					Label: "process.runtime.name",
-					Value: "OpenJDK Runtime Environment",
-				},
-				{
-					Label: "process.runtime.version",
-					Value: "17.0.XXX",
-				},
-				{
-					Label: "service.instance.id",
-					Value: "XXX",
-				},
-				{
-					Label: "service.name",
-					Value: "XXX",
-				},
-				{
-					Label: "service.version",
-					Value: "0.0.1-SNAPSHOT",
-				},
-				{
-					Label: "telemetry.distro.name",
-					Value: "opentelemetry-spring-boot-starter",
-				},
-				{
-					Label: "telemetry.distro.version",
-					Value: "2.8.0",
-				},
-				{
-					Label: "telemetry.sdk.language",
-					Value: "java",
-				},
-				{
-					Label: "telemetry.sdk.name",
-					Value: "opentelemetry",
-				},
-				{
-					Label: "telemetry.sdk.version",
-					Value: "1.42.1",
-				},
+			{
+				Label: "c",
+				Value: "e",
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseStreamFields(tt.streamFields)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseStreamFields() error = %#v, wantErr %#v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseStreamFields() got = %#v, want %#v", got, tt.want)
-			}
-		})
+	f(o)
+
+	// contains spaces
+	o = opts{
+		streamFields: `{ a = "b", c="d"}`,
+		want: []StreamField{
+			{
+				Label: "a",
+				Value: "b",
+			},
+			{
+				Label: "c",
+				Value: "d",
+			},
+		},
 	}
+	f(o)
+
+	// include comma inside value
+	o = opts{
+		streamFields: `{a="b,c", d="e"}`,
+		want: []StreamField{
+			{
+				Label: "a",
+				Value: "b,c",
+			},
+			{
+				Label: "d",
+				Value: "e",
+			},
+		},
+	}
+	f(o)
+
+	// include equal sign inside value
+	o = opts{
+		streamFields: `{a="b=c", d="e"}`,
+		want: []StreamField{
+			{
+				Label: "a",
+				Value: "b=c",
+			},
+			{
+				Label: "d",
+				Value: "e",
+			},
+		},
+	}
+	f(o)
+
+	// all labels with dots
+	o = opts{
+		streamFields: `{a.b.c="d"}`,
+		want: []StreamField{
+			{
+				Label: "a.b.c",
+				Value: "d",
+			},
+		},
+	}
+	f(o)
+
+	// many labels with dots
+	o = opts{
+		streamFields: `{a.b.c="d", e.f.g="h"}`,
+		want: []StreamField{
+			{
+				Label: "a.b.c",
+				Value: "d",
+			},
+			{
+				Label: "e.f.g",
+				Value: "h",
+			},
+		},
+	}
+	f(o)
+
+	// all labels with dots and comma
+	o = opts{
+		streamFields: `{a.b,c,d="e"}`,
+		want: []StreamField{
+			{
+				Label: "a.b,c,d",
+				Value: "e",
+			},
+		},
+	}
+	f(o)
+
+	// different label values
+	o = opts{
+		streamFields: `{a.b,c,d="e", d="f", a,.b.c.d="e"}`,
+		want: []StreamField{
+			{
+				Label: "a.b,c,d",
+				Value: "e",
+			},
+			{
+				Label: "d",
+				Value: "f",
+			},
+			{
+				Label: "a,.b.c.d",
+				Value: "e",
+			},
+		},
+	}
+	f(o)
+
+	// label contains spaces
+	o = opts{
+		streamFields: `{a d="e", d="f", a,.b.c.d="e"}`,
+		want: []StreamField{
+			{
+				Label: "a d",
+				Value: "e",
+			},
+			{
+				Label: "d",
+				Value: "f",
+			},
+			{
+				Label: "a,.b.c.d",
+				Value: "e",
+			},
+		},
+	}
+	f(o)
+
+	// empty stream field
+	o = opts{
+		streamFields: `{}`,
+		want:         []StreamField(nil),
+	}
+	f(o)
+
+	// complex stream fields with the comma inside the value
+	o = opts{
+		streamFields: `{a="b", c="d,e,f", g="h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z"}`,
+		want: []StreamField{
+			{
+				Label: "a",
+				Value: "b",
+			},
+			{
+				Label: "c",
+				Value: "d,e,f",
+			},
+			{
+				Label: "g",
+				Value: "h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z",
+			},
+		},
+	}
+	f(o)
+
+	// real world example
+	o = opts{
+		streamFields: `{process.command_args="[\"/opt/java/openjdk/bin/java\",\"-jar\",\"/app.jar\"]"}`,
+		want: []StreamField{
+			{
+				Label: "process.command_args",
+				Value: "[\"/opt/java/openjdk/bin/java\",\"-jar\",\"/app.jar\"]",
+			},
+		},
+	}
+	f(o)
+
+	// space after the quote and before the comma
+	o = opts{
+		streamFields: `{process.command_args="[\"/opt/java/openjdk/bin/java\" ,\"-jar\",\"/app.jar\"]"}`,
+		want: []StreamField{
+			{
+				Label: "process.command_args",
+				Value: "[\"/opt/java/openjdk/bin/java\" ,\"-jar\",\"/app.jar\"]",
+			},
+		},
+	}
+	f(o)
+
+	// space after the quote and before the comma for the many of them
+	o = opts{
+		streamFields: `{process.command_args="[\"/opt/java/openjdk/bin/java\" ,\"-jar\" ,\"/app.jar\"]"}`,
+		want: []StreamField{
+			{
+				Label: "process.command_args",
+				Value: "[\"/opt/java/openjdk/bin/java\" ,\"-jar\" ,\"/app.jar\"]",
+			},
+		},
+	}
+	f(o)
+
+	// real world example with comma inside the value after the quotes
+	o = opts{
+		streamFields: `{deployment.environment="dev",host.arch="amd64",host.name="ip-XXX.compute.internal",os.description="Linux 5.10.XXX.amzn2.x86_64",os.type="linux",process.command_args="[\"/opt/java/openjdk/bin/java\",\"-jar\",\"/app.jar\"]",process.executable.path="/opt/java/openjdk/bin/java",process.pid="1",process.runtime.description="Eclipse Adoptium OpenJDK 64-Bit Server VM XXX",process.runtime.name="OpenJDK Runtime Environment",process.runtime.version="17.0.XXX",service.instance.id="XXX",service.name="XXX",service.version="0.0.1-SNAPSHOT",telemetry.distro.name="opentelemetry-spring-boot-starter",telemetry.distro.version="2.8.0",telemetry.sdk.language="java",telemetry.sdk.name="opentelemetry",telemetry.sdk.version="1.42.1"}`,
+		want: []StreamField{
+			{
+				Label: "deployment.environment",
+				Value: "dev",
+			},
+			{
+				Label: "host.arch",
+				Value: "amd64",
+			},
+			{
+				Label: "host.name",
+				Value: "ip-XXX.compute.internal",
+			},
+			{
+				Label: "os.description",
+				Value: "Linux 5.10.XXX.amzn2.x86_64",
+			},
+			{
+				Label: "os.type",
+				Value: "linux",
+			},
+			{
+				Label: "process.command_args",
+				Value: "[\"/opt/java/openjdk/bin/java\",\"-jar\",\"/app.jar\"]",
+			},
+			{
+				Label: "process.executable.path",
+				Value: "/opt/java/openjdk/bin/java",
+			},
+			{
+				Label: "process.pid",
+				Value: "1",
+			},
+			{
+				Label: "process.runtime.description",
+				Value: "Eclipse Adoptium OpenJDK 64-Bit Server VM XXX",
+			},
+			{
+				Label: "process.runtime.name",
+				Value: "OpenJDK Runtime Environment",
+			},
+			{
+				Label: "process.runtime.version",
+				Value: "17.0.XXX",
+			},
+			{
+				Label: "service.instance.id",
+				Value: "XXX",
+			},
+			{
+				Label: "service.name",
+				Value: "XXX",
+			},
+			{
+				Label: "service.version",
+				Value: "0.0.1-SNAPSHOT",
+			},
+			{
+				Label: "telemetry.distro.name",
+				Value: "opentelemetry-spring-boot-starter",
+			},
+			{
+				Label: "telemetry.distro.version",
+				Value: "2.8.0",
+			},
+			{
+				Label: "telemetry.sdk.language",
+				Value: "java",
+			},
+			{
+				Label: "telemetry.sdk.name",
+				Value: "opentelemetry",
+			},
+			{
+				Label: "telemetry.sdk.version",
+				Value: "1.42.1",
+			},
+		},
+	}
+	f(o)
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -8,582 +8,582 @@ import (
 )
 
 func TestGetTime(t *testing.T) {
-	tests := []struct {
-		name    string
+	type opts struct {
 		s       string
 		want    func() time.Time
 		wantErr bool
-	}{
-		{
-			name:    "empty string",
-			s:       "",
-			want:    func() time.Time { return time.Time{} },
-			wantErr: true,
-		},
-		{
-			name: "only year",
-			s:    "2019",
-			want: func() time.Time {
-				t := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "year and month",
-			s:    "2019-01",
-			want: func() time.Time {
-				t := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "year and not first month",
-			s:    "2019-02",
-			want: func() time.Time {
-				t := time.Date(2019, 2, 1, 0, 0, 0, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "year, month and day",
-			s:    "2019-02-01",
-			want: func() time.Time {
-				t := time.Date(2019, 2, 1, 0, 0, 0, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "year, month and not first day",
-			s:    "2019-02-10",
-			want: func() time.Time {
-				t := time.Date(2019, 2, 10, 0, 0, 0, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "year, month, day and time",
-			s:    "2019-02-02T00",
-			want: func() time.Time {
-				t := time.Date(2019, 2, 2, 0, 0, 0, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "year, month, day and one hour time",
-			s:    "2019-02-02T01",
-			want: func() time.Time {
-				t := time.Date(2019, 2, 2, 1, 0, 0, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "time with zero minutes",
-			s:    "2019-02-02T01:00",
-			want: func() time.Time {
-				t := time.Date(2019, 2, 2, 1, 0, 0, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "time with one minute",
-			s:    "2019-02-02T01:01",
-			want: func() time.Time {
-				t := time.Date(2019, 2, 2, 1, 1, 0, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "time with zero seconds",
-			s:    "2019-02-02T01:01:00",
-			want: func() time.Time {
-				t := time.Date(2019, 2, 2, 1, 1, 0, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "timezone with one second",
-			s:    "2019-02-02T01:01:01",
-			want: func() time.Time {
-				t := time.Date(2019, 2, 2, 1, 1, 1, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "time with two second and timezone",
-			s:    "2019-07-07T20:01:02Z",
-			want: func() time.Time {
-				t := time.Date(2019, 7, 7, 20, 1, 02, 0, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "time with seconds and timezone",
-			s:    "2019-07-07T20:47:40+03:00",
-			want: func() time.Time {
-				l, _ := time.LoadLocation("Europe/Kiev")
-				t := time.Date(2019, 7, 7, 20, 47, 40, 0, l)
-				return t
-			},
-		},
-		{
-			name:    "negative time",
-			s:       "-292273086-05-16T16:47:06Z",
-			want:    func() time.Time { return time.Time{} },
-			wantErr: true,
-		},
-		{
-			name: "float timestamp representation",
-			s:    "1562529662.324",
-			want: func() time.Time {
-				t := time.Date(2019, 7, 7, 20, 01, 02, 324e6, time.UTC)
-				return t
-			},
-		},
-		{
-			name: "negative timestamp",
-			s:    "-9223372036.855",
-			want: func() time.Time {
-				return time.Date(1970, 01, 01, 00, 00, 00, 00, time.UTC)
-			},
-			wantErr: false,
-		},
-		{
-			name: "big timestamp",
-			s:    "1223372036855",
-			want: func() time.Time {
-				t := time.Date(2008, 10, 7, 9, 33, 56, 855e6, time.UTC)
-				return t
-			},
-			wantErr: false,
-		},
-		{
-			name: "duration time",
-			s:    "1h5m",
-			want: func() time.Time {
-				t := time.Now().Add(-1 * time.Hour).Add(-5 * time.Minute)
-				return t
-			},
+	}
+	f := func(opts opts) {
+		t.Helper()
+		got, err := GetTime(opts.s)
+		if (err != nil) != opts.wantErr {
+			t.Errorf("ParseTime() error = %v, wantErr %v", err, opts.wantErr)
+			return
+		}
+		w := opts.want()
+		if got.Unix() != w.Unix() {
+			t.Errorf("ParseTime() got = %v, want %v", got, w)
+		}
+	}
+
+	// empty string
+	o := opts{
+		want:    func() time.Time { return time.Time{} },
+		wantErr: true,
+	}
+	f(o)
+
+	// only year
+	o = opts{
+		s: "2019",
+		want: func() time.Time {
+			t := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+			return t
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetTime(tt.s)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseTime() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			w := tt.want()
-			if got.Unix() != w.Unix() {
-				t.Errorf("ParseTime() got = %v, want %v", got, w)
-			}
-		})
+	f(o)
+
+	// year and month
+	o = opts{
+		s: "2019-01",
+		want: func() time.Time {
+			t := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+			return t
+		},
 	}
+	f(o)
+
+	// year and not first month
+	o = opts{
+		s: "2019-02",
+		want: func() time.Time {
+			t := time.Date(2019, 2, 1, 0, 0, 0, 0, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// year, month and day
+	o = opts{
+		s: "2019-02-01",
+		want: func() time.Time {
+			t := time.Date(2019, 2, 1, 0, 0, 0, 0, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// year, month and not first day
+	o = opts{
+		s: "2019-02-10",
+		want: func() time.Time {
+			t := time.Date(2019, 2, 10, 0, 0, 0, 0, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// year, month, day and time
+	o = opts{
+		s: "2019-02-02T00",
+		want: func() time.Time {
+			t := time.Date(2019, 2, 2, 0, 0, 0, 0, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// year, month, day and one hour time
+	o = opts{
+		s: "2019-02-02T01",
+		want: func() time.Time {
+			t := time.Date(2019, 2, 2, 1, 0, 0, 0, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// time with zero minutes
+	o = opts{
+		s: "2019-02-02T01:00",
+		want: func() time.Time {
+			t := time.Date(2019, 2, 2, 1, 0, 0, 0, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// time with one minute
+	o = opts{
+		s: "2019-02-02T01:01",
+		want: func() time.Time {
+			t := time.Date(2019, 2, 2, 1, 1, 0, 0, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// time with zero seconds
+	o = opts{
+		s: "2019-02-02T01:01:00",
+		want: func() time.Time {
+			t := time.Date(2019, 2, 2, 1, 1, 0, 0, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// timezone with one second
+	o = opts{
+		s: "2019-02-02T01:01:01",
+		want: func() time.Time {
+			t := time.Date(2019, 2, 2, 1, 1, 1, 0, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// time with two second and timezone
+	o = opts{
+		s: "2019-07-07T20:01:02Z",
+		want: func() time.Time {
+			t := time.Date(2019, 7, 7, 20, 1, 02, 0, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// time with seconds and timezone
+	o = opts{
+		s: "2019-07-07T20:47:40+03:00",
+		want: func() time.Time {
+			l, _ := time.LoadLocation("Europe/Kiev")
+			t := time.Date(2019, 7, 7, 20, 47, 40, 0, l)
+			return t
+		},
+	}
+	f(o)
+
+	// negative time
+	o = opts{
+		s:       "-292273086-05-16T16:47:06Z",
+		want:    func() time.Time { return time.Time{} },
+		wantErr: true,
+	}
+	f(o)
+
+	// float timestamp representation
+	o = opts{
+		s: "1562529662.324",
+		want: func() time.Time {
+			t := time.Date(2019, 7, 7, 20, 01, 02, 324e6, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// negative timestamp
+	o = opts{
+		s: "-9223372036.855",
+		want: func() time.Time {
+			return time.Date(1970, 01, 01, 00, 00, 00, 00, time.UTC)
+		},
+	}
+	f(o)
+
+	// big timestamp
+	o = opts{
+		s: "1223372036855",
+		want: func() time.Time {
+			t := time.Date(2008, 10, 7, 9, 33, 56, 855e6, time.UTC)
+			return t
+		},
+	}
+	f(o)
+
+	// duration time
+	o = opts{
+		s: "1h5m",
+		want: func() time.Time {
+			t := time.Now().Add(-1 * time.Hour).Add(-5 * time.Minute)
+			return t
+		},
+	}
+	f(o)
 }
 
 func TestReplaceTemplateVariable(t *testing.T) {
-	tests := []struct {
-		name      string
+	type opts struct {
 		expr      string
 		interval  int64
 		timeRange backend.TimeRange
 		want      string
-	}{
-		{
-			name:     "empty string",
-			expr:     "",
-			interval: 0,
-			timeRange: backend.TimeRange{
-				From: time.Time{},
-				To:   time.Time{},
-			},
-			want: "",
-		},
-		{
-			name:     "no variable",
-			expr:     "test",
-			interval: 0,
-			timeRange: backend.TimeRange{
-				From: time.Time{},
-				To:   time.Time{},
-			},
-			want: "test",
-		},
-		{
-			name:     "variable",
-			expr:     "$__interval",
-			interval: 15,
-			timeRange: backend.TimeRange{
-				From: time.Time{},
-				To:   time.Time{},
-			},
-			want: "15ms",
-		},
-		{
-			name:     "variable with text",
-			expr:     "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:$__interval, host) count() logs",
-			interval: 15,
-			timeRange: backend.TimeRange{
-				From: time.Time{},
-				To:   time.Time{},
-			},
-			want: "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:15ms, host) count() logs",
-		},
-		{
-			name:     "variable with text and range",
-			expr:     "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:$__range, host) count() logs",
-			interval: 15,
-			timeRange: backend.TimeRange{
-				From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
-			},
-			want: "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:[1732320000, 1732492800], host) count() logs",
-		},
-		{
-			name:     "simple range with stats request",
-			expr:     "_time:$__range | stats count()",
-			interval: 15,
-			timeRange: backend.TimeRange{
-				From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
-			},
-			want: "_time:[1732320000, 1732492800] | stats count()",
-		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ReplaceTemplateVariable(tt.expr, tt.interval, tt.timeRange); got != tt.want {
-				t.Errorf("ReplaceTemplateVariable() = %v, want %v", got, tt.want)
-			}
-		})
+
+	f := func(opts opts) {
+		t.Helper()
+		if got := ReplaceTemplateVariable(opts.expr, opts.interval, opts.timeRange); got != opts.want {
+			t.Errorf("ReplaceTemplateVariable() = %v, want %v", got, opts.want)
+		}
 	}
+
+	// empty string
+	o := opts{}
+	f(o)
+
+	// no variable
+	o = opts{
+		expr: "test",
+		want: "test",
+	}
+	f(o)
+
+	// variable
+	o = opts{
+		expr:     "$__interval",
+		interval: 15,
+		want:     "15ms",
+	}
+	f(o)
+
+	// variable with text
+	o = opts{
+		expr:     "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:$__interval, host) count() logs",
+		interval: 15,
+		want:     "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:15ms, host) count() logs",
+	}
+	f(o)
+
+	// variable with text and range
+	o = opts{
+		expr:     "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:$__range, host) count() logs",
+		interval: 15,
+		timeRange: backend.TimeRange{
+			From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
+		},
+		want: "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:[1732320000, 1732492800], host) count() logs",
+	}
+	f(o)
+
+	// simple range with stats request
+	o = opts{
+		expr:     "_time:$__range | stats count()",
+		interval: 15,
+		timeRange: backend.TimeRange{
+			From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
+		},
+		want: "_time:[1732320000, 1732492800] | stats count()",
+	}
+	f(o)
 }
 
 func Test_calculateStep(t *testing.T) {
-	tests := []struct {
+	type opts struct {
 		name         string
 		baseInterval time.Duration
 		timeRange    backend.TimeRange
 		resolution   int64
 		want         string
-	}{
-		{
-			name:         "one month timerange and max point 43200 with 20 second base interval",
-			baseInterval: 20 * time.Second,
-			timeRange: backend.TimeRange{
-				From: time.Now().Add(-time.Hour * 24 * 30),
-				To:   time.Now(),
-			},
-			resolution: 43200,
-			want:       "1m0s",
-		},
-		{
-			name:         "one month timerange interval max points 43200 with 1 second base interval",
-			baseInterval: 1 * time.Second,
-			timeRange: backend.TimeRange{
-				From: time.Now().Add(-time.Hour * 24 * 30),
-				To:   time.Now(),
-			},
-			resolution: 43200,
-			want:       "1m0s",
-		},
-		{
-			name:         "one month timerange interval max points 10000 with 5 second base interval",
-			baseInterval: 5 * time.Second,
-			timeRange: backend.TimeRange{
-				From: time.Now().Add(-time.Hour * 24 * 30),
-				To:   time.Now(),
-			},
-			resolution: 10000,
-			want:       "5m0s",
-		},
-		{
-			name:         "one month timerange interval max points 10000 with 5 second base interval",
-			baseInterval: 5 * time.Second,
-			timeRange: backend.TimeRange{
-				From: time.Now().Add(-time.Hour * 1),
-				To:   time.Now(),
-			},
-			resolution: 10000,
-			want:       "5s",
-		},
-		{
-			name:         "one month timerange interval max points 10000 with 5 second base interval",
-			baseInterval: 2 * time.Minute,
-			timeRange: backend.TimeRange{
-				From: time.Now().Add(-time.Hour * 1),
-				To:   time.Now(),
-			},
-			resolution: 10000,
-			want:       "2m0s",
-		},
-		{
-			name:         "two days time range with minimal resolution",
-			baseInterval: 60 * time.Second,
-			timeRange: backend.TimeRange{
-				From: time.Now().Add(-time.Hour * 2 * 24),
-				To:   time.Now(),
-			},
-			resolution: 100,
-			want:       "30m0s",
-		},
-		{
-			name:         "two days time range with minimal resolution",
-			baseInterval: 60 * time.Second,
-			timeRange: backend.TimeRange{
-				From: time.Now().Add(-time.Hour * 24 * 90),
-				To:   time.Now(),
-			},
-			resolution: 100000,
-			want:       "1m0s",
-		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := CalculateStep(tt.baseInterval, tt.timeRange, tt.resolution); got.String() != tt.want {
-				t.Errorf("calculateStep() = %v, want %v", got, tt.want)
-			}
-		})
+	f := func(opts opts) {
+		t.Helper()
+		if got := CalculateStep(opts.baseInterval, opts.timeRange, opts.resolution); got.String() != opts.want {
+			t.Errorf("calculateStep() = %v, want %v", got, opts.want)
+		}
 	}
+
+	// one month timerange and max point 43200 with 20 second base interval
+	o := opts{
+		baseInterval: 20 * time.Second,
+		timeRange: backend.TimeRange{
+			From: time.Now().Add(-time.Hour * 24 * 30),
+			To:   time.Now(),
+		},
+		resolution: 43200,
+		want:       "1m0s",
+	}
+	f(o)
+
+	// one month timerange interval max points 43200 with 1 second base interval
+	o = opts{
+		baseInterval: 1 * time.Second,
+		timeRange: backend.TimeRange{
+			From: time.Now().Add(-time.Hour * 24 * 30),
+			To:   time.Now(),
+		},
+		resolution: 43200,
+		want:       "1m0s",
+	}
+	f(o)
+
+	// one month timerange interval max points 10000 with 5 second base interval
+	o = opts{
+		baseInterval: 5 * time.Second,
+		timeRange: backend.TimeRange{
+			From: time.Now().Add(-time.Hour * 24 * 30),
+			To:   time.Now(),
+		},
+		resolution: 10000,
+		want:       "5m0s",
+	}
+	f(o)
+
+	// one month timerange interval max points 10000 with 5 second base interval
+	o = opts{
+		baseInterval: 5 * time.Second,
+		timeRange: backend.TimeRange{
+			From: time.Now().Add(-time.Hour * 1),
+			To:   time.Now(),
+		},
+		resolution: 10000,
+		want:       "5s",
+	}
+	f(o)
+
+	// one month timerange interval max points 10000 with 5 second base interval
+	o = opts{
+		baseInterval: 2 * time.Minute,
+		timeRange: backend.TimeRange{
+			From: time.Now().Add(-time.Hour * 1),
+			To:   time.Now(),
+		},
+		resolution: 10000,
+		want:       "2m0s",
+	}
+	f(o)
+
+	// two days time range with minimal resolution
+	o = opts{
+		baseInterval: 60 * time.Second,
+		timeRange: backend.TimeRange{
+			From: time.Now().Add(-time.Hour * 2 * 24),
+			To:   time.Now(),
+		},
+		resolution: 100,
+		want:       "30m0s",
+	}
+	f(o)
+
+	//two days time range with minimal resolution
+	o = opts{
+		baseInterval: 60 * time.Second,
+		timeRange: backend.TimeRange{
+			From: time.Now().Add(-time.Hour * 24 * 90),
+			To:   time.Now(),
+		},
+		resolution: 100000,
+		want:       "1m0s",
+	}
+	f(o)
 }
 
 func Test_getIntervalFrom(t *testing.T) {
-	type args struct {
+	type opts struct {
 		dsInterval      string
 		queryInterval   string
 		queryIntervalMS int64
 		defaultInterval time.Duration
+		want            time.Duration
+		wantErr         bool
 	}
-	tests := []struct {
-		name    string
-		args    args
-		want    time.Duration
-		wantErr bool
-	}{
-		{
-			name: "empty intervals",
-			args: args{
-				dsInterval:      "",
-				queryInterval:   "",
-				queryIntervalMS: 0,
-				defaultInterval: 0,
-			},
-			want:    0,
-			wantErr: false,
-		},
-		{
-			name: "enabled dsInterval intervals",
-			args: args{
-				dsInterval:      "20s",
-				queryInterval:   "",
-				queryIntervalMS: 0,
-				defaultInterval: 0,
-			},
-			want:    time.Second * 20,
-			wantErr: false,
-		},
-		{
-			name: "enabled dsInterval and query intervals",
-			args: args{
-				dsInterval:      "20s",
-				queryInterval:   "10s",
-				queryIntervalMS: 0,
-				defaultInterval: 0,
-			},
-			want:    time.Second * 10,
-			wantErr: false,
-		},
-		{
-			name: "enabled queryIntervalMS intervals",
-			args: args{
-				dsInterval:      "20s",
-				queryInterval:   "10s",
-				queryIntervalMS: 5000,
-				defaultInterval: 0,
-			},
-			want:    time.Second * 10,
-			wantErr: false,
-		},
-		{
-			name: "enabled queryIntervalMS and empty queryInterval intervals",
-			args: args{
-				dsInterval:      "20s",
-				queryInterval:   "",
-				queryIntervalMS: 5000,
-				defaultInterval: 0,
-			},
-			want:    time.Second * 5,
-			wantErr: false,
-		},
-		{
-			name: "enabled queryIntervalMS and defaultInterval",
-			args: args{
-				dsInterval:      "",
-				queryInterval:   "",
-				queryIntervalMS: 5000,
-				defaultInterval: 10000,
-			},
-			want:    time.Second * 5,
-			wantErr: false,
-		},
-		{
-			name: "enabled defaultInterval",
-			args: args{
-				dsInterval:      "",
-				queryInterval:   "",
-				queryIntervalMS: 0,
-				defaultInterval: time.Second * 5,
-			},
-			want:    time.Second * 5,
-			wantErr: false,
-		},
-		{
-			name: "enabled dsInterval only a number",
-			args: args{
-				dsInterval:      "123",
-				queryInterval:   "",
-				queryIntervalMS: 0,
-				defaultInterval: time.Second * 5,
-			},
-			want:    time.Minute*2 + time.Second*3,
-			wantErr: false,
-		},
-		{
-			name: "dsInterval 0s",
-			args: args{
-				dsInterval:      "0s",
-				queryInterval:   "2s",
-				queryIntervalMS: 0,
-				defaultInterval: 0,
-			},
-			want:    time.Second * 2,
-			wantErr: false,
-		},
-		{
-			name: "incorrect dsInterval",
-			args: args{
-				dsInterval:      "a3",
-				queryInterval:   "",
-				queryIntervalMS: 0,
-				defaultInterval: 0,
-			},
-			want:    0,
-			wantErr: true,
-		},
-		{
-			name: "incorrect queryInterval",
-			args: args{
-				dsInterval:      "",
-				queryInterval:   "a3",
-				queryIntervalMS: 0,
-				defaultInterval: 0,
-			},
-			want:    0,
-			wantErr: true,
-		},
+	f := func(opts opts) {
+		t.Helper()
+		got, err := GetIntervalFrom(opts.dsInterval, opts.queryInterval, opts.queryIntervalMS, opts.defaultInterval)
+		if (err != nil) != opts.wantErr {
+			t.Errorf("getIntervalFrom() error = %v, wantErr %v", err, opts.wantErr)
+			return
+		}
+		if got != opts.want {
+			t.Errorf("getIntervalFrom() got = %v, want %v", got, opts.want)
+		}
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetIntervalFrom(tt.args.dsInterval, tt.args.queryInterval, tt.args.queryIntervalMS, tt.args.defaultInterval)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getIntervalFrom() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("getIntervalFrom() got = %v, want %v", got, tt.want)
-			}
-		})
+
+	// empty intervals
+	o := opts{}
+	f(o)
+
+	// enabled dsInterval intervals
+	o = opts{
+		dsInterval: "20s",
+		want:       time.Second * 20,
 	}
+	f(o)
+
+	// enabled dsInterval and query intervals
+	o = opts{
+		dsInterval:    "20s",
+		queryInterval: "10s",
+		want:          time.Second * 10,
+	}
+	f(o)
+
+	// enabled queryIntervalMS intervals
+	o = opts{
+		dsInterval:      "20s",
+		queryInterval:   "10s",
+		queryIntervalMS: 5000,
+		want:            time.Second * 10,
+	}
+	f(o)
+
+	// enabled queryIntervalMS and empty queryInterval intervals
+	o = opts{
+		dsInterval:      "20s",
+		queryInterval:   "",
+		queryIntervalMS: 5000,
+		defaultInterval: 0,
+		want:            time.Second * 5,
+	}
+	f(o)
+
+	// enabled queryIntervalMS and defaultInterval
+	o = opts{
+		queryIntervalMS: 5000,
+		defaultInterval: 10000,
+		want:            time.Second * 5,
+	}
+	f(o)
+
+	// enabled defaultInterval
+	o = opts{
+		defaultInterval: time.Second * 5,
+		want:            time.Second * 5,
+	}
+	f(o)
+
+	// enabled dsInterval only a number
+	o = opts{
+		dsInterval:      "123",
+		defaultInterval: time.Second * 5,
+		want:            time.Minute*2 + time.Second*3,
+	}
+	f(o)
+
+	// dsInterval 0s
+	o = opts{
+		dsInterval:    "0s",
+		queryInterval: "2s",
+		want:          time.Second * 2,
+	}
+	f(o)
+
+	// incorrect dsInterval
+	o = opts{
+		dsInterval: "a3",
+		wantErr:    true,
+	}
+	f(o)
+
+	// incorrect queryInterval
+	o = opts{
+		queryInterval: "a3",
+		wantErr:       true,
+	}
+	f(o)
 }
 
 func TestAddTimeFieldWithRange(t *testing.T) {
-	tests := []struct {
-		name      string
+	type opts struct {
 		expr      string
 		timeRange backend.TimeRange
 		want      string
-	}{
-		{
-			name: "empty string",
-			expr: "",
-			timeRange: backend.TimeRange{
-				From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
-			},
-			want: "",
-		},
-		{
-			name: "simple expression",
-			expr: "*",
-			timeRange: backend.TimeRange{
-				From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
-			},
-			want: "_time:[1732320000, 1732492800] *",
-		},
-		{
-			name: "simple range",
-			expr: "_time:[1732320000, 1732492800]",
-			timeRange: backend.TimeRange{
-				From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
-			},
-			want: "_time:[1732320000, 1732492800]",
-		},
-		{
-			name: "simple stats request no time field",
-			expr: "* | stats count()",
-			timeRange: backend.TimeRange{
-				From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
-			},
-			want: "_time:[1732320000, 1732492800] * | stats count()",
-		},
-		{
-			name: "simple stats request with time field",
-			expr: "_time:1s | stats count()",
-			timeRange: backend.TimeRange{
-				From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
-			},
-			want: "_time:1s | stats count()",
-		},
-		{
-			name: "time field after the first pipe",
-			expr: "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:1s, host) count() logs",
-			timeRange: backend.TimeRange{
-				From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
-			},
-			want: "_time:[1732320000, 1732492800] host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:1s, host) count() logs",
-		},
-		{
-			name: "time field present in the first part of the expression",
-			expr: "_time:5s host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:$__range, host) count() logs",
-			timeRange: backend.TimeRange{
-				From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
-			},
-			want: "_time:5s host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:$__range, host) count() logs",
-		},
-		{
-			name: "complex query with pipes and time field in stats",
-			expr: `kubernetes.pod_namespace:~"vm-operator" kubernetes.pod_name:~".*" kubernetes.container_name:~".*" 
-| format if (log.level:"") "other" as log.level
-| stats by (_time:1s) count()`,
-			timeRange: backend.TimeRange{
-				From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
-			},
-			want: `_time:[1732320000, 1732492800] kubernetes.pod_namespace:~"vm-operator" kubernetes.pod_name:~".*" kubernetes.container_name:~".*" 
-| format if (log.level:"") "other" as log.level
-| stats by (_time:1s) count()`,
+	}
+	f := func(opts opts) {
+		t.Helper()
+		if got := AddTimeFieldWithRange(opts.expr, opts.timeRange); got != opts.want {
+			t.Errorf("AddTimeFieldWithRange() = %v, want %v", got, opts.want)
+		}
+	}
+
+	// empty string
+	o := opts{
+		timeRange: backend.TimeRange{
+			From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := AddTimeFieldWithRange(tt.expr, tt.timeRange); got != tt.want {
-				t.Errorf("AddTimeFieldWithRange() = %v, want %v", got, tt.want)
-			}
-		})
+	f(o)
+
+	// simple expression
+	o = opts{
+		expr: "*",
+		timeRange: backend.TimeRange{
+			From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
+		},
+		want: "_time:[1732320000, 1732492800] *",
 	}
+	f(o)
+
+	// simple range
+	o = opts{
+		expr: "_time:[1732320000, 1732492800]",
+		timeRange: backend.TimeRange{
+			From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
+		},
+		want: "_time:[1732320000, 1732492800]",
+	}
+	f(o)
+
+	// simple stats request no time field
+	o = opts{
+		expr: "* | stats count()",
+		timeRange: backend.TimeRange{
+			From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
+		},
+		want: "_time:[1732320000, 1732492800] * | stats count()",
+	}
+	f(o)
+
+	// simple stats request with time field
+	o = opts{
+		expr: "_time:1s | stats count()",
+		timeRange: backend.TimeRange{
+			From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
+		},
+		want: "_time:1s | stats count()",
+	}
+	f(o)
+
+	// time field after the first pipe
+	o = opts{
+		expr: "host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:1s, host) count() logs",
+		timeRange: backend.TimeRange{
+			From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
+		},
+		want: "_time:[1732320000, 1732492800] host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:1s, host) count() logs",
+	}
+	f(o)
+
+	// time field present in the first part of the expression
+	o = opts{
+		expr: "_time:5s host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:$__range, host) count() logs",
+		timeRange: backend.TimeRange{
+			From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
+		},
+		want: "_time:5s host:~'^$host$' and compose_project:~'^$compose_project$' and compose_service:~'^$compose_service$' and $log_query  | stats by (_time:$__range, host) count() logs",
+	}
+	f(o)
+
+	// complex query with pipes and time field in stats
+	o = opts{
+		expr: `kubernetes.pod_namespace:~"vm-operator" kubernetes.pod_name:~".*" kubernetes.container_name:~".*" 
+| format if (log.level:"") "other" as log.level
+| stats by (_time:1s) count()`,
+		timeRange: backend.TimeRange{
+			From: time.Date(2024, 11, 23, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2024, 11, 25, 0, 0, 0, 0, time.UTC),
+		},
+		want: `_time:[1732320000, 1732492800] kubernetes.pod_namespace:~"vm-operator" kubernetes.pod_name:~".*" kubernetes.container_name:~".*" 
+| format if (log.level:"") "other" as log.level
+| stats by (_time:1s) count()`,
+	}
+	f(o)
 }

--- a/src/language_provider.ts
+++ b/src/language_provider.ts
@@ -1,5 +1,4 @@
 import { getDefaultTimeRange, LanguageProvider, TimeRange, } from '@grafana/data';
-import { BackendSrvRequest } from '@grafana/runtime';
 
 import { VictoriaLogsDatasource } from './datasource';
 import { FieldHits, FilterFieldType } from "./types";
@@ -33,17 +32,6 @@ export default class LogsQlLanguageProvider extends LanguageProvider {
 
     Object.assign(this, initialValues);
   }
-
-  request = async (url: string, defaultValue: any, params = {}, options?: Partial<BackendSrvRequest>): Promise<any> => {
-    try {
-      const res = await this.datasource.metadataRequest({ url, params, options });
-      return res.data?.values;
-    } catch (error) {
-      console.error(error);
-    }
-
-    return defaultValue;
-  };
 
   start = async (): Promise<any[]> => {
     return Promise.all([]);
@@ -85,7 +73,7 @@ export default class LogsQlLanguageProvider extends LanguageProvider {
     }
 
     try {
-      const res = await this.datasource.metadataRequest({ url, params, options: { method: 'POST' } });
+      const res = await this.datasource.postResource(url, params);
       const result = (res.data?.values || []) as FieldHits[];
       const sortedResult = sortFieldHits(result);
       this.cacheValues.set(key, sortedResult);

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,16 +42,13 @@ export enum QueryEditorMode {
   Code = 'code',
 }
 
-export interface QueryFromSchema extends DataQuery {
+export interface Query extends DataQuery {
   editorMode?: QueryEditorMode;
   expr: string;
   legendFormat?: string;
   maxLines?: number;
   step?: string;
   extraFilters?: string;
-}
-
-export interface Query extends QueryFromSchema {
   direction?: QueryDirection;
   supportingQueryType?: SupportingQueryType;
   queryType?: QueryType;

--- a/vendor/github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter/doc.go
+++ b/vendor/github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter/doc.go
@@ -1,0 +1,2 @@
+// Package httpadapter provides support for handling resource calls using an http.Handler.
+package httpadapter

--- a/vendor/github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter/handler.go
+++ b/vendor/github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter/handler.go
@@ -1,0 +1,81 @@
+package httpadapter
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+// New creates a new backend.CallResourceHandler adapter for
+// handling resource calls using an http.Handler
+func New(handler http.Handler) backend.CallResourceHandler {
+	return &httpResourceHandler{
+		handler: handler,
+	}
+}
+
+type httpResourceHandler struct {
+	handler http.Handler
+}
+
+func (h *httpResourceHandler) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	var reqBodyReader io.Reader
+	if len(req.Body) > 0 {
+		reqBodyReader = bytes.NewReader(req.Body)
+	}
+
+	// Shouldn't be needed since adapter adds this, but doesn't hurt to
+	// be on the safe side in case someone depends on this/using this in a
+	// test for example.
+	ctx = backend.WithPluginContext(ctx, req.PluginContext)
+	ctx = backend.WithUser(ctx, req.PluginContext.User)
+	reqURL, err := url.Parse(req.URL)
+	if err != nil {
+		return err
+	}
+
+	resourceURL := req.Path
+	if reqURL.RawQuery != "" {
+		resourceURL += "?" + reqURL.RawQuery
+	}
+
+	if !strings.HasPrefix(resourceURL, "/") {
+		resourceURL = "/" + resourceURL
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, resourceURL, reqBodyReader)
+	if err != nil {
+		return err
+	}
+
+	for key, values := range req.Headers {
+		httpReq.Header[key] = values
+	}
+
+	writer := newResponseWriter(sender)
+	h.handler.ServeHTTP(writer, httpReq)
+	writer.close()
+
+	return nil
+}
+
+// PluginConfigFromContext returns backend.PluginConfig from context.
+//
+// Deprecated: PluginConfigFromContext exists for historical compatibility
+// and might be removed in a future version. Please migrate to [backend.PluginConfigFromContext].
+func PluginConfigFromContext(ctx context.Context) backend.PluginContext {
+	return backend.PluginConfigFromContext(ctx)
+}
+
+// UserFromContext returns backend.User from context.
+//
+// Deprecated: UserFromContext exists for historical compatibility
+// and might be removed in a future version. Please migrate to [backend.UserFromContext].
+func UserFromContext(ctx context.Context) *backend.User {
+	return backend.UserFromContext(ctx)
+}

--- a/vendor/github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter/response_writer.go
+++ b/vendor/github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter/response_writer.go
@@ -1,0 +1,158 @@
+package httpadapter
+
+import (
+	"bytes"
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+// callResourceResponseWriter is an implementation of http.ResponseWriter that
+// writes a backend.CallResourceResponse as Result().
+type callResourceResponseWriter struct {
+	stream backend.CallResourceResponseSender
+
+	// Code is the HTTP response code set by WriteHeader.
+	//
+	// Note that if a Handler never calls WriteHeader or Write,
+	// this might end up being 0, rather than the implicit
+	// http.StatusOK. To get the implicit value, use the Result
+	// method.
+	Code int
+
+	// HeaderMap contains the headers explicitly set by the Handler.
+	// It is an internal detail.
+	//
+	// Deprecated: HeaderMap exists for historical compatibility
+	// and should not be used. To access the headers returned by a handler,
+	// use the Response.Header map as returned by the Result method.
+	HeaderMap http.Header
+
+	// Body is the buffer to which the Handler's Write calls are sent.
+	// If nil, the Writes are silently discarded.
+	Body *bytes.Buffer
+
+	// Flushed is whether the Handler called Flush.
+	Flushed bool
+
+	wroteHeader     bool
+	sentFirstStream bool
+}
+
+func newResponseWriter(stream backend.CallResourceResponseSender) *callResourceResponseWriter {
+	return &callResourceResponseWriter{
+		stream:    stream,
+		HeaderMap: make(http.Header),
+		Body:      new(bytes.Buffer),
+		Code:      200,
+	}
+}
+
+// Header implements http.ResponseWriter. It returns the response
+// headers to mutate within a handler. To test the headers that were
+// written after a handler completes, use the Result method and see
+// the returned Response value's Header.
+func (rw *callResourceResponseWriter) Header() http.Header {
+	m := rw.HeaderMap
+	if m == nil {
+		m = make(http.Header)
+		rw.HeaderMap = m
+	}
+	return m
+}
+
+// writeHeader writes a header if it was not written yet and
+// detects Content-Type if needed.
+//
+// bytes or str are the beginning of the response body.
+// We pass both to avoid unnecessarily generate garbage
+// in rw.WriteString which was created for performance reasons.
+// Non-nil bytes win.
+func (rw *callResourceResponseWriter) writeHeader(b []byte, str string) {
+	if rw.wroteHeader {
+		return
+	}
+	if len(str) > 512 {
+		str = str[:512]
+	}
+
+	m := rw.Header()
+
+	_, hasType := m["Content-Type"]
+	hasTE := m.Get("Transfer-Encoding") != ""
+	if !hasType && !hasTE {
+		if b == nil {
+			b = []byte(str)
+		}
+		m.Set("Content-Type", http.DetectContentType(b))
+	}
+
+	rw.WriteHeader(200)
+}
+
+// Write implements http.ResponseWriter. The data in buf is written to
+// rw.Body, if not nil.
+func (rw *callResourceResponseWriter) Write(buf []byte) (int, error) {
+	rw.writeHeader(buf, "")
+	if rw.Body != nil {
+		rw.Body.Write(buf)
+	}
+	return len(buf), nil
+}
+
+// WriteHeader implements http.ResponseWriter.
+func (rw *callResourceResponseWriter) WriteHeader(code int) {
+	if rw.wroteHeader {
+		return
+	}
+	rw.Code = code
+	rw.wroteHeader = true
+	if rw.HeaderMap == nil {
+		rw.HeaderMap = make(http.Header)
+	}
+}
+
+// Flush implements http.Flusher.
+func (rw *callResourceResponseWriter) Flush() {
+	if !rw.wroteHeader {
+		rw.WriteHeader(200)
+	}
+
+	resp := rw.getResponse()
+	if resp != nil {
+		if err := rw.stream.Send(resp); err != nil {
+			log.DefaultLogger.Error("Failed to send resource response", "error", err)
+		}
+	}
+
+	rw.Body = new(bytes.Buffer)
+}
+
+func (rw *callResourceResponseWriter) getResponse() *backend.CallResourceResponse {
+	if !rw.sentFirstStream {
+		res := &backend.CallResourceResponse{
+			Status:  rw.Code,
+			Headers: rw.Header().Clone(),
+		}
+
+		if rw.Body != nil {
+			res.Body = rw.Body.Bytes()
+		}
+
+		rw.sentFirstStream = true
+		return res
+	}
+
+	if rw.Body != nil && rw.Body.Len() > 0 {
+		return &backend.CallResourceResponse{
+			Body: rw.Body.Bytes(),
+		}
+	}
+
+	return nil
+}
+
+func (rw *callResourceResponseWriter) close() {
+	rw.Flush()
+}

--- a/vendor/gopkg.in/yaml.v3/yaml.go
+++ b/vendor/gopkg.in/yaml.v3/yaml.go
@@ -587,7 +587,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					ftype = ftype.Elem()
 				}
 				if ftype.Kind() != reflect.Struct {
-					return nil, errors.New("option ,inline may only be used on a struct or map field")
+					return nil, fmt.Errorf("option ,inline may only be used on a struct or map field: %+v", ftype.Kind())
 				}
 				if reflect.PtrTo(ftype).Implements(unmarshalerType) {
 					inlineUnmarshalers = append(inlineUnmarshalers, []int{i})
@@ -615,7 +615,7 @@ func getStructInfo(st reflect.Type) (*structInfo, error) {
 					}
 				}
 			default:
-				return nil, errors.New("option ,inline may only be used on a struct or map field")
+				return nil, fmt.Errorf("option ,inline may only be used on a struct or map field: %+v", field.Type.Kind())
 			}
 			continue
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -128,6 +128,7 @@ github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt
 github.com/grafana/grafana-plugin-sdk-go/backend/internal/endpointctx
 github.com/grafana/grafana-plugin-sdk-go/backend/log
 github.com/grafana/grafana-plugin-sdk-go/backend/proxy
+github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter
 github.com/grafana/grafana-plugin-sdk-go/backend/tracing
 github.com/grafana/grafana-plugin-sdk-go/backend/useragent
 github.com/grafana/grafana-plugin-sdk-go/build

--- a/yarn.lock
+++ b/yarn.lock
@@ -4223,6 +4223,11 @@ eslint-plugin-react@^7.37.4:
     string.prototype.matchall "^4.0.12"
     string.prototype.repeat "^1.0.0"
 
+eslint-plugin-unused-imports@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz#62ddc7446ccbf9aa7b6f1f0b00a980423cda2738"
+  integrity sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
- rewrote tests to f-tests
- upgrade golangci-lint
- fixed ability to export dashboards publicly
- fixed constantly appearing client timeout errors on a plugin backend in a live tailing mode with a separate client, that has no timeout
- added unused imports eslinter
- removed usage of deprecated plugin endpoints `/api/datasources/proxy/*`