### PR TITLE
add "Ad-hoc filters to root query" checkbox to Query Editor options. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * FEATURE: limit the number of field values. This limit can be configured in the datasource settings. See [#543](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/543).
+* FEATURE: add "Ad-hoc filters to root query" checkbox to Query Editor options. When enabled, ad-hoc filters are applied directly to the root query expression instead of using the `extra_filters` parameter, preventing filter propagation into subqueries (join, union, etc.). See [#511](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/511).
 
 ## v0.24.1
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -100,10 +100,7 @@ describe('VictoriaLogsDatasource', () => {
         getVariables: jest.fn().mockReturnValue([]),
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
-      const replacedQuery = ds.applyTemplateVariables(
-        { expr: 'foo: $var', refId: 'A' },
-        scopedVars
-      );
+      const replacedQuery = ds.applyTemplateVariables({ expr: 'foo: $var', refId: 'A' }, scopedVars);
       expect(replacedQuery.expr).toBe('foo: $var');
     });
 
@@ -116,10 +113,7 @@ describe('VictoriaLogsDatasource', () => {
         getVariables: jest.fn().mockReturnValue([]),
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
-      const replacedQuery = ds.applyTemplateVariables(
-        { expr: 'foo: $var', refId: 'A' },
-        scopedVars
-      );
+      const replacedQuery = ds.applyTemplateVariables({ expr: 'foo: $var', refId: 'A' }, scopedVars);
       expect(replacedQuery.expr).toBe('foo: "bar"');
     });
 
@@ -133,10 +127,7 @@ describe('VictoriaLogsDatasource', () => {
         getVariables: jest.fn().mockReturnValue([]),
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
-      const replacedQuery = ds.applyTemplateVariables(
-        { expr: '_stream{val=~"$var"}', refId: 'A' },
-        scopedVars
-      );
+      const replacedQuery = ds.applyTemplateVariables({ expr: '_stream{val=~"$var"}', refId: 'A' }, scopedVars);
       expect(replacedQuery.expr).toBe('_stream{val=~"(foo|bar)"}');
     });
 
@@ -149,10 +140,7 @@ describe('VictoriaLogsDatasource', () => {
         getVariables: jest.fn().mockReturnValue([]),
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
-      const replacedQuery = ds.applyTemplateVariables(
-        { expr: 'foo: $var', refId: 'A' },
-        scopedVars
-      );
+      const replacedQuery = ds.applyTemplateVariables({ expr: 'foo: $var', refId: 'A' }, scopedVars);
       expect(replacedQuery.expr).toBe('foo: ("foo" OR "bar")');
     });
 
@@ -165,10 +153,7 @@ describe('VictoriaLogsDatasource', () => {
         getVariables: jest.fn().mockReturnValue([]),
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
-      const replacedQuery = ds.applyTemplateVariables(
-        { expr: 'foo: $var', refId: 'A' },
-        scopedVars
-      );
+      const replacedQuery = ds.applyTemplateVariables({ expr: 'foo: $var', refId: 'A' }, scopedVars);
       expect(replacedQuery.expr).toBe('foo: "0.0.0.0:3000"');
     });
 
@@ -184,10 +169,7 @@ describe('VictoriaLogsDatasource', () => {
         getVariables: jest.fn().mockReturnValue([]),
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
-      const replacedQuery = ds.applyTemplateVariables(
-        { expr: 'foo: $var', refId: 'A' },
-        scopedVars
-      );
+      const replacedQuery = ds.applyTemplateVariables({ expr: 'foo: $var', refId: 'A' }, scopedVars);
       expect(replacedQuery.expr).toBe('foo: ("http://localhost:3001/" OR "http://192.168.50.60:3000/foo")');
     });
 
@@ -200,10 +182,7 @@ describe('VictoriaLogsDatasource', () => {
         getVariables: jest.fn().mockReturnValue([]),
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
-      const replacedQuery = ds.applyTemplateVariables(
-        { expr: 'foo: $var', refId: 'A' },
-        scopedVars
-      );
+      const replacedQuery = ds.applyTemplateVariables({ expr: 'foo: $var', refId: 'A' }, scopedVars);
       expect(replacedQuery.expr).toBe('foo: ');
     });
 
@@ -217,12 +196,99 @@ describe('VictoriaLogsDatasource', () => {
         getVariables: jest.fn().mockReturnValue([]),
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
-      const replacedQuery = ds.applyTemplateVariables(
-        { expr: 'baz: $var1 AND qux: $var2', refId: 'A' },
-        scopedVars
-      );
+      const replacedQuery = ds.applyTemplateVariables({ expr: 'baz: $var1 AND qux: $var2', refId: 'A' }, scopedVars);
       expect(replacedQuery.expr).toBe('baz: "foo" AND qux: "bar"');
     });
+
+    it('should apply ad-hoc filters to root query when isApplyExtraFiltersToRootQuery is true', () => {
+      const adhocFilters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+      ];
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_time:5m', refId: 'A', isApplyExtraFiltersToRootQuery: true },
+        {},
+        adhocFilters
+      );
+      expect(replacedQuery.expr).toBe('level:="error" | _time:5m');
+      expect(replacedQuery.extraFilters).toBeUndefined();
+    });
+
+    it('should not apply ad-hoc filters to root query when isApplyExtraFiltersToRootQuery is false', () => {
+      const adhocFilters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+      ];
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_time:5m', refId: 'A', isApplyExtraFiltersToRootQuery: false },
+        {},
+        adhocFilters
+      );
+      expect(replacedQuery.expr).toBe('_time:5m');
+      expect(replacedQuery.extraFilters).toBe('level:="error"');
+    });
+
+    it('should apply multiple ad-hoc filters to root query when isApplyExtraFiltersToRootQuery is true', () => {
+      const adhocFilters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+        { key: 'app', operator: '!=', value: 'test' },
+      ];
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_time:5m', refId: 'A', isApplyExtraFiltersToRootQuery: true },
+        {},
+        adhocFilters
+      );
+      expect(replacedQuery.expr).toBe('level:="error" AND app:!="test" | _time:5m');
+      expect(replacedQuery.extraFilters).toBeUndefined();
+    });
+
+    it('should handle isApplyExtraFiltersToRootQuery when no ad-hoc filters are present', () => {
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_time:5m', refId: 'A', isApplyExtraFiltersToRootQuery: true },
+        {}
+      );
+      expect(replacedQuery.expr).toBe('_time:5m');
+      expect(replacedQuery.extraFilters).toBeUndefined();
+    });
+
+    it('should preserve existing extraFilters and apply them to root query when isApplyExtraFiltersToRootQuery is true', () => {
+      const adhocFilters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+      ];
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_time:5m', refId: 'A', extraFilters: 'app:="frontend"', isApplyExtraFiltersToRootQuery: true },
+        {},
+        adhocFilters
+      );
+      expect(replacedQuery.expr).toBe('app:="frontend" AND level:="error" | _time:5m');
+      expect(replacedQuery.extraFilters).toBeUndefined();
+    });
+
+
+
   });
 
   describe('getExtraFilters', () => {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -195,11 +195,19 @@ export class VictoriaLogsDatasource
         value: '$__interval_ms',
       },
     };
