### PR TITLE
Fix correlation query example in README

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -221,7 +221,7 @@ feature for navigating from a span in a trace directly to logs relevant for that
 
 An example of the correlation query in traces datasource is the following:
 ```
-trace_id:="${__trace.traceId}" AND span_id:="${__trace.spanId}"
+trace_id:="${__trace.traceId}" AND span_id:="${__span.spanId}"
 ```
 
 ### Log to metrics


### PR DESCRIPTION
### Describe Your Changes

Updated span_id variable in correlation query example.


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the README trace-to-logs correlation query by replacing `span_id:"${__trace.spanId}"` with `span_id:"${__span.spanId}"`, ensuring the example returns logs for the selected span.

<sup>Written for commit 471979fe665f91ef023525d2cf65ffb5f196034e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

