### PR TITLE
fix(explore): skip redundant supplementary requests in datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * BUGFIX: protect Raw Logs queries from excessively large line limits. A hard upper bound of 10000 lines is now enforced on both the per-query `Line limit` and the datasource-wide `Maximum lines` settings; a confirmation dialog warns before committing a value above 1000 lines. See [#613](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/613).
 * BUGFIX: fix interpolation of a query with the variable at the end of the line. See [#614](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/614);
+* BUGFIX: skip the redundant `/select/logsql/hits` (logs volume) request for `Range` and `Instant` query types in Grafana Explore. The histogram is only meaningful for `Raw Logs` queries; for stats query types the main response already provides the chart. See [#630](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/630).
 
 ## v0.26.3
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,4 +1,11 @@
-import { AdHocVariableFilter, DataQueryRequest, DataSourceInstanceSettings, LogLevel } from '@grafana/data';
+import {
+  AdHocVariableFilter,
+  DataQueryRequest,
+  DataSourceInstanceSettings,
+  LogLevel,
+  SupplementaryQueryOptions,
+  SupplementaryQueryType,
+} from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 
 // eslint-disable-next-line jest/no-mocks-import
@@ -7,7 +14,7 @@ import { LogLevelRuleType } from './configuration/LogLevelRules/types';
 import { OpenTelemetryPreset } from './configuration/OpenTelemetryPreset/types';
 import { LOGS_LIMIT_HARD_CAP, VARIABLE_ALL_VALUE } from './constants';
 import { VictoriaLogsDatasource } from './datasource';
-import { Query } from './types';
+import { Query, QueryType, SupportingQueryType } from './types';
 
 const replaceMock = jest.fn().mockImplementation((a: string) => a);
 
@@ -541,5 +548,89 @@ describe('VictoriaLogsDatasource preset merge', () => {
     const errorRules = ds.logLevelRules.filter(r => r.value === 'ERROR');
     expect(errorRules).toHaveLength(1);
     expect(errorRules[0].level).toBe(LogLevel.critical);
+  });
+
+  describe('getSupplementaryQuery', () => {
+    let ds: VictoriaLogsDatasource;
+
+    beforeEach(() => {
+      ds = createDatasource(templateSrvStub);
+    });
+
+    const makeRequest = (): DataQueryRequest<Query> => ({
+      app: 'explore',
+      requestId: 'r1',
+      interval: '1s',
+      intervalMs: 1000,
+      range: {
+        from: { utcOffset: () => 0, diff: () => 3600 } as any,
+        to: { utcOffset: () => 0, diff: () => 3600 } as any,
+        raw: { from: 'now-1h', to: 'now' },
+      } as any,
+      scopedVars: {},
+      targets: [],
+      timezone: 'UTC',
+      startTime: 0,
+    }) as DataQueryRequest<Query>;
+
+    const makeQuery = (queryType: QueryType, overrides: Partial<Query> = {}): Query => ({
+      refId: 'A',
+      expr: '*',
+      queryType,
+      ...overrides,
+    });
+
+    describe('LogsVolume', () => {
+      const opts: SupplementaryQueryOptions = { type: SupplementaryQueryType.LogsVolume };
+
+      it('returns a Hits supplementary query for Raw Logs (Instant) queryType', () => {
+        const result = ds.getSupplementaryQuery(opts, makeQuery(QueryType.Instant), makeRequest());
+        expect(result).toBeDefined();
+        expect(result?.queryType).toBe(QueryType.Hits);
+        expect(result?.supportingQueryType).toBe(SupportingQueryType.LogsVolume);
+        expect(result?.refId).toBe('log-volume-A');
+      });
+
+      it.each([
+        ['StatsRange (Range UI)', QueryType.StatsRange],
+        ['Stats (Instant UI)', QueryType.Stats],
+        ['Hits (internal)', QueryType.Hits],
+      ])('returns undefined for %s — fix #630', (_label, queryType) => {
+        const result = ds.getSupplementaryQuery(opts, makeQuery(queryType), makeRequest());
+        expect(result).toBeUndefined();
+      });
+
+      it('returns undefined when the query is hidden', () => {
+        const result = ds.getSupplementaryQuery(
+          opts,
+          makeQuery(QueryType.Instant, { hide: true }),
+          makeRequest(),
+        );
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('LogsSample', () => {
+      const opts: SupplementaryQueryOptions = { type: SupplementaryQueryType.LogsSample };
+
+      it.each([
+        ['StatsRange (Range UI)', QueryType.StatsRange],
+        ['Stats (Instant UI)', QueryType.Stats],
+      ])('returns an Instant supplementary query for %s', (_label, queryType) => {
+        const result = ds.getSupplementaryQuery(opts, makeQuery(queryType), makeRequest());
+        expect(result).toBeDefined();
+        expect(result?.queryType).toBe(QueryType.Instant);
+        expect(result?.supportingQueryType).toBe(SupportingQueryType.LogsSample);
+        expect(result?.refId).toBe('log-sample-A');
+      });
+
+      it.each([
+        ['Instant (Raw Logs UI)', QueryType.Instant],
+        ['Hits (internal)', QueryType.Hits],
+      ])('returns undefined for %s — would duplicate the main request', (_label, queryType) => {
+        const result = ds.getSupplementaryQuery(opts, makeQuery(queryType), makeRequest());
+        expect(result).toBeUndefined();
+      });
+    });
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -459,6 +459,13 @@ export class VictoriaLogsDatasource
 
     switch (options.type) {
       case SupplementaryQueryType.LogsVolume: {
+        // Logs volume histogram is only meaningful for raw log queries
+        // Skip it for stats query types (StatsRange/Stats) — their main response already
+        // produces the chart, so the extra /select/logsql/hits call is redundant
+        if (query.queryType !== QueryType.Instant) {
+          return undefined;
+        }
+
         const totalSeconds = request.range.to.diff(request.range.from, 'second');
         const step = Math.ceil(totalSeconds / LOGS_VOLUME_BARS) || '';
 
@@ -476,6 +483,12 @@ export class VictoriaLogsDatasource
         };
       }
       case SupplementaryQueryType.LogsSample:
+        // Logs sample is only meaningful for metric queries — it shows raw log lines
+        // behind an aggregated chart. For raw log queries it would just duplicate the main request
+        if (query.queryType !== QueryType.StatsRange && query.queryType !== QueryType.Stats) {
+          return undefined;
+        }
+
         return {
           ...query,
           queryType: QueryType.Instant,


### PR DESCRIPTION
Related issue: #630 

### Describe Your Changes

Skip redundant supplementary requests in datasource.
For Range/Instant queries the /select/logsql/hits call was unused — the main response already renders the chart — but in practice was much slower and returned larger bodies than the main request, especially without `| fields _time`. LogsSample for Raw Logs duplicated the main /select/logsql/query request.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips redundant supplementary requests in Grafana Explore. Removes the unused logs volume call for Stats queries and the duplicate log sample for Raw Logs to reduce latency and payload size. Addresses #630.

- **Bug Fixes**
  - Skip `LogsVolume` (`/select/logsql/hits`) for `StatsRange` and `Stats`; keep only for Raw Logs.
  - Skip `LogsSample` for Raw Logs; run only for stats/metric queries to avoid duplicating `/select/logsql/query`.

<sup>Written for commit 6631e3e9f27d1eacccae058dfd862dffc9836e59. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victorialogs-datasource/pull/631?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

