### PR TITLE
fix(multitenancy): replace tenant hint with health-check based warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: disable tenant configuration inputs (`Tenant`, `AccountID`, `ProjectID`) until the datasource health check passes. Previously, entering and clearing a tenant on a freshly created (not yet saved) datasource produced a validation error. See [#639](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/639).
+
 ## v0.27.1
 
 * BUGFIX: fix a case where tenant settings (`AccountID`, `ProjectID`) and custom HTTP headers configured for the datasource could be silently dropped when the plugin automatically retried a request after a transient network error. This could lead to authorization failures or requests being served from the wrong tenant. The retried request now uses the same headers as the original one.

--- a/src/configuration/OpenTelemetryPreset/OpenTelemetryPreset.tsx
+++ b/src/configuration/OpenTelemetryPreset/OpenTelemetryPreset.tsx
@@ -16,7 +16,6 @@ export const OpenTelemetryPreset = (props: PropsConfigEditor) => {
   const {
     preset,
     healthStatus,
-    healthMessage,
     fieldNames,
     isDetecting,
     error,
@@ -47,7 +46,7 @@ export const OpenTelemetryPreset = (props: PropsConfigEditor) => {
             Auto-generate derived fields for trace/span IDs and log level rules for OTel severity.
             Your own derived fields and log level rules are preserved.
           </Text>
-          {healthStatus === HealthStatus.Error && healthMessage && (
+          {healthStatus === HealthStatus.Error && (
             <Text variant='bodySmall' color='warning' element='p'>
               To use the OpenTelemetry preset, need to set the datasource url first and save the datasource configuration
             </Text>

--- a/src/configuration/OpenTelemetryPreset/detection.ts
+++ b/src/configuration/OpenTelemetryPreset/detection.ts
@@ -1,5 +1,6 @@
 import { dateTime, TimeRange } from '@grafana/data';
 
+import { VictoriaLogsDatasource } from '../../datasource';
 import { FieldHits, FilterFieldType } from '../../types';
 
 import {
@@ -65,10 +66,13 @@ export function classifyValueCase(severityField: string): SeverityValueCase {
 }
 
 export async function runDetection(
-  backend: DetectionBackend,
+  backend: VictoriaLogsDatasource,
   options: RunDetectionOptions = {},
 ): Promise<[OpenTelemetryPresetDetection, string[]]> {
   const timeRange = buildDetectionTimeRange();
+  if (!backend.languageProvider) {
+    throw new Error('Language provider is not available');
+  }
   const fieldHits = await backend.languageProvider.getFieldList({
     type: FilterFieldType.FieldName,
     limit: FIELD_NAMES_SAMPLE_LIMIT,

--- a/src/configuration/OpenTelemetryPreset/useOtelPreset.ts
+++ b/src/configuration/OpenTelemetryPreset/useOtelPreset.ts
@@ -6,6 +6,7 @@ import { getDataSourceSrv, HealthStatus } from '@grafana/runtime';
 import { VictoriaLogsDatasource } from '../../datasource';
 import { FilterFieldType } from '../../types';
 import { PropsConfigEditor } from '../ConfigEditor';
+import { HealthCheckStatus, useHealthCheck } from '../useHealthCheck';
 
 import { runDetection } from './detection';
 import { OpenTelemetryPreset as PresetState } from './types';
@@ -21,12 +22,9 @@ export const makePresetUpdater = (props: PropsConfigEditor) => (next: Partial<Pr
   });
 };
 
-export type HealthCheckStatus = Omit<HealthStatus, 'unknown'> | 'checking';
-
 export interface OtelPresetHook {
   preset: PresetState;
   healthStatus: HealthCheckStatus;
-  healthMessage: string | null;
   fieldNames: string[];
   isDetecting: boolean;
   error: string | null;
@@ -43,35 +41,16 @@ export function useOtelPreset(props: PropsConfigEditor): OtelPresetHook {
   const preset: PresetState = options.jsonData.otelPreset ?? { enabled: false };
   const update = makePresetUpdater(props);
 
-  const [healthStatus, setHealthStatus] = useState<HealthCheckStatus>('checking');
-  const [healthMessage, setHealthMessage] = useState<string | null>(null);
+  const { healthStatus } = useHealthCheck(options);
   const [fieldNames, setFieldNames] = useState<string[]>([]);
   const [isDetecting, setIsDetecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isChangingSeverity, setIsChangingSeverity] = useState(false);
   const detectionTriggeredRef = useRef(false);
 
-  // Re-run health check when the datasource is saved (id/version change after "Save & test").
+  // Reset auto-detection trigger when the datasource is saved so detection can re-run.
   useEffect(() => {
     detectionTriggeredRef.current = false;
-
-    const check = async () => {
-      try {
-        const ds = await getDataSourceSrv().get(options.uid) as VictoriaLogsDatasource;
-        const health = await ds.callHealthCheck();
-        if (health.status === HealthStatus.OK) {
-          setHealthStatus(HealthStatus.OK);
-          setHealthMessage(null);
-        } else {
-          setHealthStatus(HealthStatus.Error);
-          setHealthMessage(health.message || 'Save datasource changes first to detect format.');
-        }
-      } catch {
-        setHealthStatus(HealthStatus.OK);
-        setHealthMessage('Save datasource changes first to detect format.');
-      }
-    };
-    void check();
   }, [options.id, options.version]);
 
   const detect = useCallback(async (severityField?: string) => {
@@ -79,7 +58,7 @@ export function useOtelPreset(props: PropsConfigEditor): OtelPresetHook {
     setIsDetecting(true);
     try {
       const ds = await getDataSourceSrv().get(options.uid) as VictoriaLogsDatasource;
-      const [detection, fieldNames] = await runDetection(ds as any, { severityField });
+      const [detection, fieldNames] = await runDetection(ds, { severityField });
       setFieldNames(fieldNames);
       update({ detection });
     } catch (e) {
@@ -130,7 +109,6 @@ export function useOtelPreset(props: PropsConfigEditor): OtelPresetHook {
   return {
     preset,
     healthStatus,
-    healthMessage,
     fieldNames,
     isDetecting,
     error,

--- a/src/configuration/TenantSettings.tsx
+++ b/src/configuration/TenantSettings.tsx
@@ -1,7 +1,7 @@
 import React, { SyntheticEvent, useCallback, useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceSrv, HealthStatus } from '@grafana/runtime';
 import { ComboboxOption, InlineField, Input, Stack, Text, TextLink } from '@grafana/ui';
 
 import { CompatibleCombobox } from '../components/CompatibleCombobox';
@@ -10,6 +10,7 @@ import { VictoriaLogsDatasource } from '../datasource';
 import { TenantHeaderNames } from '../types';
 
 import { PropsConfigEditor } from './ConfigEditor';
+import { useHealthCheck } from './useHealthCheck';
 import { getValueFromEventItem } from './utils';
 
 const documentationLink = (
@@ -29,25 +30,18 @@ export const TenantSettings = (props: PropsConfigEditor) => {
 
   const [tenants, setTenants] = useState<ComboboxOption[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [hint, setHint] = useState<string>('');
+  const { healthStatus } = useHealthCheck(options);
 
   const loadTenantIds = useCallback(async () => {
-    // Only try to load if datasource is saved (has ID)
-    if (!options.id) {
+    if (!options.id || healthStatus !== HealthStatus.OK) {
       setIsLoading(false);
       return;
     }
 
     setIsLoading(true);
-    setHint('');
     try {
       const ds = await getDataSourceSrv().get(options.uid) as VictoriaLogsDatasource;
       const tenantList = await ds.fetchTenantIds();
-      if (!Array.isArray(tenantList)) {
-        setHint(tenantList.hint);
-        return;
-      }
-
       setTenants(tenantList.map(id => ({ label: id, value: id })));
     } catch (error) {
       // Silently fail - tenant IDs are optional
@@ -55,9 +49,9 @@ export const TenantSettings = (props: PropsConfigEditor) => {
     } finally {
       setIsLoading(false);
     }
-  }, [options.id, options.uid]);
+  }, [options.id, options.uid, healthStatus]);
 
-  // if changed version, reload tenant IDs, because the datasource url may have changed
+  // if changed version or health status, reload tenant IDs
   useEffect(() => {
     void loadTenantIds();
   }, [loadTenantIds, options.version]);
@@ -94,6 +88,8 @@ export const TenantSettings = (props: PropsConfigEditor) => {
   };
 
   const hasTenants = tenants.length > 0;
+  const isReady = healthStatus === HealthStatus.OK;
+  const isDisabled = isReadOnly || isLoading || !isReady;
 
   // Combine current accountId and projectId into tenant format
   const currentTenant = multitenancyHeaders?.[TenantHeaderNames.AccountID] && multitenancyHeaders?.[TenantHeaderNames.ProjectID]
@@ -107,9 +103,11 @@ export const TenantSettings = (props: PropsConfigEditor) => {
         <Text variant='bodySmall' color='disabled' element='p'>
           Manage tenants and multitenancy settings. {documentationLink}
         </Text>
-        {hint && <Text variant='bodySmall' color='warning' element='p'>
-          {hint}
-        </Text>}
+        {healthStatus === HealthStatus.Error && (
+          <Text variant='bodySmall' color='warning' element='p'>
+            To use multitenancy, need to set the datasource url first and save the datasource configuration
+          </Text>
+        )}
       </div>
 
       <div className='gf-form-group'>
@@ -120,7 +118,7 @@ export const TenantSettings = (props: PropsConfigEditor) => {
               labelWidth={28}
               interactive={true}
               tooltip='Format: accountId:projectId (e.g., 1:2)'
-              disabled={isReadOnly || isLoading}
+              disabled={isDisabled}
             >
               <CompatibleCombobox
                 placeholder='Select Tenant'
@@ -130,7 +128,7 @@ export const TenantSettings = (props: PropsConfigEditor) => {
                 onChange={onTenantChange}
                 loading={isLoading}
                 width={30}
-                disabled={isReadOnly || isLoading}
+                disabled={isDisabled}
               />
             </InlineField>
           </div>
@@ -141,7 +139,7 @@ export const TenantSettings = (props: PropsConfigEditor) => {
                 label='Account ID'
                 labelWidth={28}
                 interactive={true}
-                disabled={isReadOnly || isLoading}
+                disabled={isDisabled}
               >
                 <Input
                   className='width-8'
@@ -150,7 +148,7 @@ export const TenantSettings = (props: PropsConfigEditor) => {
                   placeholder='0'
                   value={`${multitenancyHeaders?.[TenantHeaderNames.AccountID] || ''}`}
                   onChange={onInputChange(TenantHeaderNames.AccountID)}
-                  disabled={isReadOnly || isLoading}
+                  disabled={isDisabled}
                 />
               </InlineField>
             </div>
@@ -160,7 +158,7 @@ export const TenantSettings = (props: PropsConfigEditor) => {
                 label='Project ID'
                 labelWidth={28}
                 interactive={true}
-                disabled={isReadOnly || isLoading}
+                disabled={isDisabled}
               >
                 <Input
                   className='width-8'
@@ -169,7 +167,7 @@ export const TenantSettings = (props: PropsConfigEditor) => {
                   placeholder='0'
                   value={`${multitenancyHeaders?.[TenantHeaderNames.ProjectID] || ''}`}
                   onChange={onInputChange(TenantHeaderNames.ProjectID)}
-                  disabled={isReadOnly || isLoading}
+                  disabled={isDisabled}
                 />
               </InlineField>
             </div>

--- a/src/configuration/useHealthCheck.ts
+++ b/src/configuration/useHealthCheck.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+
+import { getDataSourceSrv, HealthStatus } from '@grafana/runtime';
+
+import { VictoriaLogsDatasource } from '../datasource';
+
+export type HealthCheckStatus = Omit<HealthStatus, 'unknown'> | 'checking';
+
+export interface HealthCheckResult {
+  healthStatus: HealthCheckStatus;
+  healthMessage: string | null;
+}
+
+export interface UseHealthCheckArgs {
+  uid: string;
+  // id/version trigger a re-check after "Save & test"
+  id?: number;
+  version?: number;
+}
+
+export function useHealthCheck({ uid, id, version }: UseHealthCheckArgs): HealthCheckResult {
+  const [healthStatus, setHealthStatus] = useState<HealthCheckStatus>('checking');
+  const [healthMessage, setHealthMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- useEffect doesn't depend on healthStatus or healthMessage
+    setHealthStatus('checking');
+    setHealthMessage(null);
+    const check = async () => {
+      try {
+        const ds = await getDataSourceSrv().get(uid) as VictoriaLogsDatasource;
+        const health = await ds.callHealthCheck();
+        if (cancelled) {
+          return;
+        }
+        if (health.status === HealthStatus.OK) {
+          setHealthStatus(HealthStatus.OK);
+          setHealthMessage(null);
+        } else {
+          setHealthStatus(HealthStatus.Error);
+          setHealthMessage(health.message || null);
+        }
+      } catch {
+        if (!cancelled) {
+          setHealthStatus(HealthStatus.Error);
+          setHealthMessage(null);
+        }
+      }
+    };
+    void check();
+    return () => {
+      cancelled = true;
+    };
+  }, [uid, id, version]);
+
+  return { healthStatus, healthMessage };
+}

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -608,14 +608,11 @@ export class VictoriaLogsDatasource
     return { ...timeRange, raw: timeRange };
   };
 
-  async fetchTenantIds(): Promise<{ hint: string } | string[]> {
+  async fetchTenantIds(): Promise<string[]> {
     try {
       const res = await this.postResource<{ hint: string } | Tenant[]>('select/tenant_ids', {});
 
       if (!Array.isArray(res)) {
-        if (res.hint) {
-          return res;
-        }
         return [];
       }
 


### PR DESCRIPTION
Related issue: #639 

### Describe Your Changes

Disabled tenant configuration inputs (`Tenant`, `AccountID`, `ProjectID`) until the datasource health check passes. Previously, entering and clearing a tenant on a freshly created (not yet saved) datasource produced a validation error.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable multitenancy inputs and OTel preset actions until the datasource health check passes, replacing the server “tenant hint” with a client-side health-check warning. Prevents first-time setup validation errors. Fixes #639.

- **Bug Fixes**
  - Tenant combobox and `AccountID`/`ProjectID` inputs are disabled until health is OK; tenant IDs load only after health passes. OTel preset shows the same warning and blocks detection until the datasource is saved.

- **Refactors**
  - Added shared `useHealthCheck` and used it in Tenant Settings and the OpenTelemetry preset.
  - Simplified `fetchTenantIds` to always return a `string[]` and ignore server “hint” responses.

<sup>Written for commit 50b6f204b160bccbf057194c8dc77e633c745c47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

