### PR TITLE
feat(QueryEditor): validate ad-hoc filters against via known field names from `field_names` request

### DIFF
--- a/src/components/QueryEditor/AdHocFiltersControl.tsx
+++ b/src/components/QueryEditor/AdHocFiltersControl.tsx
@@ -1,100 +1,81 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React, { useMemo } from 'react';
 
-import { CoreApp, GrafanaTheme2 } from '@grafana/data';
-import { Button, Icon, useStyles2 } from '@grafana/ui';
+import { CoreApp, GrafanaTheme2, TimeRange } from '@grafana/data';
+import { Button, Icon, Tooltip, useStyles2 } from '@grafana/ui';
 
-import { FilterVisualQuery, Query } from '../../types';
-import { buildVisualQueryFromString } from '../../utils/query/parseFromString';
+import { VictoriaLogsDatasource } from '../../datasource';
+import { addLabelToQuery } from '../../modifyQuery';
+import { Query } from '../../types';
+import {
+  appendFilterPipeToQuery,
+  formatAdHocFilterLabel,
+  queryHasPipes,
+} from '../../utils/query/adHocFilters';
+
+import { useAdHocFilterValidation } from './useAdHocFilterValidation';
 
 interface AdHocFiltersControlProps {
+  datasource: VictoriaLogsDatasource;
   query: Query;
+  timeRange?: TimeRange;
   app?: CoreApp;
   onChange: (query: Query) => void;
   onRunQuery: () => void;
 }
 
