### PR TITLE
feat: add three-way ad-hoc filters mode (extra_filters, root query, off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## tip
 
+* FEATURE: replace the "Ad-hoc filters to root query" checkbox in Query Editor options with a three-mode selector: `Extra Filters` (default, sends filters as the `extra_filters` query parameter), `Root Query` (prepends filters to the query expression, preventing propagation into `join`/`union` subqueries) and `Off` (disables automatic ad-hoc filter injection entirely — useful when ad-hoc values are managed through Grafana variable interpolation or applied to pipe-transformed fields). Saved dashboards using the previous `isApplyExtraFiltersToRootQuery` flag continue to work without migration. See [#633](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/633). Thanks to @edspc for contributing.
 * FEATURE: add ability to set custom field names in dashboard variables, since fields do not necessarily exist at the time of creation or manipulation (e.g. when importing a dashboard from JSON, then editing a variable). See [pr #606](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/606). Thanks to @github-vincent-miszczak for contributing.
 
 * BUGFIX: disable tenant configuration inputs (`Tenant`, `AccountID`, `ProjectID`) until the datasource health check passes. Previously, entering and clearing a tenant on a freshly created (not yet saved) datasource produced a validation error. See [#639](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/639).

--- a/src/README.md
+++ b/src/README.md
@@ -221,8 +221,18 @@ VictoriaLogs datasource supports [variables](https://grafana.com/docs/grafana/la
 
 #### Ad Hoc filter
 You can use [Ad Hoc filters](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#add-ad-hoc-filters) to filter logs in Dashboards.
-Ad Hoc filters are applied to all panels in the Dashboard as [extra_filters](https://docs.victoriametrics.com/victorialogs/querying/#extra-filters) query parameter. If you navigate to the Explore page from the Dashboard, Ad Hoc filters are also applied there.
+By default, ad-hoc filters are applied to all panels in the Dashboard as the [extra_filters](https://docs.victoriametrics.com/victorialogs/querying/#extra-filters) query parameter. If you navigate to the Explore page from the Dashboard, ad-hoc filters are also applied there.
 <img alt="Ad hoc filters" src="https://github.com/VictoriaMetrics/victorialogs-datasource/blob/main/src/img/extra_filters_explore_page.png?raw=true">
+
+##### Ad-hoc filters mode
+
+> **Note:** available since [v0.28.0](https://github.com/VictoriaMetrics/victorialogs-datasource/releases/tag/v0.28.0).
+
+Each panel exposes an **Ad-hoc filters** selector in the Query Editor *Options* section that controls how ad-hoc values reach the query:
+
+* **Extra Filters** — *default*. Filters are sent as the `extra_filters` query parameter. They are applied at the top of the pipeline and do **not** propagate into `join` / `union` subqueries.
+* **Root Query** — filters are prepended to the query expression (e.g. `level:="error" | <your-query>`). Use this when you want ad-hoc values to participate in the main pipeline as ordinary filters.
+* **Off** — disables automatic ad-hoc filter injection for the panel. Choose this when you intentionally interpolate ad-hoc values yourself (e.g. through template variables) to avoid double filtering, or when filtering on fields produced by pipe transformations would silently drop all rows.
 
 
 #### Word filter

--- a/src/components/QueryEditor/QueryEditorOptions.tsx
+++ b/src/components/QueryEditor/QueryEditorOptions.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from 'react';
 
 import { CoreApp, isValidGrafanaDuration, SelectableValue } from '@grafana/data';
-import { AutoSizeInput, InlineSwitch, Input, RadioButtonGroup, TextLink } from '@grafana/ui';
+import { AutoSizeInput, Input, RadioButtonGroup, TextLink } from '@grafana/ui';
 
 import { VICTORIA_LOGS_DOCS_HOST } from '../../conf';
 import { LOGS_LIMIT_HARD_CAP, LOGS_LIMIT_WARNING_THRESHOLD } from '../../constants';
-import { Query, QueryType } from '../../types';
+import { resolveAdHocFiltersMode } from '../../datasource';
+import { AdHocFiltersMode, Query, QueryType } from '../../types';
 import { isVariable } from '../../utils/isVariable';
 import { useMaxLinesWarning } from '../shared/shared/useMaxLinesWarning';
 
@@ -38,6 +39,12 @@ export const queryTypeOptions: Array<SelectableValue<QueryType>> = [
     label: 'Instant',
     description: 'Use `/select/logsql/stats_query` for querying log stats at the given time.'
   },
+];
+
+const adHocFiltersModeOptions: Array<SelectableValue<AdHocFiltersMode>> = [
+  { value: AdHocFiltersMode.ExtraFilters, label: 'Extra Filters' },
+  { value: AdHocFiltersMode.RootQuery, label: 'Root Query' },
+  { value: AdHocFiltersMode.Off, label: 'Off' },
 ];
 
 export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onChange, onRunQuery }) => {
@@ -94,8 +101,8 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
     onRunQuery();
   };
 
-  const onFiltersToRootQueryChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
-    onChange({ ...query, isApplyExtraFiltersToRootQuery: e.currentTarget.checked });
+  const onAdHocFiltersModeChange = (value: AdHocFiltersMode) => {
+    onChange({ ...query, adHocFiltersMode: value, isApplyExtraFiltersToRootQuery: undefined });
     onRunQuery();
   };
 
@@ -169,12 +176,13 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
         )}
         {app !== CoreApp.Explore && (
           <EditorField
-            label='Ad-hoc filters to root query'
-            tooltip='When enabled, ad-hoc filters are prepended to the query expression instead of being sent as extra_filters parameter. This prevents filters from propagating into join/union subqueries.'
+            label='Ad-hoc filters'
+            tooltip='Controls how ad-hoc filters are applied. "Extra Filters" sends them as a query parameter (default). "Root Query" prepends them to the query expression. "Off" disables automatic injection entirely.'
           >
-            <InlineSwitch
-              value={query.isApplyExtraFiltersToRootQuery ?? false}
-              onChange={onFiltersToRootQueryChange}
+            <RadioButtonGroup
+              options={adHocFiltersModeOptions}
+              value={resolveAdHocFiltersMode(query)}
+              onChange={onAdHocFiltersModeChange}
             />
           </EditorField>
         )}
@@ -211,11 +219,9 @@ function getCollapsedInfo({ app, query, queryType, maxLines, isValidStep }: Coll
   }
 
   if (app !== CoreApp.Explore) {
-    if (query.isApplyExtraFiltersToRootQuery) {
-      items.push('Ad-hoc filters: root query');
-    } else {
-      items.push('Ad-hoc filters: extra_filters');
-    }
+    const mode = resolveAdHocFiltersMode(query);
+    const modeLabel = adHocFiltersModeOptions.find(o => o.value === mode)?.label ?? mode;
+    items.push(`Ad-hoc filters: ${modeLabel}`);
   }
 
   return items;

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -13,8 +13,8 @@ import { createDatasource } from './__mocks__/datasource';
 import { LogLevelRuleType } from './configuration/LogLevelRules/types';
 import { OpenTelemetryPreset } from './configuration/OpenTelemetryPreset/types';
 import { LOGS_LIMIT_HARD_CAP, TEXT_FILTER_ALL_VALUE, VARIABLE_ALL_VALUE } from './constants';
-import { VictoriaLogsDatasource } from './datasource';
-import { FilterActionType, Query, QueryType, SupportingQueryType, ToggleFilterAction } from './types';
+import { resolveAdHocFiltersMode, VictoriaLogsDatasource } from './datasource';
+import { AdHocFiltersMode, FilterActionType, Query, QueryType, SupportingQueryType, ToggleFilterAction } from './types';
 
 const replaceMock = jest.fn().mockImplementation((a: string) => a);
 
@@ -210,7 +210,117 @@ describe('VictoriaLogsDatasource', () => {
       expect(replacedQuery.expr).toBe('baz: "foo" AND qux: "bar"');
     });
 
-    it('should apply ad-hoc filters to root query when isApplyExtraFiltersToRootQuery is true', () => {
+    it('should apply ad-hoc filters to root query when adHocFiltersMode is rootQuery', () => {
+      const adhocFilters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+      ];
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery },
+        {},
+        adhocFilters
+      );
+      expect(replacedQuery.expr).toBe('level:="error" | _time:5m');
+      expect(replacedQuery.extraFilters).toBeUndefined();
+    });
+
+    it('should apply ad-hoc filters as extra_filters when adHocFiltersMode is extraFilters', () => {
+      const adhocFilters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+      ];
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.ExtraFilters },
+        {},
+        adhocFilters
+      );
+      expect(replacedQuery.expr).toBe('_time:5m');
+      expect(replacedQuery.extraFilters).toBe('level:="error"');
+    });
+
+    it('should not apply ad-hoc filters when adHocFiltersMode is off', () => {
+      const adhocFilters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+      ];
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.Off },
+        {},
+        adhocFilters
+      );
+      expect(replacedQuery.expr).toBe('_time:5m');
+      expect(replacedQuery.extraFilters).toBeUndefined();
+    });
+
+    it('should apply multiple ad-hoc filters to root query when adHocFiltersMode is rootQuery', () => {
+      const adhocFilters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+        { key: 'app', operator: '!=', value: 'test' },
+      ];
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery },
+        {},
+        adhocFilters
+      );
+      expect(replacedQuery.expr).toBe('level:="error" AND app:!="test" | _time:5m');
+      expect(replacedQuery.extraFilters).toBeUndefined();
+    });
+
+    it('should handle rootQuery mode when no ad-hoc filters are present', () => {
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery },
+        {}
+      );
+      expect(replacedQuery.expr).toBe('_time:5m');
+      expect(replacedQuery.extraFilters).toBeUndefined();
+    });
+
+    it('should preserve existing adHocFilters and apply them to root query in rootQuery mode', () => {
+      const adhocFilters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+      ];
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const replacedQuery = ds.applyTemplateVariables(
+        {
+          expr: '_time:5m',
+          refId: 'A',
+          adHocFilters: [{ key: 'app', operator: '=', value: 'frontend' }],
+          adHocFiltersMode: AdHocFiltersMode.RootQuery,
+        },
+        {},
+        adhocFilters
+      );
+      expect(replacedQuery.expr).toBe('app:="frontend" AND level:="error" | _time:5m');
+      expect(replacedQuery.extraFilters).toBeUndefined();
+    });
+
+    it('should fall back to legacy isApplyExtraFiltersToRootQuery when adHocFiltersMode is not set', () => {
       const adhocFilters: AdHocVariableFilter[] = [
         { key: 'level', operator: '=', value: 'error' },
       ];
@@ -319,6 +429,23 @@ describe('VictoriaLogsDatasource', () => {
       ];
       const result = ds.getExtraFilters(filters);
       expect(result).toBe('key1:="value1" AND key2:!="value2"');
+    });
+  });
+
+  describe('resolveAdHocFiltersMode', () => {
+    it('should return adHocFiltersMode when set', () => {
+      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', adHocFiltersMode: AdHocFiltersMode.Off })).toBe(AdHocFiltersMode.Off);
+      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery })).toBe(AdHocFiltersMode.RootQuery);
+      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', adHocFiltersMode: AdHocFiltersMode.ExtraFilters })).toBe(AdHocFiltersMode.ExtraFilters);
+    });
+
+    it('should fall back to legacy isApplyExtraFiltersToRootQuery', () => {
+      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', isApplyExtraFiltersToRootQuery: true })).toBe(AdHocFiltersMode.RootQuery);
+      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', isApplyExtraFiltersToRootQuery: false })).toBe(AdHocFiltersMode.ExtraFilters);
+    });
+
+    it('should default to extraFilters when neither field is set', () => {
+      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A' })).toBe(AdHocFiltersMode.ExtraFilters);
     });
   });
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -57,6 +57,7 @@ import { removeDoubleQuotesAroundVar } from './parsing';
 import { replaceOperatorWithIn, returnVariables } from './parsingUtils';
 import { transformBackendResult } from './transformers';
 import {
+  AdHocFiltersMode,
   DerivedFieldConfig,
   FilterActionType,
   FilterFieldType,
@@ -229,12 +230,17 @@ export class VictoriaLogsDatasource
       },
     };
 
