### PR TITLE
fix an issue where an empty textbox variable was incorrectly interpolated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue where an empty textbox variable was incorrectly interpolated. See [#454](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/454).
+
 ## v0.22.1
 
 * BUGFIX: fix an interpolating query with multivariables when going to the "explore" page. See [#380](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/380).

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -210,7 +210,7 @@ export class VictoriaLogsDatasource
   }
 
   interpolateQueryExpr(value: any, _variable: any) {
-    if (typeof value === 'string') {
+    if (typeof value === 'string' && value) {
       value = [value];
     }
 


### PR DESCRIPTION
Related issue: #454 
Fixed a case with an empty textbox filter. For details, see [this comment](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/454#issuecomment-3559604602).