### PR TITLE
fix interpolation of a query with the variable at the end of the line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix interpolation of a query with the variable at the end of the line. See [#614](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/614);
+
 ## v0.26.3
 
 * BUGFIX: fix time range provided in `field_names` and `field_values` requests. Instead of being rounded to a 24-hour time range, the selected time range is now provided. See [pr #581](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/581).

--- a/src/parsingUtils.test.ts
+++ b/src/parsingUtils.test.ts
@@ -29,6 +29,26 @@ describe('replaceOperatorWithIn', () => {
           const output = replaceOperatorWithIn(input, 'variableName');
           expect(output).toBe('field1:in($variableName)');
         });
+
+        it(`should replace ${operator} operator with field name which contains /`, () => {
+          const input = `kubernetes.pod_labels.app.kubernetes.io/name${operator}$variableName`;
+          const output = replaceOperatorWithIn(input, 'variableName');
+          expect(output).toBe('kubernetes.pod_labels.app.kubernetes.io/name:in($variableName)');
+        });
+
+        ['\r', '\n', '\t'].forEach((separator) => {
+          it(`should replace ${operator} operator with the separator ${JSON.stringify(separator)}`, () => {
+            const input = `_stream:{kubernetes.pod_namespace="$namespace"} kubernetes.pod_labels.app.kubernetes.io/name${operator}$variableName${separator}
+| format if (kubernetes.pod_labels.app.kubernetes.io/name:"") "unknown" as kubernetes.pod_labels.app.kubernetes.io/name
+| stats by (kubernetes.pod_labels.app.kubernetes.io/name) count()
+| count()`;
+            const output = replaceOperatorWithIn(input, 'variableName');
+            expect(output).toBe(`_stream:{kubernetes.pod_namespace="$namespace"} kubernetes.pod_labels.app.kubernetes.io/name:in($variableName)${separator}
+| format if (kubernetes.pod_labels.app.kubernetes.io/name:"") "unknown" as kubernetes.pod_labels.app.kubernetes.io/name
+| stats by (kubernetes.pod_labels.app.kubernetes.io/name) count()
+| count()`);
+          });
+        });
       });
     });
 

--- a/src/parsingUtils.ts
+++ b/src/parsingUtils.ts
@@ -38,7 +38,7 @@ export function replaceVariables(expr: string) {
 *  '}' - for end of a stream
 *  ',' - for stream filter separator
 * */
-const validAfterVariableChars = [' ', '|', '}', ','];
+const validAfterVariableChars = [' ', '|', '}', ',', '\r', '\n', '\t'];
 function findIndexEndOfFilter(expr: string, startIndex = 0): number {
   for (let i = startIndex; i < expr.length; i++) {
     if (validAfterVariableChars.includes(expr[i])) {


### PR DESCRIPTION
Related issue: #614 

### Describe Your Changes

Fix interpolation of a query with the variable at the end of the line

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes variable interpolation when a variable appears at the end of a line, so trailing variables are parsed and rewritten correctly. Addresses #614.

- **Bug Fixes**
  - Treat `\r`, `\n`, and `\t` as valid terminators after variables in the parser to detect filter boundaries.
  - Support path-like field names containing `/` in `replaceOperatorWithIn`.
  - Add tests for newline/tab separators and slash-containing field names.
  - Update `CHANGELOG.md` with the bugfix note.

<sup>Written for commit d32ff42916623038d1d0b49ee91ecf1b8eb0d380. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

