### PR TITLE
feat(dashboard variables): allow custom values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: add ability to set custom field names in dashboard variables, since fields do not necessarily exist at the time of creation or manipulation (e.g. when importing a dashboard from JSON, then editing a variable). See [pr #606](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/606). Thanks to @github-vincent-miszczak for contributing.
+
 ## v0.26.3
 
 * BUGFIX: fix time range provided in `field_names` and `field_values` requests. Instead of being rounded to a 24-hour time range, the selected time range is now provided. See [pr #581](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/581).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## tip
 
-* BUGFIX: disable tenant configuration inputs (`Tenant`, `AccountID`, `ProjectID`) until the datasource health check passes. Previously, entering and clearing a tenant on a freshly created (not yet saved) datasource produced a validation error. See [#639](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/639).
 * FEATURE: add ability to set custom field names in dashboard variables, since fields do not necessarily exist at the time of creation or manipulation (e.g. when importing a dashboard from JSON, then editing a variable). See [pr #606](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/606). Thanks to @github-vincent-miszczak for contributing.
+
+* BUGFIX: disable tenant configuration inputs (`Tenant`, `AccountID`, `ProjectID`) until the datasource health check passes. Previously, entering and clearing a tenant on a freshly created (not yet saved) datasource produced a validation error. See [#639](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/639).
 
 ## v0.27.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: disable tenant configuration inputs (`Tenant`, `AccountID`, `ProjectID`) until the datasource health check passes. Previously, entering and clearing a tenant on a freshly created (not yet saved) datasource produced a validation error. See [#639](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/639).
+* FEATURE: add ability to set custom field names in dashboard variables, since fields do not necessarily exist at the time of creation or manipulation (e.g. when importing a dashboard from JSON, then editing a variable). See [pr #606](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/606). Thanks to @github-vincent-miszczak for contributing.
 
 ## v0.27.1
 

--- a/src/components/CompatibleCombobox.tsx
+++ b/src/components/CompatibleCombobox.tsx
@@ -27,6 +27,13 @@ export const CompatibleCombobox: typeof Combobox = (props) => {
     });
   };
 
+  const handleCreateOption = (customValue: string) => {
+    props.onChange({
+      value: customValue as any,
+      label: customValue,
+    });
+  };
+
   const asyncOption = useCallback((value: SelectValue<any>) => {
     if (typeof props.options === 'function') {
       return props.options(value);
@@ -61,7 +68,9 @@ export const CompatibleCombobox: typeof Combobox = (props) => {
         loadOptions={selectOptions}
         defaultOptions
         allowCustomValue={props.createCustomValue}
+        onCreateOption={props.createCustomValue ? handleCreateOption : undefined}
         onChange={handleSelectChange}
+        onBlur={props.onBlur}
         isClearable={props.isClearable}
         isLoading={props.loading}
         disabled={props.disabled}
@@ -76,7 +85,9 @@ export const CompatibleCombobox: typeof Combobox = (props) => {
       value={normalizedValue}
       options={selectOptions}
       allowCustomValue={props.createCustomValue}
+      onCreateOption={props.createCustomValue ? handleCreateOption : undefined}
       onChange={handleSelectChange}
+      onBlur={props.onBlur}
       isClearable={props.isClearable}
       isLoading={props.loading}
       disabled={props.disabled}

--- a/src/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -4,10 +4,9 @@ import React, { FormEvent, useEffect, useState } from 'react';
 import { DEFAULT_FIELD_DISPLAY_VALUES_LIMIT, QueryEditorProps, SelectableValue } from '@grafana/data';
 import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
 
-import { CompatibleCombobox } from '../CompatibleCombobox';
-
 import { VictoriaLogsDatasource } from '../../datasource';
 import { FilterFieldType, Options, Query, VariableQuery } from '../../types';
+import { CompatibleCombobox } from '../CompatibleCombobox';
 
 const variableOptions = [
   { label: 'Field names', value: FilterFieldType.FieldName },
@@ -36,7 +35,11 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
   };
 
   const handleFieldChange = (option: { value: string }) => {
-    setField(String(option.value));
+    setField(option.value);
+    if (!type) {
+      return;
+    }
+    onChange({ refId, type, field: option.value, query: queryFilter, limit });
   };
 
   const handleBlur = () => {
@@ -136,7 +139,6 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
             <CompatibleCombobox
               placeholder='Select field'
               onChange={handleFieldChange}
-              onBlur={handleBlur}
               value={field || null}
               options={fieldNames}
               width={20}

--- a/src/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -2,7 +2,7 @@ import { debounce } from 'lodash';
 import React, { FormEvent, useEffect, useState } from 'react';
 
 import { DEFAULT_FIELD_DISPLAY_VALUES_LIMIT, QueryEditorProps, SelectableValue } from '@grafana/data';
-import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
+import { Combobox, InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
 
 import { VictoriaLogsDatasource } from '../../datasource';
 import { FilterFieldType, Options, Query, VariableQuery } from '../../types';
@@ -31,10 +31,6 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
     }
     setType(newType.value);
     onChange({ refId, type: newType.value, field, query: queryFilter });
-  };
-
-  const handleFieldChange = (newField: SelectableValue<string>) => {
-    setField(newField.value || '');
   };
 
   const handleBlur = () => {
@@ -131,14 +127,18 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
             error={error}
             invalid={!!error}
           >
-            <Select
-              aria-label='Field value'
-              onChange={handleFieldChange}
-              onBlur={handleBlur}
-              value={field}
+            <Combobox
+              placeholder='Select field'
+              onChange={(option) => {
+                const newField = String(option.value);
+                setField(newField);
+                onChange({ refId, type: type!, field: newField, query: queryFilter, limit });
+              }}
+              value={field || null}
               options={fieldNames}
               width={20}
-              isLoading={isLoading}
+              loading={isLoading}
+              createCustomValue
             />
           </InlineField>
         )}

--- a/src/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -2,7 +2,9 @@ import { debounce } from 'lodash';
 import React, { FormEvent, useEffect, useState } from 'react';
 
 import { DEFAULT_FIELD_DISPLAY_VALUES_LIMIT, QueryEditorProps, SelectableValue } from '@grafana/data';
-import { Combobox, InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
+import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
+
+import { CompatibleCombobox } from '../CompatibleCombobox';
 
 import { VictoriaLogsDatasource } from '../../datasource';
 import { FilterFieldType, Options, Query, VariableQuery } from '../../types';
@@ -21,7 +23,7 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
   const [queryFilter, setQueryFilter] = useState<string>('');
   const [field, setField] = useState<string>('');
   const [limit, setLimit] = useState<number>(DEFAULT_FIELD_DISPLAY_VALUES_LIMIT);
-  const [fieldNames, setFieldNames] = useState<SelectableValue<string>[]>([]);
+  const [fieldNames, setFieldNames] = useState<Array<{ value: string; label: string; description?: string }>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
@@ -31,6 +33,10 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
     }
     setType(newType.value);
     onChange({ refId, type: newType.value, field, query: queryFilter });
+  };
+
+  const handleFieldChange = (option: { value: string }) => {
+    setField(String(option.value));
   };
 
   const handleBlur = () => {
@@ -127,13 +133,10 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
             error={error}
             invalid={!!error}
           >
-            <Combobox
+            <CompatibleCombobox
               placeholder='Select field'
-              onChange={(option) => {
-                const newField = String(option.value);
-                setField(newField);
-                onChange({ refId, type: type!, field: newField, query: queryFilter, limit });
-              }}
+              onChange={handleFieldChange}
+              onBlur={handleBlur}
               value={field || null}
               options={fieldNames}
               width={20}

--- a/src/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -6,6 +6,7 @@ import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
 
 import { VictoriaLogsDatasource } from '../../datasource';
 import { FilterFieldType, Options, Query, VariableQuery } from '../../types';
+import { CompatibleCombobox } from '../CompatibleCombobox';
 
 const variableOptions = [
   { label: 'Field names', value: FilterFieldType.FieldName },
@@ -21,7 +22,7 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
   const [queryFilter, setQueryFilter] = useState<string>('');
   const [field, setField] = useState<string>('');
   const [limit, setLimit] = useState<number>(DEFAULT_FIELD_DISPLAY_VALUES_LIMIT);
-  const [fieldNames, setFieldNames] = useState<SelectableValue<string>[]>([]);
+  const [fieldNames, setFieldNames] = useState<Array<{ value: string; label: string; description?: string }>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
@@ -33,8 +34,12 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
     onChange({ refId, type: newType.value, field, query: queryFilter });
   };
 
-  const handleFieldChange = (newField: SelectableValue<string>) => {
-    setField(newField.value || '');
+  const handleFieldChange = (option: { value: string }) => {
+    setField(option.value);
+    if (!type) {
+      return;
+    }
+    onChange({ refId, type, field: option.value, query: queryFilter, limit });
   };
 
   const handleBlur = () => {
@@ -131,14 +136,14 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
             error={error}
             invalid={!!error}
           >
-            <Select
-              aria-label='Field value'
+            <CompatibleCombobox
+              placeholder='Select field'
               onChange={handleFieldChange}
-              onBlur={handleBlur}
-              value={field}
+              value={field || null}
               options={fieldNames}
               width={20}
-              isLoading={isLoading}
+              loading={isLoading}
+              createCustomValue
             />
           </InlineField>
         )}


### PR DESCRIPTION
When working with dashboard variables, fields do not necessarily exist at the time of creation/manipulation(when importing a dashboard from JSON for instance, then editing a variable).

This feature keeps the existing behavior, but also allows custom values from user or JSON.

<img width="1567" height="403" alt="image" src="https://github.com/user-attachments/assets/fb7fc672-2a6c-4c73-a135-07420fdf8be1" />
<img width="2804" height="915" alt="image" src="https://github.com/user-attachments/assets/f93ec41d-84bf-4be2-be96-9b2509ceb31b" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow entering custom field names in the dashboard variable editor so variables work even if the field doesn’t exist yet (e.g., after importing JSON). Replaces the field dropdown with a `CompatibleCombobox` that supports freeform input and better loading/focus handling.

- **New Features**
  - Swapped `Select` for `CompatibleCombobox` (wrapper around `@grafana/ui` `Combobox`) with custom values via `createCustomValue` + `onCreateOption`, forwards `onBlur`, and uses the `loading` prop.
  - On field select or create, immediately triggers `onChange` with updated `type`, `field`, `query`, and `limit`.
  - Normalized `fieldNames` to `{ value, label, description? }`, added "Select field" placeholder, empty -> `null`. CHANGELOG updated.

<sup>Written for commit 59a9546cd0ebc1a746b8cac6d7ff9ae3d595fc30. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victorialogs-datasource/pull/606?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

