### PR TITLE
fix: update vulnerable npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,8 @@
     "immutable": "^4.3.6",
     "flatted": "3.4.2",
     "lodash": "^4.18.0",
+    "protobufjs": "7.5.5",
+    "protocol-buffers-schema": "3.6.1",
     "serialize-javascript": "7.0.5",
     "yaml": "1.10.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9514,9 +9514,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.3.0":
-  version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4"
+"protobufjs@npm:7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -9530,14 +9530,14 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+  checksum: 10c0/3d48896a916761e3e60b52f80027eb4fba3f5a6e3f8461e04939db18812db2cb0db4c73d03e1134a960e99525ae1d236f076a0bc01273016f573b76f33ffbd47
   languageName: node
   linkType: hard
 
-"protocol-buffers-schema@npm:^3.3.1":
-  version: 3.6.0
-  resolution: "protocol-buffers-schema@npm:3.6.0"
-  checksum: 10c0/23a08612e5cc903f917ae3b680216ccaf2d889c61daa68d224237f455182fa96fff16872ac94b1954b5dd26fc7e8ce7e9360c54d54ea26218d107b2f059fca37
+"protocol-buffers-schema@npm:3.6.1":
+  version: 3.6.1
+  resolution: "protocol-buffers-schema@npm:3.6.1"
+  checksum: 10c0/e0a6858d085aa1a6719c924c0be52000dafc24bf3b0d0b1a6e1e68c8b95f8efe3d4069902e14270a2101f2144374eeefc11381dff07ad9909386a4fbc70c7ebd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Describe Your Changes
 
- protobufjs: 7.5.4→7.5.5 (GHSA-xq3m-2v4x-88gg, Critical)
- protocol-buffers-schema: 3.6.0→3.6.1 (GHSA-j452-xhg8-qg39)

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates vulnerable protobuf dependencies to patch known security issues. Reduces risk in protobuf parsing with no functional changes.

- **Dependencies**
  - `protobufjs`: 7.5.4 → 7.5.5 (GHSA-xq3m-2v4x-88gg)
  - `protocol-buffers-schema`: 3.6.0 → 3.6.1 (GHSA-j452-xhg8-qg39)

<sup>Written for commit 916eb2550b00913fba8769603c42c440f2be33fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

