### PR TITLE
update bug report template to improve playground link formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,9 +34,9 @@ body:
   - type: textarea
     id: playground
     attributes:
-      label: Link to dashboard in Victoria Metrics [playground](https://play-grafana.victoriametrics.com)
+      label: Link to dashboard in Victoria Metrics
       description: |
-        If possible, please provide a link to a VictoriaMetrics grafana playground with minimal reproducible example.
+        If possible, please provide a link to a VictoriaMetrics [playground](https://play-grafana.victoriametrics.com) with minimal reproducible example.
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
Moved link to description because in the header it was parsed incorrectly