### PR TITLE
fix an issue where the `show context` failed if disable labels with transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: fix an issue where the `Internal link` from derived fields config was disabled. See [#479](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/479).
+* BUGFIX: fix an issue where the `show context` failed if disable labels with transformations. See [#480](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/480).
 
 ## v0.22.3
 

--- a/src/backendResultTransformer.ts
+++ b/src/backendResultTransformer.ts
@@ -71,6 +71,14 @@ function addLevelField(frame: DataFrame, rules: LogLevelRule[]): DataFrame {
   return { ...frame, fields: [...frame.fields, levelField] };
 }
 
+function getStreamIds(frame: DataFrame) {
+  const labelsField = frame.fields.find(f => f.name === FrameField.Labels);
+  if (!labelsField) {
+    return [];
+  }
+  return labelsField?.values.map(labels => labels._stream_id);
+}
+
 function transformDashboardLabelField(field: Field): Field {
   if (field.name !== FrameField.Labels) {
     return field;
@@ -126,7 +134,11 @@ function processStreamFrame(
     preferredVisualisationType: 'logs',
     limit: query?.maxLines,
     searchWords: query !== undefined ? getHighlighterExpressionsFromQuery(query.expr) : undefined,
-    custom,
+    custom: {
+      ...custom,
+      // if the user decides to hide labels via transforms so that we can get the streamId for `Log context`
+      streamIds: getStreamIds(frame),
+    },
   };
 
   const frameWithMeta = setFrameMeta(frame, meta);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -457,11 +457,15 @@ export class VictoriaLogsDatasource
 
   private prepareLogContextQueryExpr = (row: LogRowModel): string => {
     let streamId = "";
+    const streamIds = row.dataFrame.meta?.custom?.streamIds;
+    if (streamIds && streamIds.length > 0) {
+      streamId = streamIds[row.rowIndex];
+    }
 
-    if (row.labels[LABEL_STREAM_ID]) {
+    if (!streamId && row.labels[LABEL_STREAM_ID]) {
       // Explore View
       streamId = row.labels[LABEL_STREAM_ID]
-    } else {
+    } else if (!streamId) {
       // Dashboard View
       const transformedLabels: Labels = {};
       Object.values(row.labels).forEach((label) => {


### PR DESCRIPTION
Related issue: #480
If users hide labels with tranformations, in this case we cannot get `streamId` from labels. So added extra `streamIds` field to `meta.custom`.