### PR TITLE
fix(adhoc filters): restore propagation adhoc variables from the Dashboard to Explore page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * FEATURE: replace the "Ad-hoc filters to root query" checkbox in Query Editor options with a three-mode selector: `Extra Filters` (default, sends filters as the `extra_filters` query parameter), `Root Query` (prepends filters to the query expression, preventing propagation into `join`/`union` subqueries) and `Off` (disables automatic ad-hoc filter injection entirely — useful when ad-hoc values are managed through Grafana variable interpolation or applied to pipe-transformed fields). Saved dashboards using the previous `isApplyExtraFiltersToRootQuery` flag continue to work without migration. See [#633](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/633). Thanks to @edspc for contributing.
 * FEATURE: add ability to set custom field names in dashboard variables, since fields do not necessarily exist at the time of creation or manipulation (e.g. when importing a dashboard from JSON, then editing a variable). See [pr #606](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/606). Thanks to @github-vincent-miszczak for contributing.
 
+* BUGFIX: restore propagation of dashboard ad-hoc filters when navigating from a panel to Grafana Explore.
 * BUGFIX: disable tenant configuration inputs (`Tenant`, `AccountID`, `ProjectID`) until the datasource health check passes. Previously, entering and clearing a tenant on a freshly created (not yet saved) datasource produced a validation error. See [#639](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/639).
 
 ## v0.27.1

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -13,8 +13,8 @@ import { createDatasource } from './__mocks__/datasource';
 import { LogLevelRuleType } from './configuration/LogLevelRules/types';
 import { OpenTelemetryPreset } from './configuration/OpenTelemetryPreset/types';
 import { LOGS_LIMIT_HARD_CAP, TEXT_FILTER_ALL_VALUE, VARIABLE_ALL_VALUE } from './constants';
-import { resolveAdHocFiltersMode, VictoriaLogsDatasource } from './datasource';
-import { AdHocFiltersMode, FilterActionType, Query, QueryType, SupportingQueryType, ToggleFilterAction } from './types';
+import { VictoriaLogsDatasource } from './datasource';
+import { AdHocFilter, AdHocFiltersMode, FilterActionType, Query, QueryType, SupportingQueryType, ToggleFilterAction } from './types';
 
 const replaceMock = jest.fn().mockImplementation((a: string) => a);
 
@@ -432,20 +432,114 @@ describe('VictoriaLogsDatasource', () => {
     });
   });
 
-  describe('resolveAdHocFiltersMode', () => {
-    it('should return adHocFiltersMode when set', () => {
-      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', adHocFiltersMode: AdHocFiltersMode.Off })).toBe(AdHocFiltersMode.Off);
-      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery })).toBe(AdHocFiltersMode.RootQuery);
-      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', adHocFiltersMode: AdHocFiltersMode.ExtraFilters })).toBe(AdHocFiltersMode.ExtraFilters);
+  describe('interpolateVariablesInQueries', () => {
+    const dashboardFilters: AdHocVariableFilter[] = [
+      { key: 'level', operator: '=', value: 'error' },
+    ];
+
+    it('materialises dashboard ad-hoc filters as chips when mode is extraFilters', () => {
+      const result = ds.interpolateVariablesInQueries(
+        [{ expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.ExtraFilters }],
+        {},
+        dashboardFilters
+      );
+      expect(result[0].adHocFilters).toEqual(dashboardFilters);
+      expect(result[0].expr).toBe('_time:5m');
+      expect(result[0].extraFilters).toBeUndefined();
     });
 
-    it('should fall back to legacy isApplyExtraFiltersToRootQuery', () => {
-      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', isApplyExtraFiltersToRootQuery: true })).toBe(AdHocFiltersMode.RootQuery);
-      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', isApplyExtraFiltersToRootQuery: false })).toBe(AdHocFiltersMode.ExtraFilters);
+    it('materialises dashboard ad-hoc filters as chips when no mode is set (defaults to extraFilters)', () => {
+      const result = ds.interpolateVariablesInQueries(
+        [{ expr: '_time:5m', refId: 'A' }],
+        {},
+        dashboardFilters
+      );
+      expect(result[0].adHocFilters).toEqual(dashboardFilters);
+      expect(result[0].extraFilters).toBeUndefined();
     });
 
-    it('should default to extraFilters when neither field is set', () => {
-      expect(resolveAdHocFiltersMode({ expr: '', refId: 'A' })).toBe(AdHocFiltersMode.ExtraFilters);
+    it('inlines dashboard ad-hoc filters into expr when mode is rootQuery', () => {
+      const result = ds.interpolateVariablesInQueries(
+        [{ expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery }],
+        {},
+        dashboardFilters
+      );
+      expect(result[0].expr).toBe('level:="error" | _time:5m');
+      expect(result[0].adHocFilters).toBeUndefined();
+      expect(result[0].extraFilters).toBeUndefined();
+    });
+
+    it('combines panel chips with dashboard ad-hoc filters into expr in rootQuery mode', () => {
+      const panelChips: AdHocFilter[] = [{ key: 'app', operator: '=', value: 'frontend' }];
+      const result = ds.interpolateVariablesInQueries(
+        [{
+          expr: '_time:5m',
+          refId: 'A',
+          adHocFiltersMode: AdHocFiltersMode.RootQuery,
+          adHocFilters: panelChips,
+        }],
+        {},
+        dashboardFilters
+      );
+      expect(result[0].expr).toBe('app:="frontend" AND level:="error" | _time:5m');
+      expect(result[0].adHocFilters).toBeUndefined();
+    });
+
+    it('drops dashboard ad-hoc filters when mode is off', () => {
+      const result = ds.interpolateVariablesInQueries(
+        [{ expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.Off }],
+        {},
+        dashboardFilters
+      );
+      expect(result[0].adHocFilters).toBeUndefined();
+    });
+
+    it('preserves panel-level adHocFilters even in off mode', () => {
+      const panelChips: AdHocFilter[] = [{ key: 'app', operator: '=', value: 'frontend' }];
+      const result = ds.interpolateVariablesInQueries(
+        [{
+          expr: '_time:5m',
+          refId: 'A',
+          adHocFiltersMode: AdHocFiltersMode.Off,
+          adHocFilters: panelChips,
+        }],
+        {},
+        dashboardFilters
+      );
+      expect(result[0].adHocFilters).toEqual(panelChips);
+    });
+
+    it('honours legacy isApplyExtraFiltersToRootQuery flag (inlines into expr)', () => {
+      const result = ds.interpolateVariablesInQueries(
+        [{ expr: '_time:5m', refId: 'A', isApplyExtraFiltersToRootQuery: true }],
+        {},
+        dashboardFilters
+      );
+      expect(result[0].expr).toBe('level:="error" | _time:5m');
+      expect(result[0].adHocFilters).toBeUndefined();
+    });
+
+    it('merges existing panel chips with dashboard ad-hoc filters', () => {
+      const panelChips: AdHocFilter[] = [{ key: 'app', operator: '=', value: 'frontend' }];
+      const result = ds.interpolateVariablesInQueries(
+        [{ expr: '_time:5m', refId: 'A', adHocFilters: panelChips }],
+        {},
+        dashboardFilters
+      );
+      expect(result[0].adHocFilters).toEqual([...panelChips, ...dashboardFilters]);
+    });
+
+    it('leaves adHocFilters undefined when there are no chips to materialise', () => {
+      const result = ds.interpolateVariablesInQueries(
+        [{ expr: '_time:5m', refId: 'A' }],
+        {},
+        []
+      );
+      expect(result[0].adHocFilters).toBeUndefined();
+    });
+
+    it('returns input unchanged when queries is empty', () => {
+      expect(ds.interpolateVariablesInQueries([], {}, dashboardFilters)).toEqual([]);
     });
   });
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -57,7 +57,6 @@ import { removeDoubleQuotesAroundVar } from './parsing';
 import { replaceOperatorWithIn, returnVariables } from './parsingUtils';
 import { transformBackendResult } from './transformers';
 import {
-  AdHocFiltersMode,
   DerivedFieldConfig,
   FilterActionType,
   FilterFieldType,
@@ -74,9 +73,14 @@ import {
   ToggleFilterAction,
   VariableQuery,
 } from './types';
-import { serializeAdHocFilters } from './utils/query/adHocFilters';
+import {
+  resolveAdHocFilters,
+  serializeChipsForBackend,
+} from './utils/query/adHocFilters';
 import { formatOffsetDuration, getMillisecondsFromDuration } from './utils/timeUtils';
 import { VariableSupport } from './variableSupport/VariableSupport';
+
+export { resolveAdHocFiltersMode } from './utils/query/adHocFilters';
 
 export const REF_ID_STARTER_LOG_VOLUME = 'log-volume-';
 export const REF_ID_STARTER_LOG_SAMPLE = 'log-sample-';
@@ -230,26 +234,15 @@ export class VictoriaLogsDatasource
       },
     };
 
-    const mode = resolveAdHocFiltersMode(target);
-    let expr = this.interpolateString(target.expr, variables);
-    let extraFilters: string | undefined;
-    if (mode !== AdHocFiltersMode.Off) {
-      const baseAdHocExpr = serializeAdHocFilters(target.adHocFilters) ?? '';
-      const filters = this.getExtraFilters(adhocFilters, baseAdHocExpr);
-      if (mode === AdHocFiltersMode.RootQuery && filters) {
-        expr = `${filters} | ${expr}`;
-      } else if (mode === AdHocFiltersMode.ExtraFilters) {
-        extraFilters = filters;
-      }
-    }
+    const interpolated = this.interpolateString(target.expr, variables);
+    const { expr, chips } = resolveAdHocFilters(target, interpolated, adhocFilters);
 
-    const extraStreamFilters = this.getExtraStreamFilters(target.streamFilters, scopedVars);
     return {
       ...target,
       legendFormat: this.templateSrv.replace(target.legendFormat, rest),
       expr,
-      extraFilters,
-      extraStreamFilters,
+      extraFilters: serializeChipsForBackend(chips),
+      extraStreamFilters: this.getExtraStreamFilters(target.streamFilters, scopedVars),
       // Backend protocol uses `extraFilters` (string); the structured array is editor-only
       adHocFilters: undefined,
     };
@@ -284,19 +277,25 @@ export class VictoriaLogsDatasource
   }
 
   interpolateVariablesInQueries(queries: Query[], scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): Query[] {
-    let expandedQueries = queries;
-    if (queries && queries.length) {
-      expandedQueries = queries.map((query) => ({
+    if (!queries?.length) {
+      return queries;
+    }
+
+    return queries.map((query) => {
+      const interpolated = this.interpolateString(query.expr, scopedVars);
+      const { expr, chips } = resolveAdHocFilters(query, interpolated, filters);
+
+      return {
         ...query,
         datasource: this.getRef(),
-        expr: this.interpolateString(query.expr, scopedVars),
+        expr,
         interval: this.templateSrv.replace(query.interval, scopedVars),
-        extraFilters: this.getExtraFilters(filters, serializeAdHocFilters(query.adHocFilters) ?? ''),
+        // Keep chips on the target so Explore can render them; applyTemplateVariables
+        // will serialise them into `extraFilters` at query-run time.
+        adHocFilters: chips,
         extraStreamFilters: this.getExtraStreamFilters(query.streamFilters, scopedVars),
-        adHocFilters: undefined,
-      }));
-    }
-    return expandedQueries;
+      };
+    });
   }
 
   async metricFindQuery(
@@ -650,9 +649,3 @@ export class VictoriaLogsDatasource
   }
 }
 
-export function resolveAdHocFiltersMode(query: Query): AdHocFiltersMode {
-  if (query.adHocFiltersMode) {
-    return query.adHocFiltersMode;
-  }
-  return query.isApplyExtraFiltersToRootQuery ? AdHocFiltersMode.RootQuery : AdHocFiltersMode.ExtraFilters;
-}

--- a/src/utils/query/adHocFilters.test.ts
+++ b/src/utils/query/adHocFilters.test.ts
@@ -1,11 +1,16 @@
-import { AdHocFilter } from '../../types';
+import { AdHocVariableFilter } from '@grafana/data';
+
+import { AdHocFilter, AdHocFiltersMode } from '../../types';
 
 import {
   adHocFilterMatches,
   appendFilterPipeToQuery,
   formatAdHocFilterLabel,
   queryHasPipes,
+  resolveAdHocFilters,
+  resolveAdHocFiltersMode,
   serializeAdHocFilters,
+  serializeChipsForBackend,
 } from './adHocFilters';
 
 describe('serializeAdHocFilters', () => {
@@ -168,5 +173,171 @@ describe('adHocFilterMatches', () => {
 
   it('does not match different value', () => {
     expect(adHocFilterMatches(f, 'service', 'web')).toBe(false);
+  });
+});
+
+describe('serializeChipsForBackend', () => {
+  it('returns undefined for undefined input', () => {
+    expect(serializeChipsForBackend(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for empty array', () => {
+    expect(serializeChipsForBackend([])).toBeUndefined();
+  });
+
+  it('serialises a single chip into a LogsQL filter', () => {
+    const chips: AdHocFilter[] = [{ key: 'level', operator: '=', value: 'error' }];
+    expect(serializeChipsForBackend(chips)).toBe('level:="error"');
+  });
+
+  it('joins multiple chips with AND', () => {
+    const chips: AdHocFilter[] = [
+      { key: 'level', operator: '=', value: 'error' },
+      { key: 'app', operator: '!=', value: 'test' },
+    ];
+    expect(serializeChipsForBackend(chips)).toBe('level:="error" AND app:!="test"');
+  });
+
+  it('restores placeholder variables via returnVariables', () => {
+    // returnVariables turns the internal `__V_0__name__V__` placeholder back into `$name`
+    const chips: AdHocFilter[] = [{ key: 'level', operator: '=', value: '__V_0__severity__V__' }];
+    expect(serializeChipsForBackend(chips)).toBe('level:="$severity"');
+  });
+});
+
+describe('resolveAdHocFiltersMode', () => {
+  it('returns AdHocFiltersMode.Off when set explicitly', () => {
+    expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', adHocFiltersMode: AdHocFiltersMode.Off })).toBe(AdHocFiltersMode.Off);
+  });
+
+  it('returns AdHocFiltersMode.RootQuery when set explicitly', () => {
+    expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery })).toBe(AdHocFiltersMode.RootQuery);
+  });
+
+  it('returns AdHocFiltersMode.ExtraFilters when set explicitly', () => {
+    expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', adHocFiltersMode: AdHocFiltersMode.ExtraFilters })).toBe(AdHocFiltersMode.ExtraFilters);
+  });
+
+  it('falls back to legacy isApplyExtraFiltersToRootQuery=true → RootQuery', () => {
+    expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', isApplyExtraFiltersToRootQuery: true })).toBe(AdHocFiltersMode.RootQuery);
+  });
+
+  it('falls back to legacy isApplyExtraFiltersToRootQuery=false → ExtraFilters', () => {
+    expect(resolveAdHocFiltersMode({ expr: '', refId: 'A', isApplyExtraFiltersToRootQuery: false })).toBe(AdHocFiltersMode.ExtraFilters);
+  });
+
+  it('defaults to ExtraFilters when neither flag is set', () => {
+    expect(resolveAdHocFiltersMode({ expr: '', refId: 'A' })).toBe(AdHocFiltersMode.ExtraFilters);
+  });
+});
+
+describe('resolveAdHocFilters', () => {
+  const dashboard: AdHocVariableFilter[] = [{ key: 'level', operator: '=', value: 'error' }];
+
+  describe('mode Off', () => {
+    it('returns interpolated expr untouched and preserves panel chips', () => {
+      const panelChips: AdHocFilter[] = [{ key: 'app', operator: '=', value: 'frontend' }];
+      const result = resolveAdHocFilters(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.Off, adHocFilters: panelChips },
+        '_time:5m',
+        dashboard
+      );
+      expect(result).toEqual({ expr: '_time:5m', chips: panelChips });
+    });
+
+    it('drops dashboard filters', () => {
+      const result = resolveAdHocFilters(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.Off },
+        '_time:5m',
+        dashboard
+      );
+      expect(result.chips).toBeUndefined();
+    });
+  });
+
+  describe('mode RootQuery', () => {
+    it('prefixes dashboard filters to expr', () => {
+      const result = resolveAdHocFilters(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery },
+        '_time:5m',
+        dashboard
+      );
+      expect(result).toEqual({ expr: 'level:="error" | _time:5m', chips: undefined });
+    });
+
+    it('combines panel chips with dashboard filters, panel first', () => {
+      const panelChips: AdHocFilter[] = [{ key: 'app', operator: '=', value: 'frontend' }];
+      const result = resolveAdHocFilters(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery, adHocFilters: panelChips },
+        '_time:5m',
+        dashboard
+      );
+      expect(result.expr).toBe('app:="frontend" AND level:="error" | _time:5m');
+      expect(result.chips).toBeUndefined();
+    });
+
+    it('leaves expr unchanged when there are no chips to prepend', () => {
+      const result = resolveAdHocFilters(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery },
+        '_time:5m',
+        []
+      );
+      expect(result).toEqual({ expr: '_time:5m', chips: undefined });
+    });
+  });
+
+  describe('mode ExtraFilters (and default)', () => {
+    it('materialises dashboard filters into chips', () => {
+      const result = resolveAdHocFilters(
+        { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.ExtraFilters },
+        '_time:5m',
+        dashboard
+      );
+      expect(result.expr).toBe('_time:5m');
+      expect(result.chips).toEqual([{ key: 'level', operator: '=', value: 'error' }]);
+    });
+
+    it('behaves like ExtraFilters when mode is unset (default)', () => {
+      const result = resolveAdHocFilters(
+        { expr: '_time:5m', refId: 'A' },
+        '_time:5m',
+        dashboard
+      );
+      expect(result.chips).toEqual([{ key: 'level', operator: '=', value: 'error' }]);
+    });
+
+    it('combines panel chips with dashboard filters, panel first', () => {
+      const panelChips: AdHocFilter[] = [{ key: 'app', operator: '=', value: 'frontend' }];
+      const result = resolveAdHocFilters(
+        { expr: '_time:5m', refId: 'A', adHocFilters: panelChips },
+        '_time:5m',
+        dashboard
+      );
+      expect(result.chips).toEqual([
+        { key: 'app', operator: '=', value: 'frontend' },
+        { key: 'level', operator: '=', value: 'error' },
+      ]);
+    });
+
+    it('returns chips=undefined when nothing to materialise', () => {
+      const result = resolveAdHocFilters(
+        { expr: '_time:5m', refId: 'A' },
+        '_time:5m',
+        []
+      );
+      expect(result.chips).toBeUndefined();
+    });
+  });
+
+  describe('legacy flag', () => {
+    it('isApplyExtraFiltersToRootQuery=true behaves as RootQuery', () => {
+      const result = resolveAdHocFilters(
+        { expr: '_time:5m', refId: 'A', isApplyExtraFiltersToRootQuery: true },
+        '_time:5m',
+        dashboard
+      );
+      expect(result.expr).toBe('level:="error" | _time:5m');
+      expect(result.chips).toBeUndefined();
+    });
   });
 });

