### PR TITLE
fix the issue of overwriting the `level` label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * BUGFIX: fix setting `extra_stream_filters` param to `Custom query parameters`. See [this comment](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/405#issuecomment-3420418177).
 * BUGFIX: add `sort by (_time) asc/desc` pipe if logs are sorted in asc/desc order. In versions of grafana below `12.x.x`, you need to manually run the query if the sorting has been changed. See [#379](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/379).
+* fix the issue of overwriting the `level` label. Set the calculated level into a `detected_level` label, which is supported only in Grafana version 11.0.8 and above.
 
 ## v0.21.1
 

--- a/src/configuration/LogLevelRules/utils.ts
+++ b/src/configuration/LogLevelRules/utils.ts
@@ -13,7 +13,7 @@ export const extractLevelFromLabels = (labels: Labels, rules: LogLevelRule[]): L
   const levelByLabel = hasInfoLabel ? labels['level'].toLowerCase() as LogLevel : null
   const levelByRule = rules.length ? resolveLogLevel(labels, rules) : null
 
-  return levelByRule || levelByLabel || LogLevel.unknown;
+  return levelByLabel || levelByRule || LogLevel.unknown;
 }
 
 const resolveLogLevel = (log: Record<string, any>, rules: LogLevelRule[]) => {


### PR DESCRIPTION
Related issue: #425 
Fixed the issue of overwriting the `level` label. Set the calculated level into a `detected_level` label to save original `level` label to avoid confusion. It is supported only in Grafana version `11.0.8` and above.