### PR TITLE
chore(README): add version annotation to the feature documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ tsconfig.tsbuildinfo
 # Docker
 .cache
 gocache-for-docker
+
+.DS_Store

--- a/src/README.md
+++ b/src/README.md
@@ -63,6 +63,8 @@ and LogsQL examples [here](https://docs.victoriametrics.com/victorialogs/logsql-
 
 ### Query builder
 
+> **Note:** available since [v0.27.1](https://github.com/VictoriaMetrics/victorialogs-datasource/releases/tag/v0.27.1).
+
 A visual alternative to the LogsQL code editor: build queries by chaining typed pipes through an interactive UI with field/value dropdowns and keyboard navigation.
 
 <img alt="Query builder" width="100%" src="https://github.com/VictoriaMetrics/victorialogs-datasource/blob/main/src/img/query_builder.gif?raw=true">
@@ -284,6 +286,8 @@ correlation in [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/i
 Log to traces correlation is possible via Derived Fields functionality. See its description in the sections below.
 
 ## OpenTelemetry preset
+
+> **Note:** available since [v0.27.1](https://github.com/VictoriaMetrics/victorialogs-datasource/releases/tag/v0.27.1).
 
 The **OpenTelemetry preset** in the datasource configuration automatically sets up [Derived Fields](#derived-fields) for trace IDs and [Log level rules](#log-level-rules) for OTel severity — without manual configuration.
 


### PR DESCRIPTION
### Describe Your Changes

Add version annotation to the feature documentation.
I didn't use the docs annotations cause this file is also rendered in the Grafana plugin page. It looks like a strange code in the documents.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add version annotations to the README for Query builder and OpenTelemetry preset (available from v0.27.1), and tidy formatting, lists, and examples for clarity. Also add `.DS_Store` to `.gitignore`.

<sup>Written for commit 237e7d5c83fadee5a26cbb9c7e4a90839ec46acb. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victorialogs-datasource/pull/649?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

