### PR TITLE
feat: Ad hoc filters support multi-value operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * FEATURE: upgrade Go builder from Go1.24.2 to Go1.25. See [Go1.25 release notes](https://tip.golang.org/doc/go1.25).
+* FEATURE: add support for multi-value operators (`one of`, `not one of`) in Ad hoc filters (available since Grafana 11.3.x). See [#293](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/293).
 
 * BUGFIX: fix log level coloring when no custom rules are configured. See [#347](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/347).
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -163,7 +163,7 @@ export class VictoriaLogsDatasource
 
     if ((isFilterFor && !hasFilter) || isFilterOut) {
       const operator = isFilterFor ? '=' : '!=';
-      expression = addLabelToQuery(expression, filter.options.key, value, operator);
+      expression = addLabelToQuery(expression, { key: filter.options.key, value, operator });
     }
 
     return { ...query, expr: expression };
@@ -199,8 +199,8 @@ export class VictoriaLogsDatasource
       return;
     }
 
-    const expr = adhocFilters.reduce((acc: string, { key, operator, value }: AdHocVariableFilter) => {
-      return addLabelToQuery(acc, key, value, operator);
+    const expr = adhocFilters.reduce((acc: string, filter: AdHocVariableFilter) => {
+      return addLabelToQuery(acc, filter);
     }, '');
 
     return returnVariables(expr);
@@ -440,7 +440,7 @@ export class VictoriaLogsDatasource
       streamId = transformedLabels[LABEL_STREAM_ID];
     }
 
-    return addLabelToQuery('', LABEL_STREAM_ID, streamId, '');
+    return addLabelToQuery('', { key: LABEL_STREAM_ID, value: streamId, operator: '' });
   };
 
   private makeLogContextDataRequest = (row: LogRowModel, options?: LogRowContextOptions): DataQueryRequest<Query> => {

--- a/src/modifyQuery.test.ts
+++ b/src/modifyQuery.test.ts
@@ -7,7 +7,7 @@ describe('modifyQuery', () => {
       const key = 'baz';
       const value = 'qux';
       const operator = '=';
-      const result = addLabelToQuery(query, key, value, operator);
+      const result = addLabelToQuery(query, { key, value, operator });
       expect(result).toBe('foo: bar AND baz:="qux"');
     });
 
@@ -16,7 +16,7 @@ describe('modifyQuery', () => {
       const key = 'baz';
       const value = 'qux';
       const operator = '=';
-      const result = addLabelToQuery(query, key, value, operator);
+      const result = addLabelToQuery(query, { key, value, operator });
       expect(result).toBe('foo: bar AND baz:="qux" | pipe1 | pipe2');
     });
 
@@ -24,16 +24,28 @@ describe('modifyQuery', () => {
       const query = 'foo: bar | pipe1 | pipe2';
       const key = '_stream';
       const value = '{event: "test"}';
-      expect(addLabelToQuery(query, key, value, '=')).toBe('foo: bar AND _stream:{event: "test"} | pipe1 | pipe2');
-      expect(addLabelToQuery(query, key, value, '!=')).toBe('foo: bar AND (! _stream: {event: "test"}) | pipe1 | pipe2');
+      expect(addLabelToQuery(query, { key, value, operator: '=' })).toBe('foo: bar AND _stream:{event: "test"} | pipe1 | pipe2');
+      expect(addLabelToQuery(query, { key, value, operator: '!=' })).toBe('foo: bar AND (! _stream: {event: "test"}) | pipe1 | pipe2');
     });
 
     it('should add ":" "!:" for _stream_id key', () => {
       const query = 'foo: bar | pipe1 | pipe2';
       const key = '_stream_id';
       const value = 'stream123';
-      expect(addLabelToQuery(query, key, value, '=')).toBe('foo: bar AND _stream_id:stream123 | pipe1 | pipe2');
-      expect(addLabelToQuery(query, key, value, '!=')).toBe('foo: bar AND (! _stream_id: stream123) | pipe1 | pipe2');
+      expect(addLabelToQuery(query, { key, value, operator: '=' })).toBe('foo: bar AND _stream_id:stream123 | pipe1 | pipe2');
+      expect(addLabelToQuery(query, { key, value, operator: '!=' })).toBe('foo: bar AND (! _stream_id: stream123) | pipe1 | pipe2');
+    });
+
+    it('should add "=|" group', () => {
+      const query = 'foo: bar';
+      const result = addLabelToQuery(query, { key: 'baz', value: '', values: ['qux', 'quux'], operator: '=|' });
+      expect(result).toBe('foo: bar AND baz:in("qux","quux")');
+    });
+
+    it('should add "!=|" group', () => {
+      const query = 'foo: bar';
+      const result = addLabelToQuery(query, { key: 'baz', value: '', values: ['qux', 'quux'], operator: '!=|' });
+      expect(result).toBe('foo: bar AND !(baz:in("qux","quux"))');
     });
   });
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -9,6 +9,7 @@
   "annotations": true,
   "streaming": true,
   "backend": true,
+  "multiValueFilterOperators": true,
   "executable": "victoriametrics_logs_backend_plugin",
   "queryOptions": {
     "maxDataPoints": true


### PR DESCRIPTION
* Added `"multiValueFilterOperators": true` flag in `plugin.json` to enable `one of` (`=|`) and `not one of` (`!=|`) operators in Ad hoc filters UI - available in Grafana starting from **v11.3.x**
* Implemented query translation (expressions are passed via the `extra_filters` parameter):
  * `one of` (`=|`) → `key:in("value1", "value2", ..., "valueN")`
  * `not one of` (`!=|`) → `!(key:in("value1", "value2", ..., "valueN"))`

Related #293

> [!IMPORTANT]  
> When using a **datasource variable**, multi-value operators will **not be shown** in Ad hoc filters due to a Grafana issue (see [grafana/grafana#110465](https://github.com/grafana/grafana/issues/110465)).

<img width="507" height="363" alt="image" src="https://github.com/user-attachments/assets/f36b902c-ad0a-48a9-9f2f-cf908fd31c3c" />

