### PR TITLE
fix search of filter values in the query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * BUGFIX: fix time range provided in `field_names` and `field_values` requests. Instead of being rounded to a 24-hour time range, the selected time range is now provided. See [pr #581](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/581).
 * BUGFIX: fix template variables not being interpolated in the `Step` field of the query editor. See [pr #594](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/594).
+* BUGFIX: fix search of filter values in the query builder.
 
 ## v0.26.2
 

--- a/src/language_provider.ts
+++ b/src/language_provider.ts
@@ -1,4 +1,4 @@
-import { getDefaultTimeRange, LanguageProvider, TimeRange } from '@grafana/data';
+import { escapeRegex, getDefaultTimeRange, LanguageProvider, TimeRange } from '@grafana/data';
 
 import { VictoriaLogsDatasource } from './datasource';
 import { FieldHits, FieldHitsResponse, FilterFieldType } from './types';
@@ -56,7 +56,7 @@ export default class LogsQlLanguageProvider extends LanguageProvider {
     // Build query with optional field value filter (prefix match for server-side filtering)
     let finalQuery = options.query || '*';
     if (options.type === FilterFieldType.FieldValue && options.field && options.fieldValueFilter) {
-      const fieldFilter = `${options.field}: i("${options.fieldValueFilter}")`;
+      const fieldFilter = `${options.field}:~"(?i)${escapeRegex(options.fieldValueFilter)}"`;
       finalQuery = finalQuery === '*' ? fieldFilter : `(${finalQuery}) AND ${fieldFilter}`;
     }
     urlParams.append('query', finalQuery);


### PR DESCRIPTION
### Describe Your Changes

Fixed search of filter values in the query builder. Changed the query filter of the incomplete filter value.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes filter value search in the query builder. Uses a properly escaped, case-insensitive regex so partial inputs and special characters return correct results.

- **Bug Fixes**
  - Switched field value filter to regex matching: field:~"(?i){escaped}" using escapeRegex to prevent malformed queries.
  - Updated CHANGELOG to record the fix.

<sup>Written for commit d2f75deb0fce100d34df2a33b46106be6487d81e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

