### PR TITLE
fix issue with parsing empty value from the datasource response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * BUGFIX: respect adhoc filters variables. See [#361](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/361)
 * BUGFIX: fix issue with concurrent map writes when performing multiple requests to the datasource. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/363)
 * BUGFIX: fix a parsing issue with quoted characters inside `_stream` fields. See [#365](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/365).
+* BUGFIX: fix an issue with parsing stats response when it can be empty or have empty string or `nil` as a value. See [#374](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/374).
 
 ## v0.19.3
 

--- a/pkg/plugin/test-data/stats_empty_value_in_the_response
+++ b/pkg/plugin/test-data/stats_empty_value_in_the_response
@@ -1,0 +1,1 @@
+{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"p95"},"value":[1756992432,""]}]}}

--- a/pkg/plugin/test-data/stats_nil_value_in_the_response
+++ b/pkg/plugin/test-data/stats_nil_value_in_the_response
@@ -1,0 +1,1 @@
+{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"p95"},"value":[1756992432,nil]}]}}

--- a/pkg/utils/pointer.go
+++ b/pkg/utils/pointer.go
@@ -1,0 +1,6 @@
+package utils
+
+// Ptr returns a pointer to the given value.
+func Ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/utils/pointer_test.go
+++ b/pkg/utils/pointer_test.go
@@ -1,0 +1,19 @@
+package utils
+
+import "testing"
+
+func TestPtr(t *testing.T) {
+	type T int
+
+	val := T(0)
+	pointer := Ptr(val)
+	if *pointer != val {
+		t.Errorf("expected %d, got %d", val, *pointer)
+	}
+
+	val = T(1)
+	pointer = Ptr(val)
+	if *pointer != val {
+		t.Errorf("expected %d, got %d", val, *pointer)
+	}
+}


### PR DESCRIPTION
Fixed the issue when the stats response can contain an empty string value in the response, or the datasource may return nothing in the response 
<img width="3600" height="2096" alt="image" src="https://github.com/user-attachments/assets/2459ac94-76c5-4370-8649-993b8144a023" />

nil value in the reponse
```
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"p95"},"value":[1756992432,nil]}]}}
```
empty string in the reposne

```
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"p95"},"value":[1756992432,""]}]}}
```


Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/374