### PR TITLE
fix issue with concurrent map writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 * FEATURE: upgrade Go builder from Go1.24.2 to Go1.25. See [Go1.25 release notes](https://tip.golang.org/doc/go1.25).
 
 * BUGFIX: fix log level coloring when no custom rules are configured. See [#347](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/347).
-
 * BUGFIX: respect adhoc filters variables. See [#361](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/361)
+* BUGFIX: fix issue with concurrent map writes when performing multiple requests to the datasource. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/363)
 
 ## v0.19.3
 

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -972,4 +973,32 @@ func TestDatasource_checkAlertingRequest(t *testing.T) {
 		headers: map[string]string{"SomeOtherHeader": "true"},
 	}
 	f(o)
+}
+
+func TestDatasourceQueryDataRace(t *testing.T) {
+	ctx := context.Background()
+	ds := NewDatasource()
+	pluginCtx := backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+			URL:      "http://localhost", // Use a valid test server if needed
+			JSONData: []byte(`{"httpMethod":"POST","customQueryParameters":""}`),
+		},
+	}
+
+	var queries []backend.DataQuery
+	for i := 0; i < 20; i++ {
+		queries = append(queries, backend.DataQuery{
+			RefID:     fmt.Sprintf("A%d", i),
+			QueryType: instantQueryPath,
+			JSON:      []byte(`{"refId":"A","instant":true,"range":false,"expr":"sum(vm_http_request_total)"}`),
+		})
+	}
+
+	_, err := ds.QueryData(ctx, &backend.QueryDataRequest{
+		PluginContext: pluginCtx,
+		Queries:       queries,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }


### PR DESCRIPTION
Make a port of the fix related to the issue described [here](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/363). 

The logs datasource behaves in the same way as the metrics datasource in case to process queries