+
+    let extraFilters = this.getExtraFilters(adhocFilters, target.extraFilters);
+    let expr = this.interpolateString(target.expr, variables);
+    if (target.isApplyExtraFiltersToRootQuery && extraFilters) {
+      expr = `${extraFilters} | ${expr}`;
+      extraFilters = undefined;
+    }
+
     return {
       ...target,
       legendFormat: this.templateSrv.replace(target.legendFormat, rest),
-      expr: this.interpolateString(target.expr, variables),
-      extraFilters: this.getExtraFilters(adhocFilters, target.extraFilters),
+      expr,
+      extraFilters,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export const QUERY_DIRECTION = {
   asc: 'asc',
   desc: 'desc',
 } as const;
-export type QueryDirection = typeof QUERY_DIRECTION[keyof typeof QUERY_DIRECTION];
+export type QueryDirection = (typeof QUERY_DIRECTION)[keyof typeof QUERY_DIRECTION];
 
 export enum SupportingQueryType {
   DataSample = 'dataSample',
@@ -54,8 +54,12 @@ export interface Query extends DataQuery {
   direction?: QueryDirection;
   supportingQueryType?: SupportingQueryType;
   queryType?: QueryType;
-  interval?: string; // for /select/logsql/query
-  fields?: string[]; // groups the results by the specified field value for /select/logsql/hits
+  /** for /select/logsql/query */
+  interval?: string;
+  /** groups the results by the specified field value for /select/logsql/hits */
+  fields?: string[];
+  /** if true, adhoc filters will be applied as the root filter, otherwise as an extra_filters */
+  isApplyExtraFiltersToRootQuery?: boolean;
 }
 
 export type VictoriaLogsQueryEditorProps = QueryEditorProps<VictoriaLogsDatasource, Query, Options>;


### PR DESCRIPTION
Related issue: #511 

### Describe Your Changes

Add "Ad-hoc filters to root query" checkbox to Query Editor options. When enabled, ad-hoc filters are applied directly to the root query expression instead of using the `extra_filters` parameter, preventing filter propagation into subqueries (join, union, etc.)
<img width="1167" height="264" alt="image" src="https://github.com/user-attachments/assets/b2a4625c-c7fc-4bf5-8d3d-5b1ba12a4ed8" />


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Ad‑hoc filters to root query" toggle in the Query Editor to apply ad‑hoc filters directly in the query instead of via extra_filters. This avoids filter propagation into join/union subqueries and addresses #511.

- **New Features**
  - Adds a toggle (InlineSwitch) in Query Editor options outside Explore.
  - Datasource prepends combined filters to expr and omits extra_filters when enabled.
  - Collapsed info shows current mode; tests cover single/multiple/no filters and existing extraFilters.
  - Adds isApplyExtraFiltersToRootQuery to Query type and updates CHANGELOG.

<sup>Written for commit 3586595d8fbfb9270d2320ff680e97a1b03eb93e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

