### PR TITLE
fix an issue where `_msg` was incorrectly parsed to `detected_level` label according to `Log Level rules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue where `_msg` was incorrectly parsed to `detected_level` label according to `Log Level rules`. See [#465](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/465).
+
 ## v0.22.2
 
 * BUGFIX: fix an issue where an empty textbox variable was incorrectly interpolated. See [#454](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/454).

--- a/src/backendResultTransformer.test.ts
+++ b/src/backendResultTransformer.test.ts
@@ -1,4 +1,3 @@
-
 import { DataQueryRequest, DataQueryResponse, dateTime, LogLevel } from "@grafana/data";
 
 import { transformBackendResult } from './backendResultTransformer';
@@ -186,9 +185,10 @@ describe('transformBackendResult', () => {
       "trace",
     ]);
   });
+
   it('should parse level according to rules, apply the origin level labels then rule labels', () => {
     const extendedLabels = labels.map((l, index) => {
-      if(index > 2) {
+      if (index > 2) {
         return {
           ...l,
           level: 'Custom unknown level'
@@ -334,6 +334,154 @@ describe('transformBackendResult', () => {
       LogLevel.critical,
       LogLevel.critical,
       LogLevel.critical,
+    ]);
+  });
+
+  it('should parse level from the _msg label according to rules', () => {
+    const extendedLabels = labels.map((l, index) => {
+      return {
+        ...l,
+        level: 'Custom unknown level'
+      }
+    });
+    const response = {
+      "data": [
+        {
+          "refId": "A",
+          "meta": {
+            "typeVersion": [
+              0,
+              0
+            ]
+          },
+          "fields": [
+            {
+              "name": "Time",
+              "type": "time",
+              "typeInfo": {
+                "frame": "time.Time"
+              },
+              "config": {},
+              "values": [
+                1760598702731,
+                1760598701836,
+                1760598700825,
+                1760598697696,
+                1760598697034,
+                1760598696367,
+              ],
+              "entities": {},
+              "nanos": [
+                713000,
+                524000,
+                282000,
+                74000,
+                506000,
+                620000,
+              ]
+            },
+            {
+              "name": "Line",
+              "type": "string",
+              "typeInfo": {
+                "frame": "string"
+              },
+              "config": {},
+              "values": [
+                "critical error",
+                "starting application",
+                "starting application",
+                "starting application",
+                "starting application",
+                "starting application",
+              ],
+              "entities": {}
+            },
+            {
+              "name": "labels",
+              "type": "other",
+              "typeInfo": {
+                "frame": "json.RawMessage"
+              },
+              "config": {},
+              "values": extendedLabels,
+              "entities": {}
+            }
+          ],
+          "length": 6
+        }
+      ],
+      "state": "Done"
+    } as DataQueryResponse;
+    const request = {
+      "app": "dashboard",
+      "requestId": "SQR100",
+      "timezone": "browser",
+      "range": {
+        "to": "2025-10-16T07:28:02.475Z",
+        "from": "2025-10-16T01:28:02.475Z",
+        "raw": {
+          "from": "now-6h",
+          "to": "now"
+        }
+      },
+      "interval": "20s",
+      "intervalMs": 20000,
+      "targets": [
+        {
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "bexw8wod6s4jke"
+          },
+          "editorMode": "code",
+          "expr": "*",
+          "queryType": "instant",
+          "refId": "A",
+          "maxLines": 1000
+        }
+      ],
+      "maxDataPoints": 913,
+      "scopedVars": {
+        "__sceneObject": {
+          "text": "__sceneObject"
+        },
+        "__interval": {
+          "text": "20s",
+          "value": "20s"
+        },
+        "__interval_ms": {
+          "text": "20000",
+          "value": 20000
+        }
+      },
+      "startTime": 1760599682628,
+      "rangeRaw": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "dashboardUID": "886b7b9f-97a7-47ee-93b6-9ec7342f6d3e",
+      "panelId": 1,
+      "panelName": "New panel",
+      "panelPluginId": "table",
+      "dashboardTitle": "double label info"
+    } as unknown as DataQueryRequest<Query>;
+    const derivedFieldConfigs: DerivedFieldConfig[] = [];
+    const logLevelRules: LogLevelRule[] = [{
+      enabled: true,
+      field: '_msg',
+      operator: LogLevelRuleType.Regex,
+      value: 'critical',
+      level: LogLevel.critical
+    }];
+    const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules);
+    expect(result.data[0].fields[2].values).toStrictEqual(extendedLabels);
+    expect(result.data[0].fields[3].values).toStrictEqual([
+      LogLevel.critical,
+      LogLevel.unknown,
+      LogLevel.unknown,
+      LogLevel.unknown,
+      LogLevel.unknown,
+      LogLevel.unknown,
     ]);
   });
 


### PR DESCRIPTION
Related issue: #465 
Fixed an issue where `_msg` was incorrectly parsed to `detected_level` label according to `Log Level rules`. Added `_msg` from `Lines` field to `labels` object during the detection of the level.