### PR TITLE
add timezone offset support for query endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: pass the selected timezone offset to the offset query arg at `/select/logsql/hits` and `/select/logsql/stats_query_range` endpoints. See [#561](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/561).
+
 ## v0.25.0
 
 * FEATURE: limit the number of field values. This limit can be configured in the datasource settings. See [#543](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/543).

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,8 @@ export interface Query extends DataQuery {
   interval?: string;
   /** groups the results by the specified field value for /select/logsql/hits */
   fields?: string[];
+  /** timezone offset for bucket alignment in stats_query_range and hits endpoints (e.g. "2h", "-5h30m") */
+  timezoneOffset?: string;
   /** if true, adhoc filters will be applied as the root filter, otherwise as an extra_filters */
   isApplyExtraFiltersToRootQuery?: boolean;
 }
@@ -73,7 +75,7 @@ export type DerivedFieldConfig = {
   matcherType?: 'label' | 'regex';
 };
 
-export type QueryFilterOptions = KeyValue<string>
+export type QueryFilterOptions = KeyValue<string>;
 
 export enum FilterActionType {
   FILTER_FOR = 'FILTER_FOR',
@@ -98,7 +100,7 @@ export interface PipeVisualQuery {
 
 export interface VisualQuery {
   filters: FilterVisualQuery;
-  pipes: string[]//PipeVisualQuery[];
+  pipes: string[]; //PipeVisualQuery[];
 }
 
 export interface RequestArguments {
@@ -143,4 +145,4 @@ export type MultitenancyHeaders = Record<TenantHeaderNames, string>;
 export type Tenant = {
   account_id: string;
   project_id: string;
-}
+};

--- a/src/utils/timeUtils.test.ts
+++ b/src/utils/timeUtils.test.ts
@@ -1,4 +1,8 @@
-import { getDurationFromMilliseconds, getMillisecondsFromDuration } from './timeUtils';
+import {
+  formatOffsetDuration,
+  getDurationFromMilliseconds,
+  getMillisecondsFromDuration,
+} from './timeUtils';
 
 describe('timeUtils', () => {
   describe('getDurationFromMilliseconds', () => {
@@ -23,11 +27,11 @@ describe('timeUtils', () => {
     });
 
     it('should return "1d 2h 3m 4s 5ms" for 93784005 milliseconds', () => {
-      expect(getDurationFromMilliseconds(93784005)).toBe('1d 2h 3m 4s 5ms');
+      expect(getDurationFromMilliseconds(93784005)).toBe('1d2h3m4s5ms');
     });
 
     it('should return "2h 30m" for 9000000 milliseconds', () => {
-      expect(getDurationFromMilliseconds(9000000)).toBe('2h 30m');
+      expect(getDurationFromMilliseconds(9000000)).toBe('2h30m');
     });
 
     it('should return an empty string for 0 milliseconds', () => {
@@ -35,11 +39,11 @@ describe('timeUtils', () => {
     });
 
     it('should handle large durations correctly', () => {
-      expect(getDurationFromMilliseconds(1234567890)).toBe('14d 6h 56m 7s 890ms');
+      expect(getDurationFromMilliseconds(1234567890)).toBe('14d6h56m7s890ms');
     });
 
     it('should handle durations with no milliseconds', () => {
-      expect(getDurationFromMilliseconds(86400000 + 3600000)).toBe('1d 1h');
+      expect(getDurationFromMilliseconds(86400000 + 3600000)).toBe('1d1h');
     });
   });
 
@@ -82,6 +86,40 @@ describe('timeUtils', () => {
 
     it('should handle invalid durations gracefully by returning 0', () => {
       expect(getMillisecondsFromDuration('invalid')).toBe(0);
+    });
+  });
+
+  describe('formatOffsetDuration', () => {
+    it('should return empty string for 0', () => {
+      expect(formatOffsetDuration('custom', 0)).toBeUndefined();
+    });
+
+    it('should format positive hours "2h"', () => {
+      expect(formatOffsetDuration('custom', 120)).toBe('2h');
+    });
+
+    it('should format negative hours "-5h"', () => {
+      expect(formatOffsetDuration('custom', -300)).toBe('-5h');
+    });
+
+    it('should format hours and minutes "5h30m"', () => {
+      expect(formatOffsetDuration('custom', 330)).toBe('5h30m');
+    });
+
+    it('should format negative hours and minutes "-5h30m"', () => {
+      expect(formatOffsetDuration('custom', -330)).toBe('-5h30m');
+    });
+
+    it('should format minutes only "30m"', () => {
+      expect(formatOffsetDuration('custom', 30)).toBe('30m');
+    });
+
+    it('should format negative minutes only "-45m"', () => {
+      expect(formatOffsetDuration('custom', -45)).toBe('-45m');
+    });
+
+    it('should format "5h45m" for Nepal timezone offset', () => {
+      expect(formatOffsetDuration('custom', 345)).toBe('5h45m');
     });
   });
 });


### PR DESCRIPTION
Related issue: #561 

### Describe Your Changes

Adjusts `/select/logsql/hits` and `/select/logsql/stats_query_range` to accept timezone offsets for bucket alignment. Updates related utilities, tests, and documentation.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add timezone offset support for /select/logsql/hits and /select/logsql/stats_query_range to align buckets with the user’s timezone. Addresses #561.

- **New Features**
  - Frontend: compute timezoneOffset from Grafana timezone and attach to queries; add formatOffsetDuration; compact duration format (e.g., 5h30m).
  - Backend: add TimezoneOffset to Query; pass offset to stats_query_range and hits when set; fix hits URL builder name.
  - Tests/Docs: add unit tests for offsets and duration formatting; update changelog.

<sup>Written for commit b4d41abc967f4f32c2e27056326d3f2b1e9b091c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

