### PR TITLE
fix unpredictable behavior when determining a `Max Data Points` for a range query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * FEATURE: add run in vmui button. The VMUI URL can be configured in the datasource settings. If not specified, the datasource URL with the path `/select/vmui` will be used. See [#369](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/369).
 
+* BUGFIX: fix unpredictable behavior when determining a `Max Data Points` option for a range query. See [#393](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/393).
+
 ## v0.20.0
 
 * FEATURE: upgrade Go builder from Go1.24.2 to Go1.25. See [Go1.25 release notes](https://tip.golang.org/doc/go1.25).

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -522,88 +522,88 @@ func roundInterval(interval time.Duration) time.Duration {
 	case interval <= 10*time.Millisecond:
 		return time.Millisecond * 1 // 0.001s
 	// 0.015s
-	case interval <= 15*time.Millisecond:
+	case interval < 15*time.Millisecond:
 		return time.Millisecond * 10 // 0.01s
 	// 0.035s
-	case interval <= 35*time.Millisecond:
+	case interval < 35*time.Millisecond:
 		return time.Millisecond * 20 // 0.02s
 	// 0.075s
-	case interval <= 75*time.Millisecond:
+	case interval < 75*time.Millisecond:
 		return time.Millisecond * 50 // 0.05s
 	// 0.15s
-	case interval <= 150*time.Millisecond:
+	case interval < 150*time.Millisecond:
 		return time.Millisecond * 100 // 0.1s
 	// 0.35s
-	case interval <= 350*time.Millisecond:
+	case interval < 350*time.Millisecond:
 		return time.Millisecond * 200 // 0.2s
 	// 0.75s
-	case interval <= 750*time.Millisecond:
+	case interval < 750*time.Millisecond:
 		return time.Millisecond * 500 // 0.5s
 	// 1.5s
-	case interval <= 1500*time.Millisecond:
+	case interval < 1500*time.Millisecond:
 		return time.Millisecond * 1000 // 1s
 	// 3.5s
-	case interval <= 3500*time.Millisecond:
+	case interval < 3500*time.Millisecond:
 		return time.Millisecond * 2000 // 2s
 	// 7.5s
-	case interval <= 7500*time.Millisecond:
+	case interval < 7500*time.Millisecond:
 		return time.Millisecond * 5000 // 5s
 	// 12.5s
-	case interval <= 12500*time.Millisecond:
+	case interval < 12500*time.Millisecond:
 		return time.Millisecond * 10000 // 10s
 	// 17.5s
-	case interval <= 17500*time.Millisecond:
+	case interval < 17500*time.Millisecond:
 		return time.Millisecond * 15000 // 15s
 	// 25s
-	case interval <= 25000*time.Millisecond:
+	case interval < 25000*time.Millisecond:
 		return time.Millisecond * 20000 // 20s
 	// 45s
-	case interval <= 45000*time.Millisecond:
+	case interval < 45000*time.Millisecond:
 		return time.Millisecond * 30000 // 30s
 	// 1.5m
-	case interval <= 90000*time.Millisecond:
+	case interval < 90000*time.Millisecond:
 		return time.Millisecond * 60000 // 1m
 	// 3.5m
-	case interval <= 210000*time.Millisecond:
+	case interval < 210000*time.Millisecond:
 		return time.Millisecond * 120000 // 2m
 	// 7.5m
-	case interval <= 450000*time.Millisecond:
+	case interval < 450000*time.Millisecond:
 		return time.Millisecond * 300000 // 5m
 	// 12.5m
-	case interval <= 750000*time.Millisecond:
+	case interval < 750000*time.Millisecond:
 		return time.Millisecond * 600000 // 10m
 	// 17.5m
-	case interval <= 1050000*time.Millisecond:
+	case interval < 1050000*time.Millisecond:
 		return time.Millisecond * 900000 // 15m
 	// 25m
-	case interval <= 1500000*time.Millisecond:
+	case interval < 1500000*time.Millisecond:
 		return time.Millisecond * 1200000 // 20m
 	// 45m
-	case interval <= 2700000*time.Millisecond:
+	case interval < 2700000*time.Millisecond:
 		return time.Millisecond * 1800000 // 30m
 	// 1.5h
-	case interval <= 5400000*time.Millisecond:
+	case interval < 5400000*time.Millisecond:
 		return time.Millisecond * 3600000 // 1h
 	// 2.5h
-	case interval <= 9000000*time.Millisecond:
+	case interval < 9000000*time.Millisecond:
 		return time.Millisecond * 7200000 // 2h
 	// 4.5h
-	case interval <= 16200000*time.Millisecond:
+	case interval < 16200000*time.Millisecond:
 		return time.Millisecond * 10800000 // 3h
 	// 9h
-	case interval <= 32400000*time.Millisecond:
+	case interval < 32400000*time.Millisecond:
 		return time.Millisecond * 21600000 // 6h
 	// 24h
-	case interval <= 86400000*time.Millisecond:
+	case interval < 86400000*time.Millisecond:
 		return time.Millisecond * 43200000 // 12h
 	// 48h
-	case interval <= 172800000*time.Millisecond:
+	case interval < 172800000*time.Millisecond:
 		return time.Millisecond * 86400000 // 24h
 	// 1w
-	case interval <= 604800000*time.Millisecond:
+	case interval < 604800000*time.Millisecond:
 		return time.Millisecond * 86400000 // 24h
 	// 3w
-	case interval <= 1814400000*time.Millisecond:
+	case interval < 1814400000*time.Millisecond:
 		return time.Millisecond * 604800000 // 1w
 	// 2y
 	case interval < 3628800000*time.Millisecond:

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -678,3 +678,51 @@ func TestTryParseTimestampRFC3339Nano_Failure(t *testing.T) {
 	// invalid second
 	f("2023-01-23T23:33:ssZ")
 }
+
+func TestRoundInterval(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    time.Duration
+		expected time.Duration
+	}
+
+	cases := []testCase{
+		// Milliseconds rounding
+		{name: "Round to 1ms", input: 5 * time.Millisecond, expected: 1 * time.Millisecond},
+		{name: "Round to 10ms", input: 12 * time.Millisecond, expected: 10 * time.Millisecond},
+		{name: "Round to 20ms", input: 25 * time.Millisecond, expected: 20 * time.Millisecond},
+		{name: "Round to 50ms", input: 60 * time.Millisecond, expected: 50 * time.Millisecond},
+		{name: "Round to 100ms", input: 125 * time.Millisecond, expected: 100 * time.Millisecond},
+
+		// Seconds rounding
+		{name: "Round to 1s", input: 1*time.Second + 200*time.Millisecond, expected: 1 * time.Second},
+		{name: "Round to 2s", input: 3 * time.Second, expected: 2 * time.Second},
+		{name: "Round to 5s", input: 6 * time.Second, expected: 5 * time.Second},
+		{name: "Round to 10s", input: 12 * time.Second, expected: 10 * time.Second},
+		{name: "Round to 15s", input: 17 * time.Second, expected: 15 * time.Second},
+
+		// Minutes rounding
+		{name: "Round to 1m", input: 70 * time.Second, expected: 1 * time.Minute},
+		{name: "Round to 2m", input: 125 * time.Second, expected: 2 * time.Minute},
+		{name: "Round to 30m", input: 40 * time.Minute, expected: 30 * time.Minute},
+		{name: "Round to 1h", input: 75 * time.Minute, expected: 1 * time.Hour},
+		{name: "Round to 2h", input: 2*time.Hour + 30*time.Minute, expected: 3 * time.Hour},
+
+		// Large intervals
+		{name: "Round to 6h", input: 7 * time.Hour, expected: 6 * time.Hour},
+		{name: "Round to 12h", input: 14 * time.Hour, expected: 12 * time.Hour},
+		{name: "Round to 12h", input: 20 * time.Hour, expected: 12 * time.Hour},
+		{name: "Round to 7d", input: 8 * 24 * time.Hour, expected: 7 * 24 * time.Hour},
+		{name: "Round to 30d", input: 31 * 24 * time.Hour, expected: 30 * 24 * time.Hour},
+		{name: "Round to 1y", input: 400 * 24 * time.Hour, expected: 365 * 24 * time.Hour},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := roundInterval(tc.input)
+			if result != tc.expected {
+				t.Errorf("roundInterval(%v) = %v; want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Related issue: #393 
Fixed unpredictable behavior when determining a `Max Data Points` for a range query by updating interval comparison logic for roundInterval to use < instead of <= for consistency with [grafana logic](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/datetime/rangeutil.ts#L383)