### PR TITLE
fix error when frames not equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue with parsings of the logs lines when in the logs line empty `_stream` and missed `_msg` fields. See [#330](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/330)
+
 ## v0.21.0
 
 * FEATURE: add run in vmui button. The VMUI URL can be configured in the datasource settings. If not specified, the datasource URL with the path `/select/vmui` will be used. See [#369](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/369).

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -98,10 +98,7 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 			for _, field := range stf {
 				labels[field.Label] = field.Value
 			}
-			if !value.Exists(messageField) && len(stf) > 0 {
-				lineField.Append("")
-			}
-			if !value.Exists(timeField) && !value.Exists(messageField) && len(stf) == 0 {
+			if !value.Exists(messageField) && len(stf) >= 0 {
 				lineField.Append("")
 			}
 		}

--- a/pkg/plugin/test-data/empty_stream_with_empty_msg_field
+++ b/pkg/plugin/test-data/empty_stream_with_empty_msg_field
@@ -1,0 +1,2 @@
+{"_time":"2025-09-23T14:26:33.559652Z","_stream_id":"00000000000000000899b9a9578ea0f11a8a45c1b4cc8e34","_stream":"{kubernetes.container_name=\"frigate\",stream=\"stdout\"}","_msg":"2025-09-23 14:26:33.559569822  172.16.0.110 - - [23/Sep/2025:14:26:33 +0000] \"GET /health HTTP/1.1\" 200 10168 \"-\" \"kube-probe/1.34\" ","stream":"stdout"}
+{"_time":"2025-09-23T14:26:33.559441Z","_stream_id":"0000000000000000e934a84adb05276890d7f7bfcadabe92","_stream":"{}"}


### PR DESCRIPTION
Fixed the corner case for the logs response when `_stream` field is empty and there are no `_msg` field. But previous logs line contains both.
Improved tests, removed the approach when tests hide the error, like 
```
frame has different field lengths, field 0 is len 59 but field 1 is len 58
```

This fix was come from the [comment](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/330#issuecomment-3324201182) in the [issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/330) 