-    const baseAdHocExpr = serializeAdHocFilters(target.adHocFilters) ?? '';
-    let extraFilters = this.getExtraFilters(adhocFilters, baseAdHocExpr);
+    const mode = resolveAdHocFiltersMode(target);
     let expr = this.interpolateString(target.expr, variables);
-    if (target.isApplyExtraFiltersToRootQuery && extraFilters) {
-      expr = `${extraFilters} | ${expr}`;
-      extraFilters = undefined;
+    let extraFilters: string | undefined;
+    if (mode !== AdHocFiltersMode.Off) {
+      const baseAdHocExpr = serializeAdHocFilters(target.adHocFilters) ?? '';
+      const filters = this.getExtraFilters(adhocFilters, baseAdHocExpr);
+      if (mode === AdHocFiltersMode.RootQuery && filters) {
+        expr = `${filters} | ${expr}`;
+      } else if (mode === AdHocFiltersMode.ExtraFilters) {
+        extraFilters = filters;
+      }
     }
 
     const extraStreamFilters = this.getExtraStreamFilters(target.streamFilters, scopedVars);
@@ -642,4 +648,11 @@ export class VictoriaLogsDatasource
       [TenantHeaderNames.ProjectID]: formatTenantId(multitenancyHeaders?.ProjectID),
     };
   }
