### PR TITLE
propagate `AccountID` and `ProjectID` headers for the `field_values` and `field_names` API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: fix an issue with missing `_msg`, `_time` fields in the response and when `_stream` field is empty. See [#560](https://github.com/VictoriaMetrics/VictoriaLogs/issues/560) 
+* BUGFIX: fix an issue with the propagating `AccountID` and `ProjectID` headers in the datasource for the `field_values` and `field_names` API calls. See [#354](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/354).
 
 ## v0.19.2
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -509,6 +509,7 @@ func (d *Datasource) VLAPIQuery(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	newReq.Header = di.grafanaSettings.CustomHeaders.Clone()
 	resp, err := di.httpClient.Do(newReq)
 	if err != nil {
 		if !isTrivialError(err) {


### PR DESCRIPTION
If the user sets up `AccountID` and `ProjectID` in the data source settings, those fields should be correctly set as headers in the request for the `field_value` and `field_names` API calls.

The correct headers with this fix:
 
<img width="448" height="669" alt="Screenshot 2025-08-13 at 11 28 03" src="https://github.com/user-attachments/assets/6f4a16ec-8a61-4068-b4f5-49b2d0d29057" />

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/354
