### PR TITLE
feat: add opt-in dataplane format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * FEATURE: add a `:` (word filter) operator to Log Level Rules, matching a field value by whole word like LogsQL (e.g. `error` matches the word `error`, not `terror`). See [#611](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/611).
 * FEATURE: the visual query builder now shows context-aware keyboard hints at the bottom of its dropdowns, so the available shortcuts (select, navigate, confirm, run) are visible while you build a query. See [pr #683](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/683).
+* FEATURE: add opt-in Grafana dataplane log format support. When enabled in datasource settings, log frames use standard field names (`timestamp`, `body`) and `DataFrameType.LogLines` metadata, enabling automatic `${labelKey}` variables in correlations.
 
 ## v0.29.0
 

--- a/src/README.md
+++ b/src/README.md
@@ -46,6 +46,8 @@ datasources:
     url: http://victorialogs:9428
     isDefault: true
     jsonData:
+      # Enable Grafana dataplane log format for correlations support
+      #useDataplaneFormat: true
       # Multitenancy settings, see https://docs.victoriametrics.com/victorialogs/#multitenancy
       # to use the multitenancy, uncomment lines below: AccountID and ProjectID
       multitenancyHeaders:
@@ -215,6 +217,19 @@ Where:
 * `level` is the log level to assign if the condition matches. Valid values: `critical`, `error`, `warning`, `info`, `debug`, `trace`, `unknown`.
 * `operator` is the comparison operator to use, such as `equals`, `notEquals`, `regex`, `lessThan`, `greaterThan`, `wordFilter`. The `wordFilter` operator follows [LogsQL word filter](https://docs.victoriametrics.com/victorialogs/logsql/#word-filter) semantics: the value matches whole tokens, not substrings (e.g. `error` matches `an error happened` but not `terror`).
 * `enabled` is a boolean flag to enable or disable the rule. Defaults to `true` if omitted.
+
+### Dataplane format
+
+The **Use dataplane format** toggle in the datasource settings enables the [Grafana dataplane log format](https://grafana.com/developers/dataplane/). When enabled, log frames use standard field names (`timestamp`, `body` instead of `Time`, `Line`) and set `DataFrameType.LogLines` metadata. This makes all label keys automatically available as `${labelKey}` variables in [correlations](https://grafana.com/docs/grafana/latest/administration/correlations/), similar to how Loki works with its dataplane support.
+
+**Note:** Enabling this setting may break existing client-side transformations that reference the `Time` or `Line` field names.
+
+To enable via provisioning:
+
+```yaml
+jsonData:
+  useDataplaneFormat: true
+```
 
 ### Variables
 VictoriaLogs datasource supports [variables](https://grafana.com/docs/grafana/latest/variables/) in queries.

--- a/src/configuration/LogsSettings.tsx
+++ b/src/configuration/LogsSettings.tsx
@@ -1,7 +1,7 @@
 import React, { SyntheticEvent, useMemo } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { InlineField, Input, Stack, Text } from '@grafana/ui';
+import { InlineField, InlineSwitch, Input, Stack, Text } from '@grafana/ui';
 
 import { Options } from '../types';
 
@@ -50,6 +50,26 @@ export const LogsSettings = (props: PropsConfigEditor) => {
               onChange={onChangeHandler('vmuiUrl', optionsWithHttpMethod, onOptionsChange)}
               spellCheck={false}
               placeholder={getDefaultVmuiUrl(optionsWithHttpMethod.url)}
+            />
+          </InlineField>
+        </div>
+        <div className='gf-form max-width-30'>
+          <InlineField
+            label='Use dataplane format'
+            labelWidth={28}
+            tooltip='Use Grafana dataplane log format (timestamp/body field names, DataFrameType.LogLines). Enables automatic label variables in correlations. May break existing client-side transformations that reference Time/Line field names.'
+          >
+            <InlineSwitch
+              value={options.jsonData.useDataplaneFormat}
+              onChange={(e) => {
+                onOptionsChange({
+                  ...options,
+                  jsonData: {
+                    ...options.jsonData,
+                    useDataplaneFormat: e.currentTarget.checked,
+                  },
+                });
+              }}
             />
           </InlineField>
         </div>

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -99,6 +99,7 @@ export class VictoriaLogsDatasource
   logLevelRules: LogLevelRule[];
   multitenancyHeaders?: MultitenancyHeaders;
   logContextProvider: LogContextProvider;
+  useDataplaneFormat: boolean;
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<Options>,
@@ -134,6 +135,7 @@ export class VictoriaLogsDatasource
     this.queryBuilderLimits = settingsData.queryBuilderLimits;
     this.multitenancyHeaders = this.parseMultitenancyHeaders(settingsData.multitenancyHeaders);
     this.logContextProvider = new LogContextProvider(this);
+    this.useDataplaneFormat = settingsData.useDataplaneFormat ?? false;
   }
 
   query(request: DataQueryRequest<Query>): Observable<DataQueryResponse> {
@@ -172,7 +174,8 @@ export class VictoriaLogsDatasource
             response,
             fixedRequest,
             this.derivedFields ?? [],
-            this.getActiveLevelRules()
+            this.getActiveLevelRules(),
+            this.useDataplaneFormat
           )
         )
       );

--- a/src/transformers/frameProcessors/streamFrameProcessor.ts
+++ b/src/transformers/frameProcessors/streamFrameProcessor.ts
@@ -1,4 +1,4 @@
-import { DataFrame, QueryResultMeta } from '@grafana/data';
+import { DataFrame, DataFrameType, QueryResultMeta } from '@grafana/data';
 
 import { LogLevelRule } from '../../configuration/LogLevelRules/types';
 import { getHighlighterExpressionsFromQuery } from '../../queryUtils';
@@ -6,19 +6,20 @@ import { DerivedFieldConfig, Query } from '../../types';
 import { getDerivedFields } from '../fields/derivedField';
 import { getStreamFields } from '../fields/labelField';
 import { addLevelField } from '../fields/levelField';
-import { ANNOTATIONS_REF_ID } from '../types';
+import { ANNOTATIONS_REF_ID, FrameField } from '../types';
 import { dataFrameHasError, setFrameMeta } from '../utils/frame/frameUtils';
 
 export function processStreamsFrames(
   frames: DataFrame[],
   queryMap: Map<string, Query>,
   derivedFieldConfigs: DerivedFieldConfig[],
-  logLevelRules: LogLevelRule[]
+  logLevelRules: LogLevelRule[],
+  useDataplaneFormat = false,
 ): DataFrame[] {
   return frames.map((frame) => {
     const query = frame.refId !== undefined ? queryMap.get(frame.refId) : undefined;
     const isAnnotations = query?.refId === ANNOTATIONS_REF_ID;
-    return processStreamFrame(frame, query, derivedFieldConfigs, logLevelRules, isAnnotations);
+    return processStreamFrame(frame, query, derivedFieldConfigs, logLevelRules, isAnnotations, useDataplaneFormat);
   });
 }
 
@@ -27,7 +28,8 @@ function processStreamFrame(
   query: Query | undefined,
   derivedFieldConfigs: DerivedFieldConfig[],
   logLevelRules: LogLevelRule[],
-  transformLabels = false
+  transformLabels = false,
+  useDataplaneFormat = false,
 ): DataFrame {
   const custom: Record<string, unknown> = {
     ...frame.meta?.custom, // keep the original meta.custom (incl. backend streamIds/streams)
@@ -50,11 +52,26 @@ function processStreamFrame(
   const derivedFields = getDerivedFields(frameWithLevel, derivedFieldConfigs);
   const baseFields = getStreamFields(frameWithLevel.fields, transformLabels);
 
+  const fields = [...baseFields, ...derivedFields];
+
+  if (useDataplaneFormat) {
+    return {
+      ...frameWithLevel,
+      fields: fields.map((f) => {
+        if (f.name === 'Time') { return { ...f, name: 'timestamp' }; }
+        if (f.name === FrameField.Line) { return { ...f, name: 'body' }; }
+        return f;
+      }),
+      meta: {
+        ...frameWithLevel.meta,
+        type: DataFrameType.LogLines,
+        typeVersion: [0, 0],
+      },
+    };
+  }
+
   return {
     ...frameWithLevel,
-    fields: [
-      ...baseFields,
-      ...derivedFields
-    ]
+    fields,
   };
 }

--- a/src/transformers/transformBackendResult.ts
+++ b/src/transformers/transformBackendResult.ts
@@ -17,6 +17,7 @@ export function transformBackendResult(
   request: DataQueryRequest<Query>,
   derivedFieldConfigs: DerivedFieldConfig[],
   logLevelRules: LogLevelRule[],
+  useDataplaneFormat = false,
 ): DataQueryResponse {
   const { data, errors, ...rest } = response;
   const queries = request.targets;
@@ -44,7 +45,7 @@ export function transformBackendResult(
     data: [
       ...processMetricRangeFrames(metricRangeFrames, request.targets, request.range.from.valueOf(), request.range.to.valueOf()),
       ...processMetricInstantFrames(metricInstantFrames),
-      ...processStreamsFrames(streamsFrames, queryMap, derivedFieldConfigs, logLevelRules),
+      ...processStreamsFrames(streamsFrames, queryMap, derivedFieldConfigs, logLevelRules, useDataplaneFormat),
       ...processHistogramFrames(histogramFrames, request.panelPluginId),
     ],
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface Options extends DataSourceJsonData {
   multitenancyHeaders?: Partial<Record<TenantHeaderNames, string>>;
   vmuiUrl?: string;
   otelPreset?: OpenTelemetryPreset;
+  useDataplaneFormat?: boolean;
 }
 
 export const QUERY_DIRECTION = {


### PR DESCRIPTION
Add an opt-in setting and the corresponding UI toggle to enable logs [dataplane](https://grafana.com/developers/dataplane/logs) format.

Using this format allows Grafana correlations to work correctly with label values.
Without it, it's not possible to craft links that use label values when using Grafana correlations.

It's opt-in because the fields are renamed, which may break client-side transformations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in setting to output logs in Grafana dataplane format, enabling automatic `${labelKey}` variables in correlations. Default is off to avoid breaking transformations that reference `Time`/`Line`.

- **New Features**
  - New “Use dataplane format” toggle in datasource settings; provisioning key: `jsonData.useDataplaneFormat`.
  - When enabled: rename `Time`→`timestamp` and `Line`→`body`, and set frame meta to `DataFrameType.LogLines` with `typeVersion [0,0]` so `${labelKey}` works in correlations.
  - Updated README, CHANGELOG, and tests to cover the new format.

<sup>Written for commit e49b2eae59398482dc282db460cd625832b57465. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

