### PR TITLE
update workflow to use `pull_request_target` for PR merge handling to handle merging PR of external contributors

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';
-            const prNumber = context.payload.pull_request.number;
             
             let issueNumbers = new Set();
             


### PR DESCRIPTION
### Describe Your Changes

Problem: Currently, when we merge the external PR, the `merge` action has no access to the GITHUB_TOKEN to update the related issue. 
Solution: use the `pull_request_target` to grant the access. But it is still secure because we don't execute or checkout the code from the PR; we just update the issue with a label and a comment.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use pull_request_target in the PR merge workflow to enable GITHUB_TOKEN and update related issues for external PRs. Also remove an unused variable; the workflow only labels and comments, and never checks out or runs PR code.

<sup>Written for commit b45a73391d3bdf74d60b49d2c858955679a8e7fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

