### PR TITLE
add support for `extra_stream_filters` in `Custom query parameters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix setting `extra_stream_filters` param to `Custom query parameters`. See [this comment](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/405#issuecomment-3420418177).
+
 ## v0.21.1
 
 * BUGFIX: fix an issue with parsings of the logs lines when in the logs line empty `_stream` and missed `_msg` fields. See [#330](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/330).

--- a/pkg/plugin/fields_query.go
+++ b/pkg/plugin/fields_query.go
@@ -8,12 +8,13 @@ import (
 )
 
 type FieldsQuery struct {
-	Query        string `json:"query"`
-	Limit        string `json:"limit"`
-	Start        string `json:"start"`
-	End          string `json:"end"`
-	Field        string `json:"field"`
-	ExtraFilters string `json:"extra_filters"`
+	Query              string `json:"query"`
+	Limit              string `json:"limit"`
+	Start              string `json:"start"`
+	End                string `json:"end"`
+	Field              string `json:"field"`
+	ExtraFilters       string `json:"extra_filters"`
+	ExtraStreamFilters string `json:"extra_stream_filters"`
 }
 
 // getFieldsQueryFromRaw parses the field values query json from the raw message.
@@ -44,6 +45,9 @@ func (fv *FieldsQuery) queryParams() url.Values {
 	}
 	if fv.ExtraFilters != "" {
 		params.Set("extra_filters", fv.ExtraFilters)
+	}
+	if fv.ExtraStreamFilters != "" {
+		params.Set("extra_stream_filters", fv.ExtraStreamFilters)
 	}
 	return params
 }


### PR DESCRIPTION
Related issue: [issue #405 comment](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/405#issuecomment-3420418177)
Fixed an issue of providing `extra_stream_filters` to `Custom query parameters` datasource settings.