### PR TITLE
add bars as the default type of visualization for explore mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: add bars as the default type of visualization for explore mode. Adjust the width of the bars to match the step size. See [#420](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/420).
+
 * BUGFIX: fix an issue where a warning was displayed when using the regexp operator not with a variable. See [#438](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/438).
 
 ## v0.21.4

--- a/src/backendResultTransformer.ts
+++ b/src/backendResultTransformer.ts
@@ -1,4 +1,3 @@
-
 import {
   DataFrame,
   DataQueryError,
@@ -8,6 +7,7 @@ import {
   FieldType,
   isDataFrame,
   QueryResultMeta,
+  DataFrameType
 } from '@grafana/data';
 
 import { LogLevelRule } from "./configuration/LogLevelRules/types";
@@ -39,10 +39,14 @@ function isMetricFrame(frame: DataFrame): boolean {
 function setFrameMeta(frame: DataFrame, meta: QueryResultMeta): DataFrame {
   const { meta: oldMeta, ...rest } = frame;
   // meta maybe be undefined, we need to handle that
-  const newMeta = { ...oldMeta, ...meta };
+  const newMeta = { ...oldMeta, ...meta, };
   return {
     ...rest,
-    meta: newMeta,
+    meta: {
+      ...newMeta,
+      typeVersion: [0, 1],
+      type: DataFrameType.TimeSeriesMulti
+    },
   };
 }
 
@@ -162,7 +166,7 @@ const generateTimestampsWithStep = (firstNotNullTimestampMs: number, startMs: nu
   }
 
   // Calculate the total number of steps from 'firstTimestamp' to 'end'
-  const totalSteps = Math.floor((endMs - firstTimestampMs)/stepMs);
+  const totalSteps = Math.floor((endMs - firstTimestampMs) / stepMs);
 
   for (let i = 0; i <= totalSteps; i++) {
     const t = firstTimestampMs + (i * stepMs);

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -21,6 +21,8 @@ import { QueryEditorHelp } from "./QueryEditorHelp";
 import { QueryEditorOptions } from "./QueryEditorOptions";
 import QueryEditorVariableRegexpError from "./QueryEditorVariableRegexpError";
 import VmuiLink from "./VmuiLink";
+import { EXPLORE_GRAPH_STYLES } from "./constants";
+import { useDefaultExploreGraph } from "./hooks/useDefaultExploreGraph";
 import { changeEditorMode, getQueryWithDefaults } from "./state";
 
 const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
@@ -29,12 +31,13 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
   const { onChange, onRunQuery, data, app, queries, datasource, range: timeRange } = props;
   const [dataIsStale, setDataIsStale] = useState(false);
   const [parseModalOpen, setParseModalOpen] = useState(false);
+  useDefaultExploreGraph(app, EXPLORE_GRAPH_STYLES.BARS);
 
   const query = getQueryWithDefaults(props.query, app, data?.request?.panelPluginId);
   const editorMode = query.editorMode!;
   const isStatsQuery = query.queryType === QueryType.Stats || query.queryType === QueryType.StatsRange;
   const showStatsWarn = isStatsQuery && !isExprHasStatsPipeFunctions(query.expr || '');
-  const  varRegExp= useMemo(() => {
+  const varRegExp = useMemo(() => {
     return getQueryExprVariableRegExp(query.expr)?.[0] || null;
   }, [query.expr]);
 

--- a/src/components/QueryEditor/constants.ts
+++ b/src/components/QueryEditor/constants.ts
@@ -1,0 +1,8 @@
+export const EXPLORE_GRAPH_STYLES = {
+  LINES: 'lines',
+  BARS: 'bars',
+  POINTS: 'points',
+  STACKED_LINES: 'stacked_lines',
+  STACKED_BARS: 'stacked_bars'
+} as const;
+export type EXPLORE_STYLE_GRAPH_STYLE = typeof EXPLORE_GRAPH_STYLES[keyof typeof EXPLORE_GRAPH_STYLES];

--- a/src/components/QueryEditor/hooks/useDefaultExploreGraph.ts
+++ b/src/components/QueryEditor/hooks/useDefaultExploreGraph.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+import { CoreApp } from "@grafana/data";
+
+import { storeKeys } from "../../../store/constants";
+import store from "../../../store/store";
+import { EXPLORE_STYLE_GRAPH_STYLE } from "../constants";
+
+export const useDefaultExploreGraph = (app: CoreApp | undefined, defaultGraph: EXPLORE_STYLE_GRAPH_STYLE) => {
+  // set default graph style for explore app
+  useEffect(() => {
+    if (app === CoreApp.Explore) {
+      const graphStyle = store.get(storeKeys.EXPLORE_STYLE_GRAPH);
+      if (!graphStyle) {
+        store.set(storeKeys.EXPLORE_STYLE_GRAPH, defaultGraph);
+      }
+    }
+  }, [app, defaultGraph]);
+}

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -58,6 +58,7 @@ import {
   ToggleFilterAction,
   VariableQuery,
 } from './types';
+import { getMillisecondsFromDuration } from "./utils/timeUtils";
 import { VariableSupport } from "./variableSupport/VariableSupport";
 
 export const REF_ID_STARTER_LOG_VOLUME = 'log-volume-';
@@ -121,16 +122,15 @@ export class VictoriaLogsDatasource
       }
     });
 
-    const fixedRequest: DataQueryRequest<Query> = {
-      ...request,
-      targets: queries,
-    };
+    // if step is defined, use it as the request interval to set the width of bars correctly
+    request.intervalMs = queries[0]?.step ? getMillisecondsFromDuration(queries[0]?.step) : request.intervalMs;
+    request.targets = queries;
 
-    if (fixedRequest.liveStreaming) {
-      return this.runLiveQueryThroughBackend(fixedRequest);
+    if (request.liveStreaming) {
+      return this.runLiveQueryThroughBackend(request);
     }
 
-    return this.runQuery(fixedRequest);
+    return this.runQuery(request);
   }
 
   runQuery(fixedRequest: DataQueryRequest<Query>) {

--- a/src/store/constants.ts
+++ b/src/store/constants.ts
@@ -1,3 +1,4 @@
 export const storeKeys = {
-  LOGS_SORT_ORDER: "grafana.explore.logs.sortOrder"
+  LOGS_SORT_ORDER: "grafana.explore.logs.sortOrder",
+  EXPLORE_STYLE_GRAPH: "grafana.explore.style.graph"
 };


### PR DESCRIPTION
Related issue: #420
Changes: 
 - add bars as the default type of visualization for explore mode;
 - adjust the width of the bars to match the step size by setting the request interval to the step size.
