### PR TITLE
bump version to 0.26.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "victoriametrics-logs-datasource",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "VictoriaLogs datasource plugin for grafana",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",


### PR DESCRIPTION
### Describe Your Changes

Release v0.26.1. This release still has 2 dev vulnerabilities related to the `minimatch` package. Would like to try to pass the Grafana checker with dev vulnerabilities.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump version to v0.26.1 to publish a patch release of the VictoriaLogs Grafana datasource. No code changes; dev-only minimatch vulnerabilities remain while we test passing the Grafana plugin checker.

<sup>Written for commit 8a4743403d96e735d0971803d2b7c01b84b6c325. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