+const buildInvalidFieldTooltip = (key: string): string =>
+  `Field "${key}" is produced by the query (e.g. by extract, unpack or another pipe) and doesn't exist in the source data.
+   The ad-hoc filter is applied at the source level,
+    so it will filter out the rows needed to produce this field — your results will be empty or incorrect.
+   To fix this, use the "Move to query" button — it will append this filter as a post-filter pipe (\`| filter ...\`) at the end of the query,
+    so it runs after the pipes that produce the field.
+   You can also add the filter manually at the appropriate position in the query expression.`;
+
 export const AdHocFiltersControl: React.FC<AdHocFiltersControlProps> = ({
+  datasource,
   query,
+  timeRange,
   app,
   onChange,
   onRunQuery,
 }) => {
   const styles = useStyles2(getStyles);
 
-  // Parse extra_filters into individual filter strings
-  const adHocFilters = useMemo(() => {
-    if (!query.extraFilters) {
-      return [];
-    }
+  const filters = useMemo(() => query.adHocFilters ?? [], [query.adHocFilters]);
 
-    try {
-      const parsed = buildVisualQueryFromString(query.extraFilters);
-      const filters: string[] = [];
+  const fieldNames = useMemo(() => Array.from(new Set(filters.map((f) => f.key))), [filters]);
+  const validation = useAdHocFilterValidation({ datasource, query, timeRange, fieldNames });
 
-      // Extract individual filter values from the parsed structure
-      const extractFilters = (values: (string | FilterVisualQuery)[]) => {
-        for (const value of values) {
-          if (typeof value === 'string') {
-            // Only add if it looks like a complete filter (has a colon)
-            if (value.includes(':')) {
-              filters.push(value);
-            }
-          } else if (value && typeof value === 'object' && value.values) {
-            // Recursively extract from nested filters
-            extractFilters(value.values);
-          }
-        }
-      };
-
-      extractFilters(parsed.query.filters.values);
-      return filters;
-    } catch (e) {
-      console.error('Failed to parse extra_filters:', e);
-      return [];
-    }
-  }, [query.extraFilters]);
-
-  const handleDeleteFilter = (filterToDelete: string) => {
-    if (!query.extraFilters) {
-      return;
-    }
-
-    const remainingFilters = adHocFilters.filter(f => f !== filterToDelete);
-    const newExtraFilters = remainingFilters.join(' AND ');
-
-    onChange({
-      ...query,
-      extraFilters: newExtraFilters || undefined,
-    });
+  const handleDeleteFilter = (index: number) => {
+    const next = filters.filter((_, i) => i !== index);
+    onChange({ ...query, adHocFilters: next.length ? next : undefined });
     onRunQuery();
   };
 
-  const handleMoveToQuery = (filterToMove: string) => {
-    if (!query.extraFilters) {
+  const handleMoveToQuery = (index: number) => {
+    const filter = filters[index];
+    if (!filter) {
       return;
     }
-
-    // Remove from extra_filters
-    const remainingFilters = adHocFilters.filter(f => f !== filterToMove);
-    const newExtraFilters = remainingFilters.join(' AND ');
-
-    // Add to query expression
     const currentExpr = query.expr?.trim() || '*';
-    const newExpr = currentExpr === '*'
-      ? filterToMove
-      : `${filterToMove} AND ${currentExpr}`;
-
+    const isInvalid = validation[filter.key] === 'invalid';
+    const filterStr = formatAdHocFilterLabel(filter);
+    const newExpr = isInvalid
+      ? appendFilterPipeToQuery(currentExpr, filter)
+      : currentExpr === '*'
+        ? filterStr
+        : addLabelToQuery(currentExpr, filter);
+    const next = filters.filter((_, i) => i !== index);
     onChange({
       ...query,
       expr: newExpr,
-      extraFilters: newExtraFilters || undefined,
+      adHocFilters: next.length ? next : undefined,
     });
     onRunQuery();
   };
 
-  // Only show on Explore page and when there are filters
-  if (app !== CoreApp.Explore || adHocFilters.length === 0) {
+  if (app !== CoreApp.Explore || filters.length === 0) {
     return null;
   }
 
@@ -104,31 +85,55 @@ export const AdHocFiltersControl: React.FC<AdHocFiltersControlProps> = ({
         <Icon name='filter' size='sm' />
         <span>Ad-hoc filters:</span>
       </div>
-      {adHocFilters.map((filter, index) => (
-        <div key={index} className={styles.adHocFilterItem}>
-          <span className={styles.filterText}>{filter}</span>
-          <div className={styles.filterActions}>
-            <Button
-              size='sm'
-              variant='secondary'
-              onClick={() => handleMoveToQuery(filter)}
-              tooltip='Move to query'
-              fill='text'
-            >
-              <Icon name='arrow-up' />
-            </Button>
-            <Button
-              size='sm'
-              variant='secondary'
-              onClick={() => handleDeleteFilter(filter)}
-              tooltip='Delete filter'
-              fill='text'
-            >
-              <Icon name='times' />
-            </Button>
+      {filters.map((filter, index) => {
+        const isInvalid = validation[filter.key] === 'invalid';
+        const willAppendAsPipe = isInvalid && queryHasPipes(query.expr ?? '');
+        const moveTooltip = willAppendAsPipe ? (
+          <>
+            Append as a post-filter pipe at the end of the query:
+            <br />
+            <code>| filter {formatAdHocFilterLabel(filter)}</code>
+          </>
+        ) : (
+          'Move to query'
+        );
+        const chip = (
+          <div className={cx(styles.adHocFilterItem, isInvalid && styles.adHocFilterItemInvalid)}>
+            {isInvalid && (
+              <Icon name='exclamation-triangle' className={styles.warningIcon} size='sm' />
+            )}
+            <span className={styles.filterText}>{formatAdHocFilterLabel(filter)}</span>
+            <div className={styles.filterActions}>
+              <Button
+                size='sm'
+                variant='secondary'
+                onClick={() => handleMoveToQuery(index)}
+                tooltip={moveTooltip}
+                fill='text'
+              >
+                <Icon name='arrow-up' />
+              </Button>
+              <Button
+                size='sm'
+                variant='secondary'
+                onClick={() => handleDeleteFilter(index)}
+                tooltip='Delete filter'
+                fill='text'
+              >
+                <Icon name='times' />
+              </Button>
+            </div>
           </div>
-        </div>
-      ))}
+        );
+
+        return isInvalid ? (
+          <Tooltip key={index} content={buildInvalidFieldTooltip(filter.key)} placement='top'>
+            {chip}
+          </Tooltip>
+        ) : (
+          <React.Fragment key={index}>{chip}</React.Fragment>
+        );
+      })}
     </div>
   );
 };
@@ -171,6 +176,17 @@ const getStyles = (theme: GrafanaTheme2) => {
         border-color: ${theme.colors.border.medium};
       }
     `,
+    adHocFilterItemInvalid: css`
+      border-color: ${theme.colors.warning.border};
+      background-color: ${theme.colors.warning.transparent};
+
+      &:hover {
+        border-color: ${theme.colors.warning.text};
+      }
+    `,
+    warningIcon: css`
+      color: ${theme.colors.warning.text};
+    `,
     filterText: css`
       color: ${theme.colors.text.primary};
       white-space: nowrap;
@@ -181,11 +197,11 @@ const getStyles = (theme: GrafanaTheme2) => {
       align-items: center;
       padding-left: ${theme.spacing(0.25)};
       border-left: 1px solid ${theme.colors.border.weak};
-      
+
       button {
         padding: 0 ${theme.spacing(0.25)};
         color: ${theme.colors.text.secondary};
-        
+
         &:hover {
           color: ${theme.colors.text.primary};
         }

--- a/src/components/QueryEditor/QueryCodeEditor.tsx
+++ b/src/components/QueryEditor/QueryCodeEditor.tsx
@@ -6,7 +6,6 @@ import { useStyles2 } from '@grafana/ui';
 
 import { VictoriaLogsQueryEditorProps } from '../../types';
 
-import { AdHocFiltersControl } from './AdHocFiltersControl';
 import QueryField from './QueryField';
 
 type Props = VictoriaLogsQueryEditorProps & {
@@ -28,16 +27,6 @@ const QueryCodeEditor = (props: Props) => {
         history={history}
         data={data}
         app={app}
-        ExtraFieldElement={
-          query.extraFilters && (
-            <AdHocFiltersControl
-              query={query}
-              app={app}
-              onChange={onChange}
-              onRunQuery={onRunQuery}
-            />
-          )
-        }
       />
     </div>
   );

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -11,6 +11,7 @@ import { TEXT_FILTER_ALL_VALUE } from '../../constants';
 import { Query, QueryEditorMode, QueryType, VictoriaLogsQueryEditorProps } from '../../types';
 import QueryEditorStatsWarn from '../QueryEditorStatsWarn';
 
+import { AdHocFiltersControl } from './AdHocFiltersControl';
 import { EditorHeader } from './EditorHeader';
 import QueryCodeEditor from './QueryCodeEditor';
 import { QueryEditorOptions } from './QueryEditorOptions';
@@ -162,6 +163,16 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
               )}
               <QueryCodeEditor {...props} query={query} onChange={onChangeInternal} showExplain={true} />
             </>
+          )}
+          {query.adHocFilters && query.adHocFilters.length > 0 && app === CoreApp.Explore && (
+            <AdHocFiltersControl
+              datasource={datasource}
+              query={query}
+              timeRange={props.range}
+              app={app}
+              onChange={onChange}
+              onRunQuery={onRunQuery}
+            />
           )}
           {varRegExp && (<QueryEditorVariableRegexpError regExp={varRegExp} query={query} onChange={onChange} />)}
           {showStatsWarn && (<QueryEditorStatsWarn queryType={query.queryType} />)}

--- a/src/components/QueryEditor/QueryField.tsx
+++ b/src/components/QueryEditor/QueryField.tsx
@@ -7,13 +7,11 @@ import { Options, Query } from '../../types';
 import { MonacoQueryFieldWrapper } from '../monaco-query-field/MonacoQueryFieldWrapper';
 
 export interface QueryFieldProps extends QueryEditorProps<VictoriaLogsDatasource, Query, Options> {
-  ExtraFieldElement?: React.ReactNode;
   'data-testid'?: string;
 }
 
 const QueryField: React.FC<QueryFieldProps> = (
   {
-    ExtraFieldElement,
     query,
     history,
     onRunQuery,
@@ -42,7 +40,6 @@ const QueryField: React.FC<QueryFieldProps> = (
           />
         </div>
       </div>
-      {ExtraFieldElement}
     </>
   );
 };

--- a/src/components/QueryEditor/useAdHocFilterValidation.ts
+++ b/src/components/QueryEditor/useAdHocFilterValidation.ts
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { TimeRange } from '@grafana/data';
+
+import { VictoriaLogsDatasource } from '../../datasource';
+import { FilterFieldType, Query } from '../../types';
+import { LRUCache } from '../../utils/LRUCache';
+import { bucketTimeRange } from '../../utils/timeUtils';
+
+import { buildStreamExtraFilters } from './shared/streamFilterUtils';
+
+const FIELD_NAMES_BATCH_LIMIT = 10_000;
+const BUCKET_CACHE_SIZE = 16;
+
+export type AdHocFilterValidationState = 'loading' | 'valid' | 'invalid';
+
+interface Args {
+  datasource: VictoriaLogsDatasource;
+  query: Query;
+  timeRange?: TimeRange;
+  fieldNames: string[];
+}
+
+type KnownFields = Set<string> | 'errored' | undefined;
+
+const streamFiltersKey = (filters: Query['streamFilters']): string =>
+  (filters ?? []).map((f) => `${f.label}|${f.operator}|${f.values.join(',')}`).join(';');
+
+const withExtraStreamFilters = (
+  base: URLSearchParams | undefined,
+  extra: string | undefined,
+): URLSearchParams | undefined => {
+  if (!extra) {
+    return base;
+  }
+  const params = new URLSearchParams(base);
+  params.set('extra_stream_filters', extra);
+  return params;
+};
+
+export const useAdHocFilterValidation = ({
+  datasource,
+  query,
+  timeRange,
+  fieldNames,
+}: Args): Record<string, AdHocFilterValidationState> => {
+  const [known, setKnown] = useState<KnownFields>(undefined);
+  const cacheRef = useRef(new LRUCache<Set<string>>(BUCKET_CACHE_SIZE));
+  const requestIdRef = useRef(0);
+
+  const bucketed = useMemo(
+    () => (timeRange ? bucketTimeRange(timeRange) : undefined),
+    [timeRange],
+  );
+
+  const cacheKey = `${bucketed?.from.valueOf() ?? ''}::${bucketed?.to.valueOf() ?? ''}::${streamFiltersKey(query.streamFilters)}`;
+  const hasFields = fieldNames.length > 0;
+
+  useEffect(() => {
+    if (!hasFields) {
+      return;
+    }
+
+    const cached = cacheRef.current.get(cacheKey);
+    if (cached) {
+      setKnown(cached);
+      return;
+    }
+
+    // Drop stale data from a previous query context while the new fetch is in flight.
+    setKnown(undefined);
+
+    const provider = datasource.languageProvider;
+    if (!provider) {
+      return;
+    }
+
+    const interpolate = (s: string) => datasource.interpolateString(s);
+    const extraStreamFilters = buildStreamExtraFilters(query.streamFilters ?? []) || undefined;
+    const customParams = withExtraStreamFilters(
+      datasource.customQueryParameters,
+      extraStreamFilters ? interpolate(extraStreamFilters) : undefined,
+    );
+
+    const requestId = ++requestIdRef.current;
+
+    provider
+      .getFieldList(
+        {
+          type: FilterFieldType.FieldName,
+          query: '*',
+          timeRange: bucketed,
+          limit: FIELD_NAMES_BATCH_LIMIT,
+        },
+        customParams,
+      )
+      .then((list) => {
+        const set = new Set((list ?? []).map((h) => h.value));
+        // Always populate the LRU keyed by the captured cacheKey, even if this
+        // request is no longer the latest — the data is still correct for that key.
+        cacheRef.current.set(cacheKey, set);
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        setKnown(set);
+      })
+      .catch(() => {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        // Network/server failure — fall back to 'valid' for all and skip caching.
+        setKnown('errored');
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasource, cacheKey, hasFields]);
+
+  return useMemo<Record<string, AdHocFilterValidationState>>(() => {
+    if (!hasFields || known === undefined) {
+      return {};
+    }
+    const interpolate = (s: string) => datasource.interpolateString(s);
+    return Object.fromEntries(
+      fieldNames.map((name): [string, AdHocFilterValidationState] => {
+        const interpolated = interpolate(name);
+        if (interpolated.includes('$') || known === 'errored') {
+          return [name, 'valid'];
+        }
+        return [name, known.has(interpolated) ? 'valid' : 'invalid'];
+      }),
+    );
+  }, [fieldNames, hasFields, known, datasource]);
+};

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -279,7 +279,7 @@ describe('VictoriaLogsDatasource', () => {
       expect(replacedQuery.extraFilters).toBeUndefined();
     });
 
-    it('should preserve existing extraFilters and apply them to root query when isApplyExtraFiltersToRootQuery is true', () => {
+    it('should preserve existing adHocFilters and apply them to root query when isApplyExtraFiltersToRootQuery is true', () => {
       const adhocFilters: AdHocVariableFilter[] = [
         { key: 'level', operator: '=', value: 'error' },
       ];
@@ -289,7 +289,12 @@ describe('VictoriaLogsDatasource', () => {
       } as unknown as TemplateSrv;
       const ds = createDatasource(templateSrvMock);
       const replacedQuery = ds.applyTemplateVariables(
-        { expr: '_time:5m', refId: 'A', extraFilters: 'app:="frontend"', isApplyExtraFiltersToRootQuery: true },
+        {
+          expr: '_time:5m',
+          refId: 'A',
+          adHocFilters: [{ key: 'app', operator: '=', value: 'frontend' }],
+          isApplyExtraFiltersToRootQuery: true,
+        },
         {},
         adhocFilters
       );
@@ -433,31 +438,42 @@ describe('VictoriaLogsDatasource', () => {
       value = 'error',
     ): ToggleFilterAction => ({ type, options: { key, value } });
 
-    it('adds FILTER_FOR into extraFilters when extraFilters is empty', () => {
+    it('adds FILTER_FOR into adHocFilters when adHocFilters is empty', () => {
       const query: Query = { refId: 'A', expr: '_time:5m' };
       const result = ds.toggleQueryFilter(query, makeFilter(FilterActionType.FILTER_FOR));
-      expect(result.extraFilters).toBe('level:="error"');
+      expect(result.adHocFilters).toEqual([{ key: 'level', operator: '=', value: 'error' }]);
       expect(result.expr).toBe('_time:5m');
     });
 
     it('adds FILTER_OUT with != operator', () => {
       const query: Query = { refId: 'A', expr: '' };
       const result = ds.toggleQueryFilter(query, makeFilter(FilterActionType.FILTER_OUT));
-      expect(result.extraFilters).toBe('level:!="error"');
+      expect(result.adHocFilters).toEqual([{ key: 'level', operator: '!=', value: 'error' }]);
       expect(result.expr).toBe('*');
     });
 
-    it('appends to existing extraFilters via AND', () => {
-      const query: Query = { refId: 'A', expr: '*', extraFilters: 'app:="api"' };
+    it('appends to existing adHocFilters', () => {
+      const query: Query = {
+        refId: 'A',
+        expr: '*',
+        adHocFilters: [{ key: 'app', operator: '=', value: 'api' }],
+      };
       const result = ds.toggleQueryFilter(query, makeFilter(FilterActionType.FILTER_FOR));
-      expect(result.extraFilters).toBe('app:="api" AND level:="error"');
+      expect(result.adHocFilters).toEqual([
+        { key: 'app', operator: '=', value: 'api' },
+        { key: 'level', operator: '=', value: 'error' },
+      ]);
       expect(result.expr).toBe('*');
     });
 
     it('toggles off existing FILTER_FOR (second click removes it)', () => {
-      const query: Query = { refId: 'A', expr: '*', extraFilters: 'level:="error"' };
+      const query: Query = {
+        refId: 'A',
+        expr: '*',
+        adHocFilters: [{ key: 'level', operator: '=', value: 'error' }],
+      };
       const result = ds.toggleQueryFilter(query, makeFilter(FilterActionType.FILTER_FOR));
-      expect(result.extraFilters).toBeUndefined();
+      expect(result.adHocFilters).toBeUndefined();
       expect(result.expr).toBe('*');
     });
 
@@ -465,7 +481,7 @@ describe('VictoriaLogsDatasource', () => {
       const query: Query = { refId: 'A', expr: 'level:="error"' };
       const result = ds.toggleQueryFilter(query, makeFilter(FilterActionType.FILTER_FOR));
       expect(result.expr).toBe('level:="error"');
-      expect(result.extraFilters).toBe('level:="error"');
+      expect(result.adHocFilters).toEqual([{ key: 'level', operator: '=', value: 'error' }]);
     });
 
     it('returns query unchanged when key or value is missing', () => {
@@ -477,13 +493,15 @@ describe('VictoriaLogsDatasource', () => {
       expect(result).toEqual(query);
     });
 
-    it('normalizes keys with colons (e.g. span:attr_id)', () => {
+    it('preserves keys with colons in adHocFilters as-is', () => {
       const query: Query = { refId: 'A', expr: '' };
       const result = ds.toggleQueryFilter(
         query,
         makeFilter(FilterActionType.FILTER_FOR, 'span:attr_id', '123'),
       );
-      expect(result.extraFilters).toBe('"span:attr_id":="123"');
+      expect(result.adHocFilters).toEqual([
+        { key: 'span:attr_id', operator: '=', value: '123' },
+      ]);
     });
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -52,8 +52,6 @@ import {
   addLabelToQuery,
   addSortPipeToQuery,
   getQueryFormat,
-  queryHasFilter,
-  removeLabelFromQuery,
 } from './modifyQuery';
 import { removeDoubleQuotesAroundVar } from './parsing';
 import { replaceOperatorWithIn, returnVariables } from './parsingUtils';
@@ -67,6 +65,7 @@ import {
   Query,
   QueryBuilderLimits,
   QueryEditorMode,
+  QueryFilterOptions,
   QueryType,
   StreamFilterState,
   SupportingQueryType,
@@ -75,6 +74,7 @@ import {
   ToggleFilterAction,
   VariableQuery,
 } from './types';
+import { serializeAdHocFilters } from './utils/query/adHocFilters';
 import { formatOffsetDuration, getMillisecondsFromDuration } from './utils/timeUtils';
 import { VariableSupport } from './variableSupport/VariableSupport';
 
@@ -185,24 +185,29 @@ export class VictoriaLogsDatasource
 
     const { key } = filter.options;
     const value = escapeLabelValueInSelector(filter.options.value);
-    const current = query.extraFilters ?? '';
-    const hasFilter = queryHasFilter(current, key, value);
+    const current = query.adHocFilters ?? [];
+    const exists = current.some((f) => f.key === key && f.value === value);
 
-    let updated = current;
-    if (hasFilter) {
-      updated = removeLabelFromQuery(updated, key, value);
-    }
+    let next = exists ? current.filter((f) => !(f.key === key && f.value === value)) : current;
 
     const isFilterFor = filter.type === FilterActionType.FILTER_FOR;
     const isFilterOut = filter.type === FilterActionType.FILTER_OUT;
 
-    if ((isFilterFor && !hasFilter) || isFilterOut) {
-      const operator = isFilterFor ? '=' : '!=';
-      updated = addLabelToQuery(updated, { key, value, operator });
+    if ((isFilterFor && !exists) || isFilterOut) {
+      next = [...next, { key, value, operator: isFilterFor ? '=' : '!=' }];
     }
 
-    const expr = query.expr || (updated ? '*' : '');
-    return { ...query, expr, extraFilters: updated || undefined };
+    const expr = query.expr || (next.length ? '*' : '');
+    return { ...query, expr, adHocFilters: next.length ? next : undefined };
+  }
+
+  // The `hasToggleableQueryFiltersSupport` type guard checks for both
+  // `toggleQueryFilter` and `queryHasFilter` on the datasource — without this
+  // method the Logs viewer hides the "Filter for / Filter out" icons next to
+  // log field values
+  queryHasFilter(query: Query, filter: QueryFilterOptions): boolean {
+    const value = escapeLabelValueInSelector(filter.value);
+    return (query.adHocFilters ?? []).some((f) => f.key === filter.key && f.value === value);
   }
 
   filterQuery(query: Query): boolean {
@@ -225,7 +230,8 @@ export class VictoriaLogsDatasource
       },
     };
 
-    let extraFilters = this.getExtraFilters(adhocFilters, target.extraFilters);
+    const baseAdHocExpr = serializeAdHocFilters(target.adHocFilters) ?? '';
+    let extraFilters = this.getExtraFilters(adhocFilters, baseAdHocExpr);
     let expr = this.interpolateString(target.expr, variables);
     if (target.isApplyExtraFiltersToRootQuery && extraFilters) {
       expr = `${extraFilters} | ${expr}`;
@@ -240,19 +246,17 @@ export class VictoriaLogsDatasource
       expr,
       extraFilters,
       extraStreamFilters,
+      // Backend protocol uses `extraFilters` (string); the structured array is editor-only
+      adHocFilters: undefined,
     };
   }
 
   getExtraFilters(adhocFilters?: AdHocVariableFilter[], initialExpr = ''): string | undefined {
-    if (!adhocFilters) {
+    if (!adhocFilters?.length) {
       return initialExpr || undefined;
     }
-
-    const expr = adhocFilters.reduce((acc: string, filter: AdHocVariableFilter) => {
-      return addLabelToQuery(acc, filter);
-    }, initialExpr);
-
-    return returnVariables(expr);
+    const expr = adhocFilters.reduce<string>((acc, filter) => addLabelToQuery(acc, filter), initialExpr);
+    return returnVariables(expr) || undefined;
   }
 
   getExtraStreamFilters(streamFilters: StreamFilterState[] | undefined, scopedVars: ScopedVars): string | undefined {
@@ -283,8 +287,9 @@ export class VictoriaLogsDatasource
         datasource: this.getRef(),
         expr: this.interpolateString(query.expr, scopedVars),
         interval: this.templateSrv.replace(query.interval, scopedVars),
-        extraFilters: this.getExtraFilters(filters, query.extraFilters),
-        extraStreamFilters: this.getExtraStreamFilters(query.streamFilters, scopedVars)
+        extraFilters: this.getExtraFilters(filters, serializeAdHocFilters(query.adHocFilters) ?? ''),
+        extraStreamFilters: this.getExtraStreamFilters(query.streamFilters, scopedVars),
+        adHocFilters: undefined,
       }));
     }
     return expandedQueries;

--- a/src/language_provider.ts
+++ b/src/language_provider.ts
@@ -66,7 +66,7 @@ export default class LogsQlLanguageProvider extends LanguageProvider {
       urlParams.append('field', options.field);
     }
 
-    if (options.limit && options.limit > 0 && options.type === FilterFieldType.FieldValue) {
+    if (options.limit && options.limit > 0) {
       urlParams.append('limit', options.limit.toString());
     }
 
@@ -114,7 +114,7 @@ export default class LogsQlLanguageProvider extends LanguageProvider {
       urlParams.append('field', options.field);
     }
 
-    if (options.limit && options.limit > 0 && options.type === FilterFieldType.FieldValue) {
+    if (options.limit && options.limit > 0) {
       urlParams.append('limit', options.limit.toString());
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,17 +57,29 @@ export interface StreamFilterState {
   values: string[];
 }
 
+export type AdHocFilterOperator = '=' | '!=' | '=~' | '!~' | '<' | '>' | '=|' | '!=|';
+
+export interface AdHocFilter {
+  key: string;
+  operator: AdHocFilterOperator;
+  value: string;
+  values?: string[];
+}
+
 export interface Query extends DataQuery {
   editorMode?: QueryEditorMode;
   expr: string;
   legendFormat?: string;
   maxLines?: number;
   step?: string;
+  /** Editor state — structured ad-hoc filter chips. Source of truth in editor; serialized to `extraFilters` only on the request boundary */
+  adHocFilters?: AdHocFilter[];
+  /** serialized adHocFilters for extra_filters query param (set during applyTemplateVariables) */
   extraFilters?: string;
-  /** serialized stream filters for extra_stream_filters query param (set during applyTemplateVariables) */
-  extraStreamFilters?: string;
   /** stream filters stored as structured data, serialized to extraStreamFilters before request */
   streamFilters?: StreamFilterState[];
+  /** serialized stream filters for extra_stream_filters query param (set during applyTemplateVariables) */
+  extraStreamFilters?: string;
   direction?: QueryDirection;
   supportingQueryType?: SupportingQueryType;
   queryType?: QueryType;

--- a/src/utils/query/adHocFilters.test.ts
+++ b/src/utils/query/adHocFilters.test.ts
@@ -1,0 +1,172 @@
+import { AdHocFilter } from '../../types';
+
+import {
+  adHocFilterMatches,
+  appendFilterPipeToQuery,
+  formatAdHocFilterLabel,
+  queryHasPipes,
+  serializeAdHocFilters,
+} from './adHocFilters';
+
+describe('serializeAdHocFilters', () => {
+  it('returns undefined for empty / missing input', () => {
+    expect(serializeAdHocFilters(undefined)).toBeUndefined();
+    expect(serializeAdHocFilters([])).toBeUndefined();
+  });
+
+  it('serializes a single equality filter', () => {
+    const filters: AdHocFilter[] = [{ key: 'service', operator: '=', value: 'api' }];
+    expect(serializeAdHocFilters(filters)).toBe('service:="api"');
+  });
+
+  it('joins multiple filters with AND', () => {
+    const filters: AdHocFilter[] = [
+      { key: 'service', operator: '=', value: 'api' },
+      { key: 'level', operator: '!=', value: 'debug' },
+    ];
+    expect(serializeAdHocFilters(filters)).toBe('service:="api" AND level:!="debug"');
+  });
+
+  it('quotes keys that contain a colon', () => {
+    const filters: AdHocFilter[] = [{ key: 'foo:bar', operator: '=', value: 'baz' }];
+    expect(serializeAdHocFilters(filters)).toBe('"foo:bar":="baz"');
+  });
+
+  it('uses :in(...) for multi-value =| operator', () => {
+    const filters: AdHocFilter[] = [
+      { key: 'level', operator: '=|', value: '', values: ['info', 'warn'] },
+    ];
+    expect(serializeAdHocFilters(filters)).toBe('level:in("info","warn")');
+  });
+
+  it('uses !key:in(...) for multi-value !=| operator', () => {
+    const filters: AdHocFilter[] = [
+      { key: 'level', operator: '!=|', value: '', values: ['info', 'warn'] },
+    ];
+    expect(serializeAdHocFilters(filters)).toBe('!level:in("info","warn")');
+  });
+
+  it('serializes _stream NOT filter with parentheses', () => {
+    const filters: AdHocFilter[] = [{ key: '_stream', operator: '!=', value: 'prod' }];
+    expect(serializeAdHocFilters(filters)).toBe('(! _stream: prod)');
+  });
+
+  it('serializes _stream equality without parentheses', () => {
+    const filters: AdHocFilter[] = [{ key: '_stream', operator: '=', value: 'prod' }];
+    expect(serializeAdHocFilters(filters)).toBe('_stream:prod');
+  });
+});
+
+describe('formatAdHocFilterLabel', () => {
+  it('returns the same shape as a single serialized filter', () => {
+    const f: AdHocFilter = { key: 'service', operator: '=', value: 'api' };
+    expect(formatAdHocFilterLabel(f)).toBe('service:="api"');
+  });
+});
+
+describe('queryHasPipes', () => {
+  it('is false for empty / whitespace', () => {
+    expect(queryHasPipes('')).toBe(false);
+    expect(queryHasPipes('   ')).toBe(false);
+  });
+
+  it('is false for `*` (no upstream to filter)', () => {
+    expect(queryHasPipes('*')).toBe(false);
+  });
+
+  it('is false for a filter expression without pipes', () => {
+    expect(queryHasPipes('service:="api"')).toBe(false);
+    expect(queryHasPipes('service:="api" AND level:="info"')).toBe(false);
+  });
+
+  it('is true when at least one top-level pipe is present', () => {
+    expect(queryHasPipes('* | stats count()')).toBe(true);
+    expect(queryHasPipes('service:="api" | extract "<u>" as user')).toBe(true);
+  });
+
+  it('ignores pipes inside quoted strings or braces', () => {
+    expect(queryHasPipes('{app="a|b"}')).toBe(false);
+    expect(queryHasPipes('msg:~"a|b"')).toBe(false);
+  });
+});
+
+describe('appendFilterPipeToQuery', () => {
+  const eqFilter: AdHocFilter = { key: 'user', operator: '=', value: 'alice' };
+
+  it('returns just the filter when expr is empty', () => {
+    expect(appendFilterPipeToQuery('', eqFilter)).toBe('user:="alice"');
+  });
+
+  it('returns just the filter when expr is `*`', () => {
+    expect(appendFilterPipeToQuery('*', eqFilter)).toBe('user:="alice"');
+  });
+
+  it('falls back to addLabelToQuery when expr has no pipes', () => {
+    expect(appendFilterPipeToQuery('service:="api"', eqFilter)).toBe(
+      'service:="api" AND user:="alice"',
+    );
+  });
+
+  it('appends as `| filter ...` when expr has at least one pipe', () => {
+    expect(
+      appendFilterPipeToQuery('* | extract "<u>" as user', eqFilter),
+    ).toBe('* | extract "<u>" as user | filter user:="alice"');
+  });
+
+  it('appends at the very end, after multiple pipes', () => {
+    expect(
+      appendFilterPipeToQuery(
+        '* | extract "<u>" as user | sort by (_time) desc',
+        eqFilter,
+      ),
+    ).toBe('* | extract "<u>" as user | sort by (_time) desc | filter user:="alice"');
+  });
+
+  it('preserves the operator (!=) in the appended pipe', () => {
+    const f: AdHocFilter = { key: 'user', operator: '!=', value: 'alice' };
+    expect(appendFilterPipeToQuery('* | extract "<u>" as user', f)).toBe(
+      '* | extract "<u>" as user | filter user:!="alice"',
+    );
+  });
+
+  it('preserves the regex operator (=~) in the appended pipe', () => {
+    const f: AdHocFilter = { key: 'user', operator: '=~', value: 'al.*' };
+    expect(appendFilterPipeToQuery('* | extract "<u>" as user', f)).toBe(
+      '* | extract "<u>" as user | filter user:~"al.*"',
+    );
+  });
+
+  it('preserves the multi-value operator (=|) in the appended pipe', () => {
+    const f: AdHocFilter = {
+      key: 'user',
+      operator: '=|',
+      value: '',
+      values: ['alice', 'bob'],
+    };
+    expect(appendFilterPipeToQuery('* | extract "<u>" as user', f)).toBe(
+      '* | extract "<u>" as user | filter user:in("alice","bob")',
+    );
+  });
+
+  it('trims trailing whitespace before appending', () => {
+    expect(
+      appendFilterPipeToQuery('*  |  extract "<u>" as user   ', eqFilter),
+    ).toBe('*  |  extract "<u>" as user | filter user:="alice"');
+  });
+});
+
+describe('adHocFilterMatches', () => {
+  const f: AdHocFilter = { key: 'service', operator: '=', value: 'api' };
+
+  it('matches by exact key and value', () => {
+    expect(adHocFilterMatches(f, 'service', 'api')).toBe(true);
+  });
+
+  it('does not match different key', () => {
+    expect(adHocFilterMatches(f, 'level', 'api')).toBe(false);
+  });
+
+  it('does not match different value', () => {
+    expect(adHocFilterMatches(f, 'service', 'web')).toBe(false);
+  });
+});

--- a/src/utils/query/adHocFilters.ts
+++ b/src/utils/query/adHocFilters.ts
@@ -1,0 +1,44 @@
+import { splitByPipes } from '../../LogsQL/splitByPipes';
+import { addLabelToQuery } from '../../modifyQuery';
+import { AdHocFilter } from '../../types';
+
+export const serializeAdHocFilters = (filters: AdHocFilter[] | undefined): string | undefined => {
+  if (!filters || filters.length === 0) {
+    return undefined;
+  }
+  const result = filters.reduce<string>((acc, f) => addLabelToQuery(acc, f), '');
+  return result || undefined;
+};
+
+export const formatAdHocFilterLabel = (f: AdHocFilter): string => addLabelToQuery('', f);
+
+export const adHocFilterMatches = (f: AdHocFilter, key: string, value: string): boolean =>
+  f.key === key && f.value === value;
+
+
+export const queryHasPipes = (expr: string): boolean => {
+  const trimmed = expr.trim();
+  if (!trimmed || trimmed === '*') {
+    return false;
+  }
+  return splitByPipes(trimmed).length > 1;
+};
+
+// Appends a filter as a post-filter pipe (`| filter <expr>`) at the end of the
+// query so it runs after the pipes that may produce the filtered field. Used
+// for ad-hoc filters whose key is not present in the source data — applying
+// such a filter at the source level (via AND) would drop the rows the pipes
+// need to produce the field. Falls back to the regular insertion when there is
+// nothing for the pipe to act on (empty / `*` / no upstream pipes).
+export const appendFilterPipeToQuery = (expr: string, filter: AdHocFilter): string => {
+  const trimmed = expr.trim();
+  const filterStr = formatAdHocFilterLabel(filter);
+
+  if (!trimmed || trimmed === '*') {
+    return filterStr;
+  }
+  if (!queryHasPipes(trimmed)) {
+    return addLabelToQuery(trimmed, filter);
+  }
+  return `${trimmed} | filter ${filterStr}`;
+};

--- a/src/utils/timeUtils.test.ts
+++ b/src/utils/timeUtils.test.ts
@@ -1,8 +1,19 @@
+import { dateTime, TimeRange } from '@grafana/data';
+
 import {
+  bucketTimeRange,
   formatOffsetDuration,
   getDurationFromMilliseconds,
   getMillisecondsFromDuration,
 } from './timeUtils';
+
+const makeRange = (fromMs: number, toMs: number): TimeRange => {
+  const from = dateTime(fromMs);
+  const to = dateTime(toMs);
+  return { from, to, raw: { from, to } };
+};
+
+const DAY_MS = 86_400_000;
 
 describe('timeUtils', () => {
   describe('getDurationFromMilliseconds', () => {
@@ -120,6 +131,89 @@ describe('timeUtils', () => {
 
     it('should format "5h45m" for Nepal timezone offset', () => {
       expect(formatOffsetDuration('custom', 345)).toBe('5h45m');
+    });
+  });
+
+  describe('bucketTimeRange', () => {
+    it('snaps a 1-hour span to the surrounding UTC day', () => {
+      const from = Date.UTC(2026, 4, 8, 12, 0, 0);
+      const to = Date.UTC(2026, 4, 8, 13, 0, 0);
+      const result = bucketTimeRange(makeRange(from, to));
+      expect(result.from.valueOf()).toBe(Date.UTC(2026, 4, 8));
+      expect(result.to.valueOf()).toBe(Date.UTC(2026, 4, 9) - 1);
+    });
+
+    it('produces the same bucket for 1h, 6h, and 23h ranges within the same UTC day', () => {
+      const day = Date.UTC(2026, 4, 8);
+      const ranges = [
+        bucketTimeRange(makeRange(day + 12 * 3600_000, day + 13 * 3600_000)),
+        bucketTimeRange(makeRange(day + 8 * 3600_000, day + 14 * 3600_000)),
+        bucketTimeRange(makeRange(day, day + 23 * 3600_000)),
+      ];
+      for (const r of ranges) {
+        expect(r.from.valueOf()).toBe(day);
+        expect(r.to.valueOf()).toBe(day + DAY_MS - 1);
+      }
+    });
+
+    it('uses the correct day bucket for ranges shifted into the past', () => {
+      // "Yesterday" 14:00 → 15:00 UTC: bucket must be that previous day, not today.
+      const from = Date.UTC(2026, 4, 7, 14, 0, 0);
+      const to = Date.UTC(2026, 4, 7, 15, 0, 0);
+      const result = bucketTimeRange(makeRange(from, to));
+      expect(result.from.valueOf()).toBe(Date.UTC(2026, 4, 7));
+      expect(result.to.valueOf()).toBe(Date.UTC(2026, 4, 8) - 1);
+    });
+
+    it('snaps a 25-hour span to the surrounding ISO week (Mon..Sun, UTC)', () => {
+      // Wed 2026-05-06 12:00 UTC → Thu 2026-05-07 13:00 UTC (25h)
+      const from = Date.UTC(2026, 4, 6, 12, 0, 0);
+      const to = Date.UTC(2026, 4, 7, 13, 0, 0);
+      const result = bucketTimeRange(makeRange(from, to));
+      // Monday of that week is 2026-05-04
+      expect(result.from.valueOf()).toBe(Date.UTC(2026, 4, 4));
+      expect(result.to.valueOf()).toBe(Date.UTC(2026, 4, 11) - 1);
+    });
+
+    it('snaps a 10-day span to the surrounding calendar month', () => {
+      const from = Date.UTC(2026, 4, 5, 0, 0, 0);
+      const to = Date.UTC(2026, 4, 14, 23, 0, 0);
+      const result = bucketTimeRange(makeRange(from, to));
+      expect(result.from.valueOf()).toBe(Date.UTC(2026, 4, 1));
+      expect(result.to.valueOf()).toBe(Date.UTC(2026, 5, 1) - 1);
+    });
+
+    it('snaps a 60-day span to the surrounding calendar year', () => {
+      const from = Date.UTC(2026, 2, 1, 0, 0, 0);
+      const to = Date.UTC(2026, 3, 30, 0, 0, 0);
+      const result = bucketTimeRange(makeRange(from, to));
+      expect(result.from.valueOf()).toBe(Date.UTC(2026, 0, 1));
+      expect(result.to.valueOf()).toBe(Date.UTC(2027, 0, 1) - 1);
+    });
+
+    it('treats exactly 24h as day-bucket and 24h + 1ms as week-bucket', () => {
+      const dayStart = Date.UTC(2026, 4, 7, 12, 0, 0);
+      // Exactly 24h still triggers day-bucket; from/to snap to two consecutive day boundaries.
+      const dayCase = bucketTimeRange(makeRange(dayStart, dayStart + DAY_MS));
+      expect(dayCase.from.valueOf()).toBe(Date.UTC(2026, 4, 7));
+      expect(dayCase.to.valueOf()).toBe(Date.UTC(2026, 4, 9) - 1);
+
+      // One millisecond more crosses into the week bucket.
+      const weekCase = bucketTimeRange(makeRange(dayStart, dayStart + DAY_MS + 1));
+      expect(weekCase.from.valueOf()).toBe(Date.UTC(2026, 4, 4));
+      expect(weekCase.to.valueOf()).toBe(Date.UTC(2026, 4, 11) - 1);
+    });
+
+    it('treats exactly 7d as week-bucket and 7d + 1ms as month-bucket', () => {
+      const weekStart = Date.UTC(2026, 4, 4, 0, 0, 0);
+      const weekCase = bucketTimeRange(makeRange(weekStart, weekStart + 7 * DAY_MS));
+      expect(weekCase.from.valueOf()).toBe(Date.UTC(2026, 4, 4));
+      // `to` snaps up to the end of its own week (the next Mon..Sun starting 2026-05-11)
+      expect(weekCase.to.valueOf()).toBe(Date.UTC(2026, 4, 18) - 1);
+
+      const monthCase = bucketTimeRange(makeRange(weekStart, weekStart + 7 * DAY_MS + 1));
+      expect(monthCase.from.valueOf()).toBe(Date.UTC(2026, 4, 1));
+      expect(monthCase.to.valueOf()).toBe(Date.UTC(2026, 5, 1) - 1);
     });
   });
 });

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -1,4 +1,4 @@
-import { durationToMilliseconds } from '@grafana/data';
+import { dateTime, durationToMilliseconds, TimeRange } from '@grafana/data';
 
 export const supportedDurations = [
   { long: 'years', short: 'y', possible: 'year' },
@@ -94,5 +94,87 @@ export function formatOffsetDuration(timezone: string, totalMinutes: number): st
   const sign = totalMinutes < 0 ? '-' : '';
   const msec = Math.abs(totalMinutes * 60000);
   return `${sign}${getDurationFromMilliseconds(msec)}`;
+}
+
+const DAY_MS = 86_400_000;
+const WEEK_MS = 7 * DAY_MS;
+
+const startOfUtcDay = (ms: number): number => {
+  const d = new Date(ms);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+};
+
+const endOfUtcDay = (ms: number): number => startOfUtcDay(ms) + DAY_MS - 1;
+
+const startOfIsoWeekUtc = (ms: number): number => {
+  const d = new Date(ms);
+  // getUTCDay: 0=Sun..6=Sat; remap so Monday=0..Sunday=6
+  const offset = (d.getUTCDay() + 6) % 7;
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - offset);
+};
+
+const endOfIsoWeekUtc = (ms: number): number => startOfIsoWeekUtc(ms) + WEEK_MS - 1;
+
+const startOfUtcMonth = (ms: number): number => {
+  const d = new Date(ms);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
+};
+
+const endOfUtcMonth = (ms: number): number => {
+  const d = new Date(ms);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1) - 1;
+};
+
+const startOfUtcYear = (ms: number): number => {
+  const d = new Date(ms);
+  return Date.UTC(d.getUTCFullYear(), 0, 1);
+};
+
+const endOfUtcYear = (ms: number): number => {
+  const d = new Date(ms);
+  return Date.UTC(d.getUTCFullYear() + 1, 0, 1) - 1;
+};
+
+/**
+ * Round a time range to a stable UTC bucket whose size scales with the original span:
+ *  - Span ≤ 24h → day
+ *  - ≤ 7d → ISO week (Mon–Sun)
+ *  - ≤ 31d → calendar month
+ *  - otherwise calendar year
+ * `from` snaps down to the start of its bucket, `to` snaps up to the end of its bucket,
+ * so close-by ranges produce identical bucketed boundaries.
+ */
+export function bucketTimeRange(range: TimeRange): TimeRange {
+  const fromMs = range.from.valueOf();
+  const toMs = range.to.valueOf();
+  const span = Math.max(0, toMs - fromMs);
+
+  let startFn: (ms: number) => number;
+  let endFn: (ms: number) => number;
+
+  if (span <= DAY_MS) {
+    startFn = startOfUtcDay;
+    endFn = endOfUtcDay;
+  } else if (span <= WEEK_MS) {
+    startFn = startOfIsoWeekUtc;
+    endFn = endOfIsoWeekUtc;
+  } else if (span <= 31 * DAY_MS) {
+    startFn = startOfUtcMonth;
+    endFn = endOfUtcMonth;
+  } else {
+    startFn = startOfUtcYear;
+    endFn = endOfUtcYear;
+  }
+
+  const bucketedFrom = startFn(fromMs);
+  const bucketedTo = endFn(toMs);
+  const fromDt = dateTime(bucketedFrom);
+  const toDt = dateTime(bucketedTo);
+
+  return {
+    from: fromDt,
+    to: toDt,
+    raw: { from: fromDt, to: toDt },
+  };
 }
 


### PR DESCRIPTION
Related issue: #626 
Follow-up: https://github.com/VictoriaMetrics/victorialogs-datasource/commit/7cac781d3d77170d7bd29352b3d08f97a4fd99cf

### Describe Your Changes

Added highlighting of field names that were added via some transformation functions, such as `unpack_json`, `unpack_logfmt`, and so on.
<img width="1280" height="346" alt="image" src="https://github.com/user-attachments/assets/c6bcbb70-7827-463f-9f4e-a099d40bbe97" />


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate ad‑hoc filters in Explore by checking filter keys against known field names from `field_names`. Mark filters that target computed fields and let users move them into the query to avoid empty or incorrect results.

- **New Features**
  - Show ad‑hoc filter chips with a warning icon and tooltip when the field isn’t in source data; actions: Move to query, Delete; shown only in Explore.
  - Validate by fetching field names via `field_names`, scoped by bucketed time range (day/week/month/year) and `streamFilters`; results cached with LRU. On request errors or unresolved variables, filters default to valid.

- **Refactors**
  - Editor stores ad‑hoc filters as structured `query.adHocFilters`; they serialize to `extraFilters` only at request time. Backend API unchanged.
  - Updated `toggleQueryFilter` to add/remove structured filters; added `queryHasFilter` so Logs viewer “Filter for/out” actions keep working.
  - Added `serializeAdHocFilters`, `formatAdHocFilterLabel`, and `bucketTimeRange`; `language_provider` now always sets `limit`.

<sup>Written for commit cd197fca4f3d60a854da9a044eb012984eb78fd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

