### PR TITLE
fix an issue where a warning was displayed when using the regexp operator not with a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue where a warning was displayed when using the regexp operator not with a variable. See [#438](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/438).
+
 ## v0.21.4
 
 * BUGFIX: fix backward compatibility with queries containing regexp variables. Error in queries with regexp variables has been replaced with a warning with quick fix action. See [#432](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/432).

--- a/src/LogsQL/regExpOperator.test.ts
+++ b/src/LogsQL/regExpOperator.test.ts
@@ -3,7 +3,22 @@ import { getQueryExprVariableRegExp, replaceRegExpOperatorToOperator } from './r
 
 describe('regExpOperator', () => {
   describe('getQueryExprVariableRegExp', () => {
-    it('should fing fieldName:~$var', () => {
+    it('should not find regexp var', () => {
+      const result = getQueryExprVariableRegExp('"fieldName":~"var.*"');
+      expect(result?.[0]).toBeUndefined();
+    });
+
+    it('should not find regexp var with spaces', () => {
+      const result = getQueryExprVariableRegExp(' "fieldName":~"var.*" ');
+      expect(result?.[0]).toBeUndefined();
+    });
+
+    it('should find fieldName:~$var with doublequotes', () => {
+      const result = getQueryExprVariableRegExp('fieldName:~"$var"');
+      expect(result?.[0]).toEqual('fieldName:~"$var"');
+    });
+
+    it('should find fieldName:~$var', () => {
       const result = getQueryExprVariableRegExp(' fieldName:~$var ');
       expect(result?.[0]).toEqual(' fieldName:~$var');
     });

--- a/src/LogsQL/regExpOperator.ts
+++ b/src/LogsQL/regExpOperator.ts
@@ -1,7 +1,7 @@
 /**
  * Regular expression for matching variables in a query expression -> filterName:~"$VariableName"
  * */
-const variableRegExpPattern = /(^|\||\s)([^\s:~]+)\s*:\s*~\s*(?:"(\$[A-Za-z0-9_.-]+)"|(\$[A-Za-z0-9_.-]+)|"([^"]+)"|([^\s|]+))(?=\s|\||$)/;
+const variableRegExpPattern = /(^|\||\s)([^\s:~]+)\s*:\s*~\s*(?:"(\$[A-Za-z0-9_.-]+)"|(\$[A-Za-z0-9_.-]+))(?=\s|\||$)/;
 
 export function getQueryExprVariableRegExp(queryExpr: string) {
   return new RegExp(variableRegExpPattern).exec(queryExpr);


### PR DESCRIPTION
Related issue: #438 
Fixed an reg exp removed the group without `$`.