### PR TITLE
add tenant information as a query parameter to `url` in `Run in vmui`button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * BUGFIX: fix an issue where the `Internal link` from derived fields config was disabled. See [#479](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/479).
 * BUGFIX: fix an issue where the `show context` failed if disable labels with transformations. See [#480](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/480).
+* BUGFIX: add tenant information as a query parameter to `url` in `Run in vmui` button. See [#480](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/480).
 
 ## v0.22.3
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -618,10 +618,21 @@ func (d *Datasource) VMUIQuery(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	accountID := di.grafanaSettings.MultitenancyHeaders["AccountID"]
+	if accountID == "" {
+		accountID = "0"
+	}
+
+	projectID := di.grafanaSettings.MultitenancyHeaders["ProjectID"]
+	if projectID == "" {
+		projectID = "0"
+	}
+
 	rw.Header().Add("Content-Type", "application/json")
 	rw.WriteHeader(http.StatusOK)
 
-	if _, err := fmt.Fprintf(rw, `{"vmuiURL": %q}`, vmuiUrl); err != nil {
+	if _, err := fmt.Fprintf(rw, `{"vmuiURL": %q, "accountID": %q, "projectID": %q}`,
+		vmuiUrl, accountID, projectID); err != nil {
 		d.logger.Warn("Error writing response", "error", err)
 	}
 }


### PR DESCRIPTION
Related issue: #464 
Added tenant information as a query parameter to `url` in `Run in vmui`button.