### PR TITLE
feat: add issue templates for bug reports, enhancements, and questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,6 +29,7 @@ body:
       description: |
         Please provide the version of VictoriaLogs datasource plugin and VictoriaLogs backend you are using.
         Also provide the version of Grafana you are using and version of the vmauth if it is used.
+      value: "Plugin version: v0.x.x\nVictoriaLogs version: v1.x.x\nGrafana version: vx.x.x\nVmauth(if used) version: v1.x.x"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,39 @@
+name: Suggest enhancement
+description: Suggest an improvement or new feature for the plugin
+labels: [enhancement, vl-datasource]
+body:
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: |
+        What problem does this enhancement solve? Describe the scenario where
+        the current behavior is insufficient or inconvenient.
+      placeholder: |
+        When I do `A`, the plugin does `B`. I'd like it to do `C` because ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: |
+        A clear and concise description of what you'd like to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: |
+        Any alternative solutions or workarounds you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: |
+        Any other context, links, screenshots, or references related to the enhancement.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,48 @@
+name: Ask a question
+description: Ask a question about the plugin usage, configuration, or behavior
+labels: [question, vl-datasource]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening an issue, please check the following resources:
+
+        - [Plugin README](https://github.com/VictoriaMetrics/victorialogs-datasource/blob/main/src/README.md) — usage and configuration documentation
+        - [VictoriaMetrics community and contributions](https://docs.victoriametrics.com/victoriametrics/#community-and-contributions) — Slack, Telegram, Reddit, and other ways to get help
+
+        For quick questions, the community channels above may get you an answer faster than a GitHub issue.
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: |
+        A clear and concise description of your question.
+    validations:
+      required: true
+  - type: textarea
+    id: what-tried
+    attributes:
+      label: What have you already tried?
+      description: |
+        Describe the steps you've already taken — documentation, community channels,
+        configuration changes, workarounds, etc.
+    validations:
+      required: false
+  - type: textarea
+    id: version
+    attributes:
+      label: Versions of the VictoriaLogs datasource and the VictoriaLogs backend
+      description: |
+        Please provide the version of the VictoriaLogs datasource plugin and the VictoriaLogs backend you are using.
+        Also, provide the Grafana version you are using and the vmauth version, if used.
+      value: "Plugin version: v0.x.x\nVictoriaLogs version: v1.x.x\nGrafana version: vx.x.x\nVmauth(if used) version: v1.x.x"
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: |
+        Any other context, links, screenshots, or references related to your question.
+    validations:
+      required: false


### PR DESCRIPTION
### Describe Your Changes

Added templates for the issues. Remove the blank issue (this type should now be available only to team members).

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitHub issue templates for bug reports, enhancements, and questions to guide users to structured forms. Also prefill version fields and disable blank issues to speed triage.

- **New Features**
  - Added enhancement template with fields for use case, proposed solution, alternatives, and context; auto-labels as enhancement and vl-datasource.
  - Added question template with links to docs/community and fields for question, what you tried, versions (prefilled), and context; auto-labels as question and vl-datasource.
  - Updated bug report template to prefill version information.
  - Disabled blank issues via `.github/ISSUE_TEMPLATE/config.yml`.

<sup>Written for commit b75ba3fd07ea438ab6c0b0cc5f87f58e713254e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

