### PR TITLE
bump version to 0.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "victoriametrics-logs-datasource",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "VictoriaLogs datasource plugin for grafana",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",


### PR DESCRIPTION
### Describe Your Changes

Release v0.24.1 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Grafana plugin version to 0.24.1 to prepare and publish the v0.24.1 patch release. No functional changes; only bumps package.json from 0.24.0 to 0.24.1.

<sup>Written for commit 5a4f8047dc782a4907f9856bda7e561920c09fd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

