### PR TITLE
fix an interpolating query with multivariables when going to the "explore" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an interpolating query with multivariables when going to the "explore" page. See [#380](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/380).
+
 ## v0.22.0
 
 * FEATURE: add bars as the default type of visualization for explore mode. Adjust the width of the bars to match the step size. See [#420](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/420).

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -226,7 +226,7 @@ export class VictoriaLogsDatasource
       expandedQueries = queries.map((query) => ({
         ...query,
         datasource: this.getRef(),
-        expr: this.templateSrv.replace(query.expr, scopedVars, this.interpolateQueryExpr),
+        expr: this.interpolateString(query.expr, scopedVars),
         interval: this.templateSrv.replace(query.interval, scopedVars),
         extraFilters: this.getExtraFilters(filters),
       }));


### PR DESCRIPTION
Related issue: #380 
Fixed an interpolating query with multivariables when going to the "explore" page.