### PR TITLE
fix an issue where the `Logs panel` shows an empty view when infinite scrolling at the bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: fix an issue where `_msg` was incorrectly parsed to `detected_level` label according to `Log Level rules`. See [#465](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/465).
+* BUGFIX: fix an issue where the `Logs panel` shows an empty view when infinite scrolling at the bottom. See [#466](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/466).
 
 ## v0.22.2
 

--- a/src/backendResultTransformer.ts
+++ b/src/backendResultTransformer.ts
@@ -1,6 +1,5 @@
 import {
-  DataFrame,
-  DataFrameType,
+  DataFrame, DataFrameType,
   DataQueryError,
   DataQueryRequest,
   DataQueryResponse,
@@ -46,7 +45,6 @@ function setFrameMeta(frame: DataFrame, meta: QueryResultMeta): DataFrame {
     meta: {
       ...newMeta,
       typeVersion: [0, 1],
-      type: DataFrameType.TimeSeriesMulti
     },
   };
 }
@@ -135,7 +133,7 @@ function processStreamFrame(
   const frameWithLevel = addLevelField(frameWithMeta, logLevelRules);
 
   const derivedFields = getDerivedFields(frameWithLevel, derivedFieldConfigs);
-  const baseFields = getStreamFields(frameWithLevel.fields, transformLabels)
+  const baseFields = getStreamFields(frameWithLevel.fields, transformLabels);
 
   return {
     ...frameWithLevel,
@@ -211,7 +209,7 @@ function getQueryMap(queries: Query[]) {
 }
 
 function processMetricRangeFrames(frames: DataFrame[], queries: Query[], startTime: number, endTime: number): DataFrame[] {
-  const meta: QueryResultMeta = { preferredVisualisationType: 'graph' };
+  const meta: QueryResultMeta = { preferredVisualisationType: 'graph', type: DataFrameType.TimeSeriesMulti };
   const queryMap = getQueryMap(queries);
 
   return frames.map((frame) => {


### PR DESCRIPTION
Related issue: #466 
Fixed bug by removing `type` from meta, because Grafana incorrectly processed it in the function [getFrameKey](https://github.com/grafana/grafana/blob/c0f6d90971bb7fa4f2bc0c77a8339d199ca39306/public/app/plugins/datasource/loki/mergeResponses.ts#L19).