### PR TITLE
feat: add current version and changelog link to Helpful links section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * FEATURE: upgrade Go builder from Go1.24.2 to Go1.25. See [Go1.25 release notes](https://tip.golang.org/doc/go1.25).
+* FEATURE: add current version and changelog link to the Helpful links section.
 
 * BUGFIX: fix log level coloring when no custom rules are configured. See [#347](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/347).
 * BUGFIX: respect adhoc filters variables. See [#361](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/361)

--- a/src/configuration/HelpfulLinks.tsx
+++ b/src/configuration/HelpfulLinks.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-import { Stack, Text } from "@grafana/ui";
+import { usePluginContext } from "@grafana/data";
+import { Stack, Text } from '@grafana/ui';
 
 const tips = [
   {
@@ -18,24 +19,43 @@ const tips = [
   {
     title: "VictoriaMetrics",
     url: "https://victoriametrics.com/",
-  }
-]
+  },
+];
 
-export const HelpfulLinks = () => (
-  <Stack direction="column" gap={2}>
-    <div>
-      <Text variant="h4">Helpful links</Text>
-    </div>
+export const HelpfulLinks = () => {
+  const ctx = usePluginContext();
+  const version = ctx?.meta?.info?.version;
+  const changelogUrl = `https://github.com/VictoriaMetrics/victorialogs-datasource/releases/tag/v${version}`;
 
-    <div className="gf-form-group gf-form-inline markdown-html">
-      {tips.map(t => (
-        <a key={t.url} className="gf-form-label gf-form-label--dashlink"
-           href={t.url}
-           target="_blank"
-           rel="docs noreferrer">
-          {t.title}
-        </a>
-      ))}
-    </div>
-  </Stack>
-)
+  return (
+    <Stack direction="column" gap={2}>
+      <div>
+        <Text variant="h4">Helpful links</Text>
+      </div>
+
+      <div className="gf-form-group gf-form-inline markdown-html">
+        {version && (
+          <a
+            className="gf-form-label gf-form-label--dashlink"
+            href={changelogUrl}
+            target="_blank"
+            rel="docs noreferrer"
+          >
+            Release v{version}
+          </a>
+        )}
+        {tips.map((t) => (
+          <a
+            key={t.url}
+            className="gf-form-label gf-form-label--dashlink"
+            href={t.url}
+            target="_blank"
+            rel="docs noreferrer"
+          >
+            {t.title}
+          </a>
+        ))}
+      </div>
+    </Stack>
+  );
+};


### PR DESCRIPTION
add current version and changelog link to the Helpful links section.
<img width="676" height="376" alt="image" src="https://github.com/user-attachments/assets/febd577c-e6f5-488a-9dca-9330858690ba" />
