### PR TITLE
fix: interpolate trace ID for internal datasource links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix internal datasource links in derived fields to properly interpolate field values instead of passing literal `${__value.raw}` strings. See [#386](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/386).
+
 ## v0.20.0
 
 * FEATURE: upgrade Go builder from Go1.24.2 to Go1.25. See [Go1.25 release notes](https://tip.golang.org/doc/go1.25).

--- a/src/getDerivedFields.ts
+++ b/src/getDerivedFields.ts
@@ -87,9 +87,10 @@ function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]):
         // Will be filled out later
         title: derivedFieldConfig.urlDisplayLabel || '',
         url: '',
-        // This is hardcoded for Jaeger or Zipkin not way right now to specify datasource specific query object
         internal: {
-          query: { query: derivedFieldConfig.url, queryType: queryType(dsSettings?.type) },
+          // For internal links, always use ${__value.raw} regardless of config
+          // derivedFieldConfig.url is meant for external URLs, not internal query objects
+          query: { query: '${__value.raw}', queryType: queryType(dsSettings?.type) },
           datasourceUid: derivedFieldConfig.datasourceUid,
           datasourceName: dsSettings?.name ?? 'Data source not found',
         },


### PR DESCRIPTION
Previously, internal links to tracing datasources (Jaeger, Zipkin, Tempo, etc.) were incorrectly using the derivedFieldConfig.url value, which is meant for external URL templates. This caused trace links to open with empty queries.

Now internal links always use `${__value.raw}` to properly interpolate the actual trace ID value from the log field, ensuring trace views open with the correct query.

Fixes #386

---

Tested and working on Grafana v12.1.1 :)