### PR TITLE
fix(query interpolation): prevent the wildcard `*` value of a multi-value template variable from being wrapped in double quotes inside the `in(...)` operator during query interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * BUGFIX: protect Raw Logs queries from excessively large line limits. A hard upper bound of 10000 lines is now enforced on both the per-query `Line limit` and the datasource-wide `Maximum lines` settings; a confirmation dialog warns before committing a value above 1000 lines. See [#613](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/613).
 * BUGFIX: fix interpolation of a query with the variable at the end of the line. See [#614](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/614);
 * BUGFIX: skip the redundant `/select/logsql/hits` (logs volume) request for `Range` and `Instant` query types in Grafana Explore. The histogram is only meaningful for `Raw Logs` queries; for stats query types the main response already provides the chart. See [#630](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/630).
+* BUGFIX: prevent the wildcard `*` value of a multi-value template variable from being wrapped in double quotes inside the `in(...)` operator during query interpolation. See [pr #638](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/638).
 
 ## v0.26.3
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -12,7 +12,7 @@ import { TemplateSrv } from '@grafana/runtime';
 import { createDatasource } from './__mocks__/datasource';
 import { LogLevelRuleType } from './configuration/LogLevelRules/types';
 import { OpenTelemetryPreset } from './configuration/OpenTelemetryPreset/types';
-import { LOGS_LIMIT_HARD_CAP, VARIABLE_ALL_VALUE } from './constants';
+import { LOGS_LIMIT_HARD_CAP, TEXT_FILTER_ALL_VALUE, VARIABLE_ALL_VALUE } from './constants';
 import { VictoriaLogsDatasource } from './datasource';
 import { FilterActionType, Query, QueryType, SupportingQueryType, ToggleFilterAction } from './types';
 
@@ -347,6 +347,38 @@ describe('VictoriaLogsDatasource', () => {
       const ds = createDatasource(templateSrvMock);
       const result = ds.interpolateString('foo: $var1 bar: $var2', scopedVars);
       expect(result).toStrictEqual('foo: in(\"foo\",\"bar\") bar:in(*)');
+    });
+
+    it('does not wrap wildcard `*` of a textbox variable in double quotes inside in(...) (regression)', () => {
+      const variables = [
+        {
+          name: 'tenant',
+          current: { value: ['0'] },
+          multi: true,
+          type: 'query',
+          query: {
+            type: 'fieldValue'
+          }
+        },
+        {
+          name: 'query_hash',
+          current: { value: TEXT_FILTER_ALL_VALUE },
+          type: 'textbox',
+          multi: false,
+        }
+      ];
+      const templateSrvMock = {
+        replace: jest.fn(() =>
+          'tenant:in($_StartMultiVariable_0_EndMultiVariable) | query_hash:in($_StartMultiVariable_*_EndMultiVariable) | type:="range" | count()'
+        ),
+        getVariables: jest.fn().mockReturnValue(variables),
+      } as unknown as TemplateSrv;
+      const ds = createDatasource(templateSrvMock);
+      const result = ds.interpolateString(
+        'tenant:in($tenant) | query_hash:$query_hash | type:="range" | count()',
+        {},
+      );
+      expect(result).toBe('tenant:in("0") | query_hash:in(*) | type:="range" | count()');
     });
   });
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -364,9 +364,10 @@ export class VictoriaLogsDatasource
     const variableNamesList = this.templateSrv.getVariables().map(v => v.name);
     expr = doubleQuoteRegExp(expr, variableNamesList);
     expr = this.templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr);
+    expr = this.replaceMultiVariables(expr);
     expr = correctRegExpValueAll(expr);
     expr = correctMultiExactOperatorValueAll(expr);
-    return this.replaceMultiVariables(expr);
+    return expr;
   }
 
   private replaceMultiVariables(input: string): string {


### PR DESCRIPTION
### Describe Your Changes

Prevent the wildcard `*` value of a multi-value template variable from being wrapped in double quotes inside the `in(...)` operator during query interpolation. 

Example: 
```
tenant:in($tenant)
| query_hash:$query_hash 
| type:="range"
| count()
```
with the textbox variable `query_hash` and value `*` was incorrectly interpolated to

```
tenant:in("0")
| query_hash:in("*")
| type:="range"
| count()
```
.

Now the interpolated query is:
```
tenant:in("0")
| query_hash:in(*)
| type:="range"
| count()
```
### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix query interpolation so the wildcard `*` inside `in(...)` is not quoted for template variables (including textbox). This now generates `in(*)` instead of `in("*")`, restoring correct wildcard behavior.

- **Bug Fixes**
  - Run multi-value replacement immediately after template replacement to keep `*` unquoted in `in(...)`.
  - Added a regression test and changelog entry.

<sup>Written for commit 745d7467b923b892116eb74538a79e00d3a6c1c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

