### PR TITLE
fix the loading of tenant IDs when creating a new datasource from scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix the loading of tenant IDs when creating a new datasource from scratch.
+
 ## v0.23.1
 
 * BUGFIX: fix a problem where the variables in the stream could be interpolated incorrectly.

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -615,6 +615,13 @@ func (d *Datasource) VLAPITenantIDs(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	if di.settings.URL == "" {
+		rw.Header().Add("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		_, err = rw.Write([]byte(`{"hint": "To use the list of possible tenants, need to set the datasource url first and save the datasource configuration"}`))
+		return
+	}
+
 	u, err := url.Parse(di.settings.URL)
 	if err != nil {
 		writeError(rw, http.StatusBadRequest, fmt.Errorf("failed to parse datasource url: %w", err))
@@ -822,7 +829,7 @@ func buildDatasourceSettings(settings backend.DataSourceInstanceSettings) (DataS
 }
 
 func setVmuiURL(settings *DataSourceInstanceSettings) error {
-	if len(settings.VMUIURL) == 0 {
+	if len(settings.VMUIURL) == 0 && settings.URL != "" {
 		vmuiUrl, err := newURL(settings.URL, "/select/vmui/", false)
 		if err != nil {
 			return fmt.Errorf("failed to build VMUI url: %w", err)

--- a/src/configuration/TenantSettings.tsx
+++ b/src/configuration/TenantSettings.tsx
@@ -28,6 +28,7 @@ export const TenantSettings = (props: PropsConfigEditor) => {
 
   const [tenants, setTenants] = useState<ComboboxOption[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [hint, setHint] = useState<string>('');
 
   const loadTenantIds = useCallback(async () => {
     // Only try to load if datasource is saved (has ID)
@@ -37,9 +38,14 @@ export const TenantSettings = (props: PropsConfigEditor) => {
     }
 
     setIsLoading(true);
+    setHint('');
     try {
       const ds = await getDataSourceSrv().get(options.uid) as VictoriaLogsDatasource;
       const tenantList = await ds.fetchTenantIds();
+      if (!Array.isArray(tenantList)) {
+        setHint(tenantList.hint);
+        return;
+      }
 
       setTenants(tenantList.map(id => ({ label: id, value: id })));
     } catch (error) {
@@ -100,9 +106,9 @@ export const TenantSettings = (props: PropsConfigEditor) => {
         <Text variant="bodySmall" color="disabled" element="p">
           Manage tenants and multitenancy settings. {documentationLink}
         </Text>
-        <Text variant="bodySmall" color="disabled" element="p">
-          If you want to use a selection of the possible tenant list, you must save the datasource configuration before using tenants.
-        </Text>
+        {hint && <Text variant="bodySmall" color="warning" element="p">
+          {hint}
+        </Text>}
       </div>
 
       <div className="gf-form-group">

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,3 +135,8 @@ export enum TenantHeaderNames {
 }
 
 export type MultitenancyHeaders = Partial<Record<TenantHeaderNames, string | undefined>>
+
+export type Tenant = {
+  account_id: string;
+  project_id: string;
+}


### PR DESCRIPTION
Related issue: #475 

### Describe Your Changes

Fixed a problem related to the error of loading tenant_ids when you create a new datasource from scratch.
<img width="787" height="705" alt="image" src="https://github.com/user-attachments/assets/0c0614f8-1887-47c9-9257-6c510b1f642c" />


Added hint for users.
<img width="691" height="189" alt="image" src="https://github.com/user-attachments/assets/5f05bfad-e49c-45e7-a81f-f9029109a7e3" />


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
