### PR TITLE
fix an issue where the `Internal link` from derived fields config was disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix an issue where the `Internal link` from derived fields config was disabled. See [#479](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/479).
+
 ## v0.22.3
 
 * BUGFIX: fix an issue where `_msg` was incorrectly parsed to `detected_level` label according to `Log Level rules`. See [#465](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/465).

--- a/src/configuration/DerivedField.tsx
+++ b/src/configuration/DerivedField.tsx
@@ -161,7 +161,7 @@ export const DerivedField = (props: Props) => {
       <div className="gf-form">
         <Field label="Internal link" className={styles.internalLink}>
           <Switch
-            value={isVisibleInternalLink}
+            value={showInternalLink}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const { checked } = e.currentTarget;
               if (!checked) {
@@ -175,7 +175,7 @@ export const DerivedField = (props: Props) => {
           />
         </Field>
 
-        {isVisibleInternalLink && (
+        {showInternalLink && (
           <Field label="" className={styles.dataSource}>
             <DataSourcePicker
               tracing={true}


### PR DESCRIPTION
Related issue: #479 
Fixed an issue where the `Internal link` from derived fields config was disabled.