### PR TITLE
fix compatibility of the Live Logs feature with the upcoming Grafana version with React 19

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -370,6 +370,10 @@ export class VictoriaLogsDatasource
           addr: {
             scope: LiveChannelScope.DataSource,
             namespace: this.uid,
+            // @ts-expect-error - from the Grafana with React 19 version,
+            // the interface of the Live feature expects the `stream` field instead of the `namespace`,
+            // so we need to send both for compatibility with older versions
+            stream: this.uid,
             path: `${request.requestId}/${query.refId}`,
             data: {
               ...query,


### PR DESCRIPTION
Related issue: #564 
### Describe Your Changes

1. run `npx -y @grafana/react-detect@latest` didn't find any breaking changes with React 19.
2. tested with Grafana Docker image with React 19: `grafana/grafana-enterprise:dev-preview-react19`. Found the problem related to Live Logs.
3. Fixed problem with Live logs by adding the additional field to stream config: `stream`. Left the `namespace` field to save compatibility with older versions of Grafana. 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Live Logs works with the upcoming Grafana version (React 19) by adding addr.stream to the live channel config, while keeping namespace for backward compatibility. Tested with grafana/grafana-enterprise:dev-preview-react19; no other React 19 issues found.

<sup>Written for commit 527a21851f5eca8b070668f9cac6f2236c63f167. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

