### PR TITLE
add a default query expression `*` in Explore mode when none is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * FEATURE: enable client side caching and make reliable behavior in QueryBuilder filters. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/357).
 * FEATURE: add compatibility with Grafana 10.x and 11.x by using dynamic component loading for Combobox.
 * FEATURE: add quick level filter, which allows filtering logs by level according to `Log Level Rules` and the base level field. It is the first part of the [issue #108](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/108). See [pr #495](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/495).
+* FEATURE: add a default query expression `*` in Explore mode when none is provided. See [#483](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/483).
 
 ## v0.22.4
 

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -22,7 +22,7 @@ import { QueryEditorHelp } from "./QueryEditorHelp";
 import { QueryEditorOptions } from "./QueryEditorOptions";
 import QueryEditorVariableRegexpError from "./QueryEditorVariableRegexpError";
 import VmuiLink from "./VmuiLink";
-import { EXPLORE_GRAPH_STYLES } from "./constants";
+import { DEFAULT_QUERY_EXPR, EXPLORE_GRAPH_STYLES } from "./constants";
 import { useDefaultExploreGraph } from "./hooks/useDefaultExploreGraph";
 import { changeEditorMode, getQueryWithDefaults } from "./state";
 
@@ -76,6 +76,13 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
     }
   }, [onRunQuery]);
 
+  useEffect(() => {
+    if (!query.expr && app === CoreApp.Explore) {
+      onChange({ ...query, expr: DEFAULT_QUERY_EXPR });
+      onRunQuery();
+    }
+  }, []);
+
   return (
     <>
       <ConfirmModal
@@ -93,7 +100,7 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
         <EditorHeader>
           {app === CoreApp.Explore &&
             <LevelQueryFilter logLevelRules={datasource.logLevelRules} query={query} onChange={onChange}/>}
-          <Stack direction={"row"} justifyContent={"flex-end"} alignItems={"center"} >
+          <Stack direction={"row"} justifyContent={"flex-end"} alignItems={"center"}>
             {showStatsWarn && (<QueryEditorStatsWarn queryType={query.queryType}/>)}
             <QueryEditorHelp/>
             <VmuiLink

--- a/src/components/QueryEditor/constants.ts
+++ b/src/components/QueryEditor/constants.ts
@@ -6,3 +6,5 @@ export const EXPLORE_GRAPH_STYLES = {
   STACKED_BARS: 'stacked_bars'
 } as const;
 export type EXPLORE_STYLE_GRAPH_STYLE = typeof EXPLORE_GRAPH_STYLES[keyof typeof EXPLORE_GRAPH_STYLES];
+
+export const DEFAULT_QUERY_EXPR = '*';


### PR DESCRIPTION
Related issue: #483 

### Describe Your Changes

Added a default query expression `*` in Explore mode when none is provided. So users can start filter their log using + and - filters from the logs view.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
