### PR TITLE
ci: add lint step to frontend workflow

### DIFF
--- a/.github/workflows/pr-checks-frontend.yml
+++ b/.github/workflows/pr-checks-frontend.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Run typecheck
         run: yarn typecheck
+
+      - name: Run lint
+        run: yarn lint


### PR DESCRIPTION
### Describe Your Changes

Added lint step to frontend check.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add linting to the frontend PR checks to enforce code style and catch issues early. The workflow now runs yarn lint after typecheck and fails on lint errors.

<sup>Written for commit bc1d786c9c79d3e858c8398753379a16b5da1c01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

