### PR TITLE
release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * BUGFIX: fix interpolation of a query with the variable at the end of the line. See [#614](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/614);
 * BUGFIX: skip the redundant `/select/logsql/hits` (logs volume) request for `Range` and `Instant` query types in Grafana Explore. The histogram is only meaningful for `Raw Logs` queries; for stats query types the main response already provides the chart. See [#630](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/630).
 * BUGFIX: prevent the wildcard `*` value of a multi-value template variable from being wrapped in double quotes inside the `in(...)` operator during query interpolation. See [pr #638](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/638).
+* BUGFIX: fix off-by-one ordering of query results where the first row appeared in the wrong position relative to the rest of the sorted output. See [#625](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/625).
 
 ## v0.26.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "victoriametrics-logs-datasource",
-  "version": "0.26.3",
+  "version": "0.27.0",
   "description": "VictoriaLogs datasource plugin for grafana",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",


### PR DESCRIPTION
### Describe Your Changes

Release v0.27.0 

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.27.0. Fixes an off-by-one sorting bug that could place the first row in the wrong position; updates `package.json` version and the changelog.

- **Bug Fixes**
  - Correct result ordering so the first row is placed correctly in sorted outputs (#625).

<sup>Written for commit a3d0bcef9f10c25ddcce60a3e5196959a40a2670. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

