### PR TITLE
docs: add some info to correlation paragraph

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -198,7 +198,7 @@ VictoriaLogs datasource supports automatic variable interpolation with the follo
 ## Correlations
 
 Signals can be correlated together if they share the same list of attributes, so they can uniquely identify the
-same system or event. Grafana provides various interfaces for the [correlations](https://grafana.com/docs/grafana/latest/administration/correlations/) feature
+same system or event. Grafana provides various interfaces for the [correlations](https://grafana.com/docs/grafana/latest/administration/correlations/)
 feature for interactive links between visualizations.
 
 ### Trace to logs


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the Correlations section in README.
Added that signals can be correlated when they share the same attributes (identifying the same system or event) and linked to Grafana’s correlations for interactive links between visualizations.

<sup>Written for commit 5c61b8b0f7170b97bfc883734828a56bdd634466. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