--- a/src/utils/query/adHocFilters.ts
+++ b/src/utils/query/adHocFilters.ts
@@ -1,6 +1,9 @@
+import { AdHocVariableFilter } from '@grafana/data';
+
 import { splitByPipes } from '../../LogsQL/splitByPipes';
 import { addLabelToQuery } from '../../modifyQuery';
-import { AdHocFilter } from '../../types';
+import { returnVariables } from '../../parsingUtils';
+import { AdHocFilter, AdHocFilterOperator, AdHocFiltersMode, Query } from '../../types';
 
 export const serializeAdHocFilters = (filters: AdHocFilter[] | undefined): string | undefined => {
   if (!filters || filters.length === 0) {
@@ -24,6 +27,21 @@ export const queryHasPipes = (expr: string): boolean => {
   return splitByPipes(trimmed).length > 1;
 };
 
+export function resolveAdHocFiltersMode(query: Query): AdHocFiltersMode {
+  if (query.adHocFiltersMode) {
+    return query.adHocFiltersMode;
+  }
+  return query.isApplyExtraFiltersToRootQuery ? AdHocFiltersMode.RootQuery : AdHocFiltersMode.ExtraFilters;
+}
+
+export function serializeChipsForBackend(chips: AdHocFilter[] | undefined): string | undefined {
+  if (!chips?.length) {
+    return undefined;
+  }
+  const serialized = serializeAdHocFilters(chips);
+  return serialized ? returnVariables(serialized) || undefined : undefined;
+}
+
 // Appends a filter as a post-filter pipe (`| filter <expr>`) at the end of the
 // query so it runs after the pipes that may produce the filtered field. Used
 // for ad-hoc filters whose key is not present in the source data — applying
@@ -42,3 +60,47 @@ export const appendFilterPipeToQuery = (expr: string, filter: AdHocFilter): stri
   }
   return `${trimmed} | filter ${filterStr}`;
 };
