### PR TITLE
fix: protect Raw Logs queries from excessively large line limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## tip
 
+* BUGFIX: protect Raw Logs queries from excessively large line limits. A hard upper bound of 10000 lines is now enforced on both the per-query `Line limit` and the datasource-wide `Maximum lines` settings; a confirmation dialog warns before committing a value above 1000 lines. See [#613](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/613).
 * BUGFIX: fix interpolation of a query with the variable at the end of the line. See [#614](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/614);
 
 ## v0.26.3

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -8,6 +8,7 @@ import { Button, ConfirmModal, Stack, useStyles2 } from '@grafana/ui';
 import { getQueryExprVariableRegExp } from '../../LogsQL/regExpOperator';
 import { isExprHasStatsPipeFunctions } from '../../LogsQL/statsPipeFunctions';
 import { LevelQueryFilter } from '../../configuration/LogLevelRules/LevelQueryFilter/LeveQueryFilter';
+import { LOGS_LIMIT_HARD_CAP } from '../../constants';
 import { Query, QueryEditorMode, QueryType, VictoriaLogsQueryEditorProps } from '../../types';
 import QueryEditorStatsWarn from '../QueryEditorStatsWarn';
 
@@ -43,6 +44,7 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
   const varRegExp = useMemo(() => {
     return getQueryExprVariableRegExp(query.expr)?.[0] || null;
   }, [query.expr]);
+  const isMaxLinesOverCap = query.maxLines !== undefined && query.maxLines > LOGS_LIMIT_HARD_CAP;
   useLogsSort(app, query, onChange, onRunQuery);
 
   const onEditorModeChange = useCallback((newEditorMode: QueryEditorMode) => {
@@ -120,7 +122,8 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
                 size='sm'
                 onClick={onRunQuery}
                 icon={data?.state === LoadingState.Loading ? 'fa fa-spinner' : undefined}
-                disabled={data?.state === LoadingState.Loading}
+                disabled={data?.state === LoadingState.Loading || isMaxLinesOverCap}
+                tooltip={isMaxLinesOverCap ? `Line limit must be ≤ ${LOGS_LIMIT_HARD_CAP}` : undefined}
               >
                 {queries && queries.length > 1 ? 'Run queries' : 'Run query'}
               </Button>

--- a/src/components/QueryEditor/QueryEditorOptions.tsx
+++ b/src/components/QueryEditor/QueryEditorOptions.tsx
@@ -1,11 +1,13 @@
 import React, { useMemo } from 'react';
 
 import { CoreApp, isValidGrafanaDuration, SelectableValue } from '@grafana/data';
-import { AutoSizeInput, InlineSwitch, RadioButtonGroup, TextLink } from '@grafana/ui';
+import { AutoSizeInput, InlineSwitch, Input, RadioButtonGroup, TextLink } from '@grafana/ui';
 
 import { VICTORIA_LOGS_DOCS_HOST } from '../../conf';
+import { LOGS_LIMIT_HARD_CAP, LOGS_LIMIT_WARNING_THRESHOLD } from '../../constants';
 import { Query, QueryType } from '../../types';
 import { isVariable } from '../../utils/isVariable';
+import { useMaxLinesWarning } from '../shared/shared/useMaxLinesWarning';
 
 import EditorField from './EditorField';
 import { EditorRow } from './EditorRow';
@@ -54,6 +56,29 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
     isValidStep,
   });
 
+  const isOverCap = query.maxLines !== undefined && query.maxLines > LOGS_LIMIT_HARD_CAP;
+  const { modal: maxLinesWarningModal, requestConfirmation } = useMaxLinesWarning(onRunQuery);
+
+  const onMaxLinesChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+    const parsed = parseInt(e.currentTarget.value, 10);
+    let newMaxLines = isNaN(parsed) || parsed < 0 ? undefined : parsed;
+    if (newMaxLines !== undefined && newMaxLines > LOGS_LIMIT_HARD_CAP){
+      newMaxLines = LOGS_LIMIT_HARD_CAP;
+    }
+    onChange({ ...query, maxLines: newMaxLines });
+  };
+
+  const onMaxLinesBlur = () => {
+    if (query.maxLines !== undefined && query.maxLines > LOGS_LIMIT_WARNING_THRESHOLD) {
+      requestConfirmation(query.maxLines);
+    }
+
+    if (query.maxLines === undefined) {
+      onRunQuery();
+      return;
+    }
+  };
+
   const onQueryTypeChange = (value: QueryType) => {
     onChange({ ...query, queryType: value });
     onRunQuery();
@@ -62,16 +87,6 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
   const onLegendFormatChanged = (e: React.FormEvent<HTMLInputElement>) => {
     onChange({ ...query, legendFormat: e.currentTarget.value });
     onRunQuery();
-  };
-
-  const onMaxLinesChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
-    const maxLines = parseInt(e.currentTarget.value, 10);
-    const newMaxLines = isNaN(maxLines) || maxLines < 0 ? undefined : maxLines;
-
-    if (query.maxLines !== newMaxLines) {
-      onChange({ ...query, maxLines: newMaxLines });
-      onRunQuery();
-    }
   };
 
   const onStepChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
@@ -86,6 +101,7 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
 
   return (
     <EditorRow>
+      {maxLinesWarningModal}
       <QueryEditorOptionsGroup
         title='Options'
         collapsedInfo={collapsedInfo}
@@ -116,14 +132,22 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
           </TextLink>
         </div>
         {queryType === QueryType.Instant && (
-          <EditorField label='Line limit' tooltip='Upper limit for number of log lines returned by query.'>
-            <AutoSizeInput
+          <EditorField
+            label='Line limit'
+            tooltip={`Upper limit for number of log lines returned by query. Maximum: ${LOGS_LIMIT_HARD_CAP}.`}
+            invalid={isOverCap}
+            error={`Maximum value is ${LOGS_LIMIT_HARD_CAP}.`}
+          >
+            <Input
+              id='line-limit-input'
               className='width-4'
               placeholder={maxLines.toString()}
               type='number'
               min={0}
-              defaultValue={query.maxLines?.toString() ?? ''}
-              onCommitChange={onMaxLinesChange}
+              max={LOGS_LIMIT_HARD_CAP}
+              value={query.maxLines?.toString() ?? ''}
+              onChange={onMaxLinesChange}
+              onBlur={onMaxLinesBlur}
             />
           </EditorField>
         )}

--- a/src/components/shared/shared/useMaxLinesWarning.test.tsx
+++ b/src/components/shared/shared/useMaxLinesWarning.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { NOT_SHOW_AGAIN_LOGS_LIMIT_WARNING_LOCAL_STORAGE_KEY } from '../../../constants';
+import store from '../../../store/store';
+
+import { useMaxLinesWarning } from './useMaxLinesWarning';
+
+jest.mock('../../../store/store', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+}));
+
+const mockedStore = store as jest.Mocked<typeof store>;
+
+const TestHost: React.FC<{ value: number; onAccept: (value: number) => void }> = ({ value, onAccept }) => {
+  const { modal, requestConfirmation } = useMaxLinesWarning(onAccept);
+  return (
+    <>
+      <button onClick={() => requestConfirmation(value)}>trigger</button>
+      {modal}
+    </>
+  );
+};
+
+const getModal = () => screen.getByText('Large line limit').closest('[role="dialog"]') as HTMLElement;
+
+describe('useMaxLinesWarning', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStore.get.mockReturnValue(null);
+  });
+
+  it('calls onAccept immediately when value is at or below the warning threshold', () => {
+    const onAccept = jest.fn();
+    render(<TestHost value={500} onAccept={onAccept} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+
+    expect(onAccept).toHaveBeenCalledWith(500);
+    expect(screen.queryByText('Large line limit')).not.toBeInTheDocument();
+  });
+
+  it('opens the modal when value exceeds the warning threshold and flag is not set', () => {
+    const onAccept = jest.fn();
+    render(<TestHost value={5000} onAccept={onAccept} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+
+    expect(onAccept).not.toHaveBeenCalled();
+    expect(screen.getByText('Large line limit')).toBeInTheDocument();
+  });
+
+  it('calls onAccept immediately when the suppression flag is set', () => {
+    mockedStore.get.mockReturnValue('true');
+    const onAccept = jest.fn();
+    render(<TestHost value={5000} onAccept={onAccept} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+
+    expect(onAccept).toHaveBeenCalledWith(5000);
+    expect(screen.queryByText('Large line limit')).not.toBeInTheDocument();
+  });
+
+  it('Confirm triggers onAccept with the pending value', async () => {
+    const onAccept = jest.fn();
+    render(<TestHost value={5000} onAccept={onAccept} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+    fireEvent.click(within(getModal()).getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(onAccept).toHaveBeenCalledWith(5000);
+    });
+  });
+
+  it('Confirm persists the suppression flag only when dontShowAgain is checked', async () => {
+    const onAccept = jest.fn();
+    render(<TestHost value={5000} onAccept={onAccept} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+    const modal = getModal();
+    fireEvent.click(within(modal).getByLabelText("Don't show this warning again"));
+    fireEvent.click(within(modal).getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(mockedStore.set).toHaveBeenCalledWith(NOT_SHOW_AGAIN_LOGS_LIMIT_WARNING_LOCAL_STORAGE_KEY, 'true');
+    });
+  });
+
+  it('Confirm does not persist the flag when dontShowAgain is not checked', async () => {
+    const onAccept = jest.fn();
+    render(<TestHost value={5000} onAccept={onAccept} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+    fireEvent.click(within(getModal()).getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(onAccept).toHaveBeenCalledWith(5000);
+    });
+    expect(mockedStore.set).not.toHaveBeenCalled();
+  });
+
+  it('Dismiss clears state and never persists the flag even if dontShowAgain is checked', () => {
+    const onAccept = jest.fn();
+    render(<TestHost value={5000} onAccept={onAccept} />);
+
+    fireEvent.click(screen.getByText('trigger'));
+    const modal = getModal();
+    fireEvent.click(within(modal).getByLabelText("Don't show this warning again"));
+    fireEvent.click(within(modal).getByRole('button', { name: /Cancel/i }));
+
+    expect(onAccept).not.toHaveBeenCalled();
+    expect(mockedStore.set).not.toHaveBeenCalled();
+    expect(screen.queryByText('Large line limit')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/shared/useMaxLinesWarning.tsx
+++ b/src/components/shared/shared/useMaxLinesWarning.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useState } from 'react';
+
+import { Checkbox, ConfirmModal, Stack } from '@grafana/ui';
+
+import { LOGS_LIMIT_WARNING_THRESHOLD, NOT_SHOW_AGAIN_LOGS_LIMIT_WARNING_LOCAL_STORAGE_KEY } from '../../../constants';
+import store from '../../../store/store';
+
+export function useMaxLinesWarning(onAccept: (value: number) => void) {
+  const [pendingValue, setPendingValue] = useState<number | null>(null);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  const requestConfirmation = useCallback(
+    (value: number) => {
+      if (value <= LOGS_LIMIT_WARNING_THRESHOLD) {
+        onAccept(value);
+        return;
+      }
+      if (store.get(NOT_SHOW_AGAIN_LOGS_LIMIT_WARNING_LOCAL_STORAGE_KEY) === 'true') {
+        onAccept(value);
+        return;
+      }
+      setPendingValue(value);
+    },
+    [onAccept]
+  );
+
+  const onConfirm = useCallback(() => {
+    if (dontShowAgain) {
+      store.set(NOT_SHOW_AGAIN_LOGS_LIMIT_WARNING_LOCAL_STORAGE_KEY, 'true');
+    }
+    if (pendingValue !== null) {
+      onAccept(pendingValue);
+    }
+    setPendingValue(null);
+    setDontShowAgain(false);
+  }, [dontShowAgain, pendingValue, onAccept]);
+
+  const onDismiss = useCallback(() => {
+    setPendingValue(null);
+    setDontShowAgain(false);
+  }, []);
+
+  const modal = (
+    <ConfirmModal
+      isOpen={pendingValue !== null}
+      title='Large line limit'
+      body={
+        <Stack direction='column' gap={2}>
+          <div>
+            {`You're about to set a line limit of ${pendingValue ?? ''}. `}
+            {`Values over ${LOGS_LIMIT_WARNING_THRESHOLD} may cause browser or backend performance issues. Continue?`}
+          </div>
+          <div>
+            <Checkbox
+              label="Don't show this warning again"
+              value={dontShowAgain}
+              onChange={(e) => setDontShowAgain(e.currentTarget.checked)}
+            />
+          </div>
+        </Stack>
+      }
+      confirmText='Continue'
+      onConfirm={onConfirm}
+      onDismiss={onDismiss}
+    />
+  );
+
+  return { modal, requestConfirmation };
+}

--- a/src/configuration/QuerySettings.test.tsx
+++ b/src/configuration/QuerySettings.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import store from '../store/store';
+
+import { QuerySettings } from './QuerySettings';
+
+jest.mock('../store/store', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+}));
+
+const mockedStore = store as jest.Mocked<typeof store>;
+
+describe('QuerySettings — Maximum lines protection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStore.get.mockReturnValue(null);
+  });
+
+  it('stores a safe typed value on change without opening the modal', () => {
+    const onMaxLinedChange = jest.fn();
+
+    render(<QuerySettings maxLines='' onMaxLinedChange={onMaxLinedChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('1000'), { target: { value: '500' } });
+
+    expect(onMaxLinedChange).toHaveBeenCalledWith('500');
+    expect(screen.queryByText('Large line limit')).not.toBeInTheDocument();
+  });
+
+  it('does not open the modal on blur when the stored value is within the safe range', () => {
+    render(<QuerySettings maxLines='500' onMaxLinedChange={jest.fn()} />);
+
+    fireEvent.blur(screen.getByPlaceholderText('1000'));
+
+    expect(screen.queryByText('Large line limit')).not.toBeInTheDocument();
+  });
+
+  it('opens the modal on blur when the stored value exceeds the warning threshold', async () => {
+    const onMaxLinedChange = jest.fn();
+
+    render(<QuerySettings maxLines='5000' onMaxLinedChange={onMaxLinedChange} />);
+
+    fireEvent.blur(screen.getByPlaceholderText('1000'));
+
+    const modal = screen.getByText('Large line limit').closest('[role="dialog"]') as HTMLElement;
+    expect(modal).toBeInTheDocument();
+
+    fireEvent.click(within(modal).getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(onMaxLinedChange).toHaveBeenCalledWith('5000');
+    });
+  });
+
+  it('clamps to the hard cap on change when the typed value exceeds it', () => {
+    const onMaxLinedChange = jest.fn();
+
+    render(<QuerySettings maxLines='' onMaxLinedChange={onMaxLinedChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('1000'), { target: { value: '50000' } });
+
+    expect(onMaxLinedChange).toHaveBeenCalledWith('10000');
+  });
+
+  it('renders invalid state when the stored value still exceeds the hard cap', () => {
+    render(<QuerySettings maxLines='50000' onMaxLinedChange={jest.fn()} />);
+
+    expect(screen.getByText('Maximum value is 10000.')).toBeInTheDocument();
+  });
+
+  it('passes raw value through on empty input', () => {
+    const onMaxLinedChange = jest.fn();
+
+    render(<QuerySettings maxLines='500' onMaxLinedChange={onMaxLinedChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('1000'), { target: { value: '' } });
+    expect(onMaxLinedChange).toHaveBeenCalledWith('');
+  });
+});

--- a/src/configuration/QuerySettings.test.tsx
+++ b/src/configuration/QuerySettings.test.tsx
@@ -68,6 +68,16 @@ describe('QuerySettings — Maximum lines protection', () => {
     expect(onMaxLinedChange).toHaveBeenCalledWith('10000');
   });
 
+  it('clears the stored value when the typed value is negative', () => {
+    const onMaxLinedChange = jest.fn();
+
+    render(<QuerySettings maxLines='500' onMaxLinedChange={onMaxLinedChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('1000'), { target: { value: '-5' } });
+
+    expect(onMaxLinedChange).toHaveBeenCalledWith('');
+  });
+
   it('renders invalid state when the stored value still exceeds the hard cap', () => {
     render(<QuerySettings maxLines='50000' onMaxLinedChange={jest.fn()} />);
 

--- a/src/configuration/QuerySettings.tsx
+++ b/src/configuration/QuerySettings.tsx
@@ -23,10 +23,19 @@ export const QuerySettings = (props: Props) => {
 
   const onChange = (event: React.FormEvent<HTMLInputElement>) => {
     const raw = event.currentTarget.value;
+    if (raw === '') {
+      onMaxLinedChange(raw);
+      return;
+    }
+
     const parsed = parseInt(raw, 10);
 
-    if (raw === '' || isNaN(parsed)) {
-      onMaxLinedChange(raw);
+    if (isNaN(parsed)) {
+      return;
+    }
+
+    if (parsed < 0) {
+      onMaxLinedChange('');
       return;
     }
 
@@ -35,7 +44,7 @@ export const QuerySettings = (props: Props) => {
       return;
     }
 
-    onMaxLinedChange(raw);
+    onMaxLinedChange(String(parsed));
   };
 
   const onBlur = () => {

--- a/src/configuration/QuerySettings.tsx
+++ b/src/configuration/QuerySettings.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { InlineField, Input } from '@grafana/ui';
+
+import { useMaxLinesWarning } from '../components/shared/shared/useMaxLinesWarning';
+import { LOGS_LIMIT_HARD_CAP, LOGS_LIMIT_WARNING_THRESHOLD } from '../constants';
 
 type Props = {
   maxLines: string;
@@ -9,29 +12,66 @@ type Props = {
 
 export const QuerySettings = (props: Props) => {
   const { maxLines, onMaxLinedChange } = props;
+  const numeric = parseInt(maxLines, 10);
+  const isOverCap = !isNaN(numeric) && numeric > LOGS_LIMIT_HARD_CAP;
+
+  const applyMaxLines = useCallback((value: number) => {
+    onMaxLinedChange(value.toString());
+  }, [onMaxLinedChange]);
+
+  const { modal: maxLinesWarningModal, requestConfirmation } = useMaxLinesWarning(applyMaxLines);
+
+  const onChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const raw = event.currentTarget.value;
+    const parsed = parseInt(raw, 10);
+
+    if (raw === '' || isNaN(parsed)) {
+      onMaxLinedChange(raw);
+      return;
+    }
+
+    if (parsed > LOGS_LIMIT_HARD_CAP) {
+      onMaxLinedChange(String(LOGS_LIMIT_HARD_CAP));
+      return;
+    }
+
+    onMaxLinedChange(raw);
+  };
+
+  const onBlur = () => {
+    if (!isNaN(numeric) && numeric > LOGS_LIMIT_WARNING_THRESHOLD) {
+      requestConfirmation(numeric);
+    }
+  };
+
   return (
     <div className='gf-form-inline'>
+      {maxLinesWarningModal}
       <InlineField
         label='Maximum lines'
         labelWidth={28}
         tooltip={
           <>
-            VictoriaLogs queries must contain a limit of the maximum number of lines returned (default: 1000). Increase this
-            limit to have a bigger result set for ad-hoc analysis. Decrease this limit if your browser becomes sluggish
+            VictoriaLogs queries must contain a limit of the maximum number of lines returned (default: 1000).
+            Maximum allowed value is {LOGS_LIMIT_HARD_CAP}. Decrease this limit if your browser becomes sluggish
             when displaying the log results.
           </>
         }
+        invalid={isOverCap}
+        error={`Maximum value is ${LOGS_LIMIT_HARD_CAP}.`}
       >
         <Input
           className='width-8'
           type='number'
+          min={0}
+          max={LOGS_LIMIT_HARD_CAP}
           value={maxLines}
-          onChange={(event: React.FormEvent<HTMLInputElement>) => onMaxLinedChange(event.currentTarget.value)}
+          onChange={onChange}
+          onBlur={onBlur}
           placeholder='1000'
           spellCheck={false}
         />
       </InlineField>
-
     </div>
   );
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,7 @@
 export const VARIABLE_ALL_VALUE = '$__all';
 export const TEXT_FILTER_ALL_VALUE = '*';
 export const PLUGIN_ID = 'victoriametrics-logs-datasource';
+
+export const LOGS_LIMIT_HARD_CAP = 10000;
+export const LOGS_LIMIT_WARNING_THRESHOLD = 1000;
+export const NOT_SHOW_AGAIN_LOGS_LIMIT_WARNING_LOCAL_STORAGE_KEY = `${PLUGIN_ID}:notShowAgainLogsLimitWarning`;

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,10 +1,11 @@
-import { AdHocVariableFilter } from '@grafana/data';
+import { AdHocVariableFilter, DataQueryRequest } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 
 // eslint-disable-next-line jest/no-mocks-import
 import { createDatasource } from './__mocks__/datasource';
-import { VARIABLE_ALL_VALUE } from './constants';
+import { LOGS_LIMIT_HARD_CAP, VARIABLE_ALL_VALUE } from './constants';
 import { VictoriaLogsDatasource } from './datasource';
+import { Query } from './types';
 
 const replaceMock = jest.fn().mockImplementation((a: string) => a);
 
@@ -332,6 +333,87 @@ describe('VictoriaLogsDatasource', () => {
       const ds = createDatasource(templateSrvMock);
       const result = ds.interpolateString('foo: $var1 bar: $var2', scopedVars);
       expect(result).toStrictEqual('foo: in(\"foo\",\"bar\") bar:in(*)');
+    });
+  });
+
+  describe('max lines clamp', () => {
+    describe('constructor', () => {
+      it('clamps datasource maxLines to HARD_CAP when config value exceeds it', () => {
+        const clamped = createDatasource(templateSrvStub, {
+          jsonData: { maxLines: '50000' },
+        });
+        expect(clamped.maxLines).toBe(LOGS_LIMIT_HARD_CAP);
+      });
+
+      it('keeps datasource maxLines as configured when below HARD_CAP', () => {
+        const ok = createDatasource(templateSrvStub, {
+          jsonData: { maxLines: '500' },
+        });
+        expect(ok.maxLines).toBe(500);
+      });
+
+      it('falls back to default 1000 when maxLines is missing', () => {
+        const def = createDatasource(templateSrvStub, { jsonData: {} });
+        expect(def.maxLines).toBe(1000);
+      });
+    });
+
+    describe('query builder', () => {
+      const buildRequest = (maxLines: number | undefined): DataQueryRequest<Query> => ({
+        app: 'dashboard',
+        requestId: 'r1',
+        interval: '1s',
+        intervalMs: 1000,
+        range: {
+          from: { utcOffset: () => 0 } as any,
+          to: { utcOffset: () => 0 } as any,
+          raw: { from: 'now-1h', to: 'now' },
+        } as any,
+        scopedVars: {},
+        targets: [{ refId: 'A', expr: 'error', maxLines }],
+        timezone: 'UTC',
+        startTime: 0,
+      }) as DataQueryRequest<Query>;
+
+      it('clamps query.maxLines to HARD_CAP when it exceeds the cap', () => {
+        const localDs = createDatasource(templateSrvStub, { jsonData: { maxLines: '500' } });
+        const runQuerySpy = jest
+          .spyOn(localDs, 'runQuery')
+          .mockReturnValue({ subscribe: jest.fn() } as any);
+
+        const req = buildRequest(50000);
+        localDs.query(req);
+
+        expect(runQuerySpy).toHaveBeenCalled();
+        expect(req.targets[0].maxLines).toBe(LOGS_LIMIT_HARD_CAP);
+        runQuerySpy.mockRestore();
+      });
+
+      it('keeps query.maxLines as-is when below HARD_CAP', () => {
+        const localDs = createDatasource(templateSrvStub, { jsonData: { maxLines: '500' } });
+        const runQuerySpy = jest
+          .spyOn(localDs, 'runQuery')
+          .mockReturnValue({ subscribe: jest.fn() } as any);
+
+        const req = buildRequest(800);
+        localDs.query(req);
+
+        expect(req.targets[0].maxLines).toBe(800);
+        runQuerySpy.mockRestore();
+      });
+
+      it('uses datasource.maxLines when query.maxLines is undefined', () => {
+        const localDs = createDatasource(templateSrvStub, { jsonData: { maxLines: '2000' } });
+        const runQuerySpy = jest
+          .spyOn(localDs, 'runQuery')
+          .mockReturnValue({ subscribe: jest.fn() } as any);
+
+        const req = buildRequest(undefined);
+        localDs.query(req);
+
+        expect(req.targets[0].maxLines).toBe(2000);
+        runQuerySpy.mockRestore();
+      });
     });
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -38,7 +38,7 @@ import {
 } from './components/QueryEditor/QueryBuilder/components/StreamFilters/streamFilterUtils';
 import QueryEditor from './components/QueryEditor/QueryEditor';
 import { LogLevelRule } from './configuration/LogLevelRules/types';
-import { TEXT_FILTER_ALL_VALUE, VARIABLE_ALL_VALUE } from './constants';
+import { LOGS_LIMIT_HARD_CAP, TEXT_FILTER_ALL_VALUE, VARIABLE_ALL_VALUE } from './constants';
 import { escapeLabelValueInSelector } from './languageUtils';
 import LogsQlLanguageProvider from './language_provider';
 import { LOGS_VOLUME_BARS, queryLogsVolume } from './logsVolumeLegacy';
@@ -109,7 +109,7 @@ export class VictoriaLogsDatasource
     this.basicAuth = instanceSettings.basicAuth;
     this.withCredentials = instanceSettings.withCredentials;
     this.httpMethod = settingsData.httpMethod || 'POST';
-    this.maxLines = parseInt(settingsData.maxLines ?? '0', 10) || 1000;
+    this.maxLines = Math.min(parseInt(settingsData.maxLines ?? '0', 10) || 1000, LOGS_LIMIT_HARD_CAP);
     this.derivedFields = settingsData.derivedFields || [];
     this.customQueryParameters = new URLSearchParams(settingsData.customQueryParameters);
     this.languageProvider = languageProvider ?? new LogsQlLanguageProvider(this);
@@ -131,7 +131,7 @@ export class VictoriaLogsDatasource
           ...q,
           // to backend sort for limited data to show first logs in the selected time range if the user clicks on the sort button
           expr: addSortPipeToQuery(q, request.app, request.liveStreaming),
-          maxLines: q.maxLines ?? this.maxLines,
+          maxLines: Math.min(q.maxLines ?? this.maxLines, LOGS_LIMIT_HARD_CAP),
           timezoneOffset,
           format: getQueryFormat(q.expr),
           step: this.templateSrv.replace(q.step, request.scopedVars),


### PR DESCRIPTION
Related issue: #613 

### Describe Your Changes

Protect Raw Logs queries from excessively large line limits
A hard upper bound of 10000 lines is now enforced on both the per-query `Line limit` and the datasource-wide `Maximum lines` settings; a confirmation dialog warns before committing a value above 1000 lines.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a hard cap of 10,000 lines for Raw Logs queries and warns for large limits to prevent slowdowns. Applies to both per-query `Line limit` and datasource `Maximum lines`, addressing #613.

- **Bug Fixes**
  - Clamp `Line limit` and datasource `Maximum lines` to 10,000 in the UI and datasource.
  - Show a confirmation dialog for values over 1,000 (with “Don’t show again”); run only after confirm.
  - Disable “Run query” over the cap and show a tooltip; display an input error when invalid.
  - Clear the setting when a negative value is entered.
  - Add tests for the warning hook, query settings validation (including negative input), and datasource clamping.

<sup>Written for commit 078da6e61e90ae9e3bf082cb8d3678ee960f1dd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

