### PR TITLE
fix issue when in log message no `_msg` field, no `_time` field and `_stream` is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue with missing `_msg`, `_time` fields in the response and when `_stream` field is empty. See [#560](https://github.com/VictoriaMetrics/VictoriaLogs/issues/560) 
+
 ## v0.19.2
 
 * BUGFIX: fix regression of the plugin that cause the plugin to not work with `field_values` and `field_names` queries. Fix comments after the plugin verification procedure.

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -32,6 +32,8 @@ const (
 	logsVisualisation = "logs"
 )
 
+var nowFunc = time.Now
+
 // parseStreamResponse reads data from the reader and collects
 // fields and frame with necessary information
 func parseInstantResponse(reader io.Reader) backend.DataResponse {
@@ -99,6 +101,9 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 			if !value.Exists(messageField) && len(stf) > 0 {
 				lineField.Append("")
 			}
+			if !value.Exists(timeField) && !value.Exists(messageField) && len(stf) == 0 {
+				lineField.Append("")
+			}
 		}
 
 		obj, err := value.Object()
@@ -133,7 +138,7 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 
 	// Grafana expects time field to be always non-empty.
 	if timeFd.Len() == 0 {
-		now := time.Now()
+		now := nowFunc()
 		for i := 0; i < lineField.Len(); i++ {
 			timeFd.Append(now)
 		}
@@ -247,7 +252,7 @@ func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
 
 		// Grafana expects time field to be always non-empty.
 		if timeFd.Len() == 0 {
-			now := time.Now()
+			now := nowFunc()
 			for i := 0; i < lineField.Len(); i++ {
 				timeFd.Append(now)
 			}

--- a/pkg/plugin/test-data/no_message_and_time_field_one_stream_is_empty
+++ b/pkg/plugin/test-data/no_message_and_time_field_one_stream_is_empty
@@ -1,0 +1,3 @@
+{"logs": "69275","_stream": "{az_id=\"use1-az2\",source=\"vector\",vpc_id=\"vpc\"}"}
+{"logs": "5022","_stream": "{namespace=\"ops-monitoring-ns\"}"}
+{"logs": "194","_stream": "{}"}


### PR DESCRIPTION
Fixed the situation when in the logs message `_msg`, `_time` fields are missing in the response, and when `_stream` field is empty. In that case time field and the line field in the Frame response do not equal the labels field elements that cause the error described in the issue.

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/355