### PR TITLE
update permission validation in PR workflow to use repository collaborator access levels

### DIFF
--- a/.github/workflows/pr-test-build.yaml
+++ b/.github/workflows/pr-test-build.yaml
@@ -22,28 +22,27 @@ jobs:
       pr-repo: ${{ steps.pr.outputs.repo }}
       pr-is-fork: ${{ steps.pr.outputs.is-fork }}
     steps:
-      - name: Check if user is team member
+      - name: Check if user has write access
         id: check
         uses: actions/github-script@v7
         with:
           script: |
             const actor = context.actor;
-            const org = context.repo.owner;
-            const team = 'development';
             
-            console.log(`🔍 Checking if ${actor} is member of ${org}/${team}`);
+            console.log(`🔍 Checking if ${actor} has write access`);
             
             try {
-              const { data: membership } = await github.rest.teams.getMembershipForUserInOrg({
-                org: org,
-                team_slug: team,
+              const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
                 username: actor
               });
-            
-              const isAuthorized = membership.state === 'active';
-              console.log(`✅ User ${actor} membership status: ${membership.state}`);
+              
+              // Check if user has write, maintain, or admin permissions
+              const isAuthorized = ['write', 'maintain', 'admin'].includes(permission.permission);
+              console.log(`User ${actor} permission level: ${permission.permission}`);
               core.setOutput('authorized', isAuthorized);
-            
+              
               if (!isAuthorized) {
                 await github.rest.reactions.createForIssueComment({
                   owner: context.repo.owner,
@@ -51,12 +50,12 @@ jobs:
                   comment_id: context.payload.comment.id,
                   content: 'confused'
                 });
-            
+              
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.issue.number,
-                  body: `❌ @${actor} You don't have permission to trigger builds.\n\nOnly members of the \`${org}/${team}\` team can use the \`/build\` command.`
+                  body: `❌ @${actor} You don't have permission to trigger builds.\n\nOnly repository collaborators with write access can use the \`/build\` command.`
                 });
               } else {
                 await github.rest.reactions.createForIssueComment({
@@ -67,27 +66,15 @@ jobs:
                 });
               }
             } catch (error) {
-              if (error.status === 404) {
-                console.log(`❌ User ${actor} is not a member of team ${org}/${team}`);
-                core.setOutput('authorized', false);
-            
-                await github.rest.reactions.createForIssueComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: context.payload.comment.id,
-                  content: 'confused'
-                });
-            
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: `❌ @${actor} You don't have permission to trigger builds.\n\nOnly members of the \`${org}/${team}\` team can use the \`/build\` command.`
-                });
-              } else {
-                console.error(`Error checking team membership: ${error.message}`);
-                core.setFailed(`Failed to check team membership: ${error.message}`);
-              }
+              console.error(`Error checking permissions: ${error.message}`);
+              core.setOutput('authorized', false);
+              
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'confused'
+              });
             }
 
       - name: Get PR details


### PR DESCRIPTION
Changed checking access by checking development team to collaborators of repository cause in this case is not need to provide extra tokens