### PR TITLE
fix an interpolation query by handling additional patterns like `:in("*")` and `word in(".*")`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * FEATURE: pass the selected timezone offset to the offset query arg at `/select/logsql/hits` and `/select/logsql/stats_query_range` endpoints. See [#561](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/561).
 
+* BUGFIX: fix an interpolation query by handling additional patterns like `:in("*")` and `word in(".*")`. See [#573](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/573).
+
 ## v0.25.0
 
 * FEATURE: limit the number of field values. This limit can be configured in the datasource settings. See [#543](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/543).

--- a/src/LogsQL/multiExactOperator.test.ts
+++ b/src/LogsQL/multiExactOperator.test.ts
@@ -20,8 +20,8 @@ describe('multiExactOperator', () => {
       expect(correctMultiExactOperatorValueAll(input)).toBe(expected);
     });
 
-    it('should NOT replace if the pattern is slightly different (e.g., missing dot)', () => {
-      const input = 'label: in(*)'; // already corrected
+    it('should  replace if the pattern is slightly different: extra space', () => {
+      const input = 'label:in(*)'; // already corrected
       expect(correctMultiExactOperatorValueAll(input)).toBe(input);
     });
 
@@ -48,6 +48,30 @@ describe('multiExactOperator', () => {
     it('should handle stream label with double quotes', () => {
       const input = '_stream:{"label" in(.*)} | count() by (level)';
       const expected = '_stream:{"label" in(*)} | count() by (level)';
+      expect(correctMultiExactOperatorValueAll(input)).toBe(expected);
+    });
+
+    it('should replace ": in(".*")" with ":in(*)"', () => {
+      const input = 'label: in(".*")';
+      const expected = 'label:in(*)';
+      expect(correctMultiExactOperatorValueAll(input)).toBe(expected);
+    });
+
+    it('should replace "word in(".*")" with "word in(*)"', () => {
+      const input = '_stream:{label in(".*")}';
+      const expected = '_stream:{label in(*)}';
+      expect(correctMultiExactOperatorValueAll(input)).toBe(expected);
+    });
+
+    it('should replace ": in("*")" with ":in(*)"', () => {
+      const input = 'label: in("*")';
+      const expected = 'label:in(*)';
+      expect(correctMultiExactOperatorValueAll(input)).toBe(expected);
+    });
+
+    it('should replace "word in("*")" with "word in(*)"', () => {
+      const input = '_stream:{label in("*")}';
+      const expected = '_stream:{label in(*)}';
       expect(correctMultiExactOperatorValueAll(input)).toBe(expected);
     });
   });

--- a/src/LogsQL/multiExactOperator.ts
+++ b/src/LogsQL/multiExactOperator.ts
@@ -1,6 +1,12 @@
 /**
  * Corrects the syntax of exact operators in a given expression string by replacing
- * occurrences of ": in(.*)" with ":in(*)" or for the _stream field "word in (.*)" with "word in (*)".
+ * occurrences of:
+ * 1. ":in(.*)" with ":in(*)"
+ * 2. ":in(".*")" with ":in(*)"
+ * 3. ":in("*") with ":in(*)"
+ * 4. "word in (.*)" with "word in (*)" for the _stream field
+ * 5. `word in (".*")` with `word in (*)` for the _stream field
+ * 6. `word in ("*")` with `word in (*)` for the _stream field
  *
  * @param {string} expr - The input expression string to be corrected.
  * @return {string} The corrected expression string with updated syntax.
@@ -8,7 +14,7 @@
 export function correctMultiExactOperatorValueAll(expr: string): string {
   return expr
     // replace ": in(*)" with ":in(*)"
-    .replace(/:\s*in\(\.\*\)/g, ':in(*)')
+    .replace(/:\s*in\(\s*("?\.?\*"?)\s*\)/g, ':in(*)')
     // replace "word in (.*)" with "word in (*)" for the stream field
-    .replace(/("(?:\\.|[^"\\])*"|[^\s:]+)\s+in\(\.\*\)/g, '$1 in(*)');
+    .replace(/("(?:\\.|[^"\\])*"|[^\s:]+)\s+in\(\s*("?\.?\*"?)\s*\)/g, '$1 in(*)');
 }

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -331,7 +331,7 @@ describe('VictoriaLogsDatasource', () => {
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
       const result = ds.interpolateString('foo: $var1 bar: $var2', scopedVars);
-      expect(result).toStrictEqual('foo: in(\"foo\",\"bar\") bar: in(*)');
+      expect(result).toStrictEqual('foo: in(\"foo\",\"bar\") bar:in(*)');
     });
   });
 });


### PR DESCRIPTION
Related issue: #573 

### Describe Your Changes

Fix an interpolation query by handling additional patterns like `:in("*")` and `word in(".*")`

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect interpolation of the textbox “All” value by normalizing wildcard patterns in LogsQL. Handles quoted and unquoted wildcards (with or without spaces) so they resolve to :in(*) / in(*). Addresses #573.

- **Bug Fixes**
  - Expand regex to match :in(.*), :in(".*"), :in("*"), and word in(.*|".*"|"*") in _stream clauses.
  - Standardize formatting to bar:in(*) and word in(*); add tests and update CHANGELOG.

<sup>Written for commit 3aa7f2217d2613882c375a0d53b647e684a52d2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