+}
+
+export function resolveAdHocFiltersMode(query: Query): AdHocFiltersMode {
+  if (query.adHocFiltersMode) {
+    return query.adHocFiltersMode;
+  }
+  return query.isApplyExtraFiltersToRootQuery ? AdHocFiltersMode.RootQuery : AdHocFiltersMode.ExtraFilters;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,12 @@ export enum QueryEditorMode {
   Code = 'code',
 }
 
+export enum AdHocFiltersMode {
+  ExtraFilters = 'extraFilters',
+  RootQuery = 'rootQuery',
+  Off = 'off',
+}
+
 export type Format = 'histogram';
 
 export type StreamFilterOperator = 'in';
@@ -89,8 +95,9 @@ export interface Query extends DataQuery {
   fields?: string[];
   /** timezone offset for bucket alignment in stats_query_range and hits endpoints (e.g. "2h", "-5h30m") */
   timezoneOffset?: string;
-  /** if true, adhoc filters will be applied as the root filter, otherwise as an extra_filters */
+  /** @deprecated Use adHocFiltersMode instead */
   isApplyExtraFiltersToRootQuery?: boolean;
+  adHocFiltersMode?: AdHocFiltersMode;
   /** shows which format of data is used */
   format?: Format;
   /** Template builder state */


### PR DESCRIPTION
Related issue: #633

### Describe Your Changes

Replace the binary "Ad-hoc filters to root query" toggle with a three-option selector so users can disable automatic ad-hoc filter injection entirely. This prevents double-filtering when users manage ad-hoc values through Grafana variable interpolation and avoids silent empty results when filtering on pipe-transformed fields.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a three-option “Ad‑hoc filters” mode (Extra Filters, Root Query, Off) to replace the old toggle. Lets users disable automatic injection to avoid double-filtering with variables and empty results with pipe-transformed fields. Related to #633.

- **New Features**
  - New `adHocFiltersMode` with `extraFilters`, `rootQuery`, `off`; legacy `isApplyExtraFiltersToRootQuery` still supported via `resolveAdHocFiltersMode`.
  - Query Editor shows a radio selector and displays the selected mode in the collapsed summary.
  - Datasource behavior:
    - Extra Filters → send as `extra_filters`.
    - Root Query → prepend to `expr` (prevents propagation into `join`/`union` subqueries) and omit `extraFilters`; preserves existing `adHocFilters`.
    - Off → no ad‑hoc filters injected.
  - Docs: README and CHANGELOG updated to explain the new modes.
  - Tests cover all modes, multiple/no filters, and legacy fallback.

- **Migration**
  - Existing queries keep their behavior: default to Extra Filters unless the legacy flag is true (then Root Query).
  - If you manage filters via Grafana variables, set mode to Off to prevent duplicates.

<sup>Written for commit 4cd3254a9ff572820ff15ca15521026c102a43b3. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victorialogs-datasource/pull/634?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