+
+export interface ResolvedAdHocFilters {
+  expr: string;
+  chips: AdHocFilter[] | undefined;
+}
+
+export function resolveAdHocFilters(
+  query: Query,
+  interpolatedExpr: string,
+  dashboardFilters?: AdHocVariableFilter[],
+): ResolvedAdHocFilters {
+  const mode = resolveAdHocFiltersMode(query);
+  const merged = mergeChips(query, dashboardFilters);
+
+  switch (mode) {
+    case AdHocFiltersMode.Off:
+      // Off disables only dashboard-level ad-hoc injection; panel chips the
+      // user added themselves (via the query editor) are preserved.
+      return { expr: interpolatedExpr, chips: query.adHocFilters };
+
+    case AdHocFiltersMode.RootQuery: {
+      const prefix = serializeChipsForBackend(merged);
+      return {
+        expr: prefix ? `${prefix} | ${interpolatedExpr}` : interpolatedExpr,
+        chips: undefined,
+      };
+    }
+
+    case AdHocFiltersMode.ExtraFilters:
+      return {
+        expr: interpolatedExpr,
+        chips: merged.length ? merged : undefined,
+      };
+  }
+}
+
+function mergeChips(query: Query, dashboardFilters?: AdHocVariableFilter[]): AdHocFilter[] {
+  const dashboardChips: AdHocFilter[] = (dashboardFilters ?? []).map((f) => ({
+    key: f.key,
+    operator: f.operator as AdHocFilterOperator,
+    value: f.value,
+  }));
+  return [...(query.adHocFilters ?? []), ...dashboardChips];
+}


### PR DESCRIPTION
### Describe Your Changes

Dashboard ad-hoc filters were silently dropped when opening a panel
  in Grafana Explore. They
  are now carried over and applied according to the panel's mode:
  - Extra Filters to materialised as removable chips under the editor
  - Root Query to inlined into the query expression
  - Off to deliberately skipped

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores propagation of dashboard ad‑hoc filters when opening a panel in Grafana Explore. Filters now carry over and apply based on the panel’s ad‑hoc mode for consistent results.

- **Bug Fixes**
  - Extra Filters: materialized as removable chips in Explore.
  - Root Query: inlined at the start of the query expression.
  - Off: dashboard filters skipped; panel chips are preserved.
  - Honors legacy `isApplyExtraFiltersToRootQuery`.
  - Explore shows chips; backend receives serialized `extraFilters`.

<sup>Written for commit 265c5c9877e4a45d89da10ef07264a3aeb771b3f. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victorialogs-datasource/pull/652?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

