### PR TITLE
fix(log-context): specify sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * FEATURE: add ability to set custom field names in dashboard variables, since fields do not necessarily exist at the time of creation or manipulation (e.g. when importing a dashboard from JSON, then editing a variable). See [pr #606](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/606). Thanks to @github-vincent-miszczak for contributing.
 
 * BUGFIX: disable tenant configuration inputs (`Tenant`, `AccountID`, `ProjectID`) until the datasource health check passes. Previously, entering and clearing a tenant on a freshly created (not yet saved) datasource produced a validation error. See [#639](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/639).
+* BUGFIX: fix incorrect ordering of results in the log context view by explicitly specifying the sort direction when fetching surrounding log lines (`asc` for forward, `desc` for backward). See [pr #653](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/653). Thanks to @KoHcoJlb for contributing.
 
 ## v0.27.1
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -547,7 +547,7 @@ export class VictoriaLogsDatasource
     return lastValueFrom(this.runQuery(contextRequest));
   };
 
-  private prepareLogContextQueryExpr = (row: LogRowModel): string => {
+  private prepareLogContextQueryExpr = (row: LogRowModel, direction: LogRowContextQueryDirection): string => {
     let streamId = '';
     const streamIds = row.dataFrame.meta?.custom?.streamIds;
     if (streamIds && streamIds.length > 0) {
@@ -568,14 +568,15 @@ export class VictoriaLogsDatasource
       streamId = transformedLabels[LABEL_STREAM_ID];
     }
 
-    return addLabelToQuery('', { key: LABEL_STREAM_ID, value: streamId, operator: '' });
+    const sortDir = direction === LogRowContextQueryDirection.Forward ? 'asc' : 'desc';
+    return `${LABEL_STREAM_ID}:"${streamId}" | sort by (_time) ${sortDir}`;
   };
 
   private makeLogContextDataRequest = (row: LogRowModel, options?: LogRowContextOptions): DataQueryRequest<Query> => {
     const direction = options?.direction || LogRowContextQueryDirection.Backward;
 
     const query: Query = {
-      expr: this.prepareLogContextQueryExpr(row),
+      expr: this.prepareLogContextQueryExpr(row, direction),
       refId: `${REF_ID_STARTER_LOG_CONTEXT_QUERY}${row.dataFrame.refId}-${options?.direction}`
     };
 


### PR DESCRIPTION
### Problem
Logsql docs state that, by default, the order of returned logs is unspecified. When number of lines in Forward/Backward window exceeds default limit of 1000, without proper sorting, some log lines in the middle can be "dropped".

In example below I have 5000 test lines ingested (i=0..5000) and it caused a jump after my selected line (2500) to the last 1000 lines, instead of showing first 1000 lines starting from it.
<img width="2154" height="1366" alt="Screenshot 2026-05-21 at 23-44-50 Explore - victoriametrics-logs-datasource - Grafana" src="https://github.com/user-attachments/assets/de6de46e-80e2-4aa7-9104-525e95b21774" />

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Specify a deterministic sort order for log context queries to return the correct window around the selected log line, preventing dropped or misordered logs when results exceed the default limit.

- **Bug Fixes**
  - Always sort by `_time` with direction-specific order: `desc` for Backward, `asc` for Forward.
  - Pass `direction` to the context query builder and build `${LABEL_STREAM_ID}:"<id>" | sort by (_time) <asc|desc>`.

<sup>Written for commit 9169557637a8df9532a63b7d3c4897c1051b8646. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/victorialogs-datasource/pull/653?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

