### PR TITLE
feat: add stable id field to log frames for Copy shortlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## tip
 
+* FEATURE: add a per-row stable `id` field to log query frames so Grafana's built-in "Copy shortlink" action becomes available next to every log line in Explore and the Logs panel. See [#344](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/344).
 * FEATURE: replace the "Ad-hoc filters to root query" checkbox in Query Editor options with a three-mode selector: `Extra Filters` (default, sends filters as the `extra_filters` query parameter), `Root Query` (prepends filters to the query expression, preventing propagation into `join`/`union` subqueries) and `Off` (disables automatic ad-hoc filter injection entirely — useful when ad-hoc values are managed through Grafana variable interpolation or applied to pipe-transformed fields). Saved dashboards using the previous `isApplyExtraFiltersToRootQuery` flag continue to work without migration. See [#633](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/633). Thanks to @edspc for contributing.
 * FEATURE: add ability to set custom field names in dashboard variables, since fields do not necessarily exist at the time of creation or manipulation (e.g. when importing a dashboard from JSON, then editing a variable). See [pr #606](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/606). Thanks to @github-vincent-miszczak for contributing.
 

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -201,7 +201,14 @@ func TestDatasourceQueryRequest(t *testing.T) {
 		b, _ := labelsToJSON(labels)
 
 		labelsField.Append(b)
-		frame := data.NewFrame("", timeFd, lineField, labelsField)
+		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+		idField.Name = gIDField
+		idField.Append(buildLogID(
+			time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC),
+			"123",
+			`{application="logs-benchmark-Apache.log-1708437847",hostname="e28a622d7792"}`,
+		))
+		frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 		rsp := backend.DataResponse{}
 		frame.Meta = &data.FrameMeta{}
@@ -280,7 +287,14 @@ func TestDatasourceQueryRequest(t *testing.T) {
 		b, _ := labelsToJSON(labels)
 
 		labelsField.Append(b)
-		frame := data.NewFrame("", timeFd, lineField, labelsField)
+		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+		idField.Name = gIDField
+		idField.Append(buildLogID(
+			time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC),
+			"123",
+			`{application="logs-benchmark-Apache.log-1708437847",hostname="e28a622d7792"}`,
+		))
+		frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 		rsp := backend.DataResponse{}
 		frame.Meta = &data.FrameMeta{}
@@ -417,8 +431,8 @@ func TestDatasourceQueryRequestWithRetry(t *testing.T) {
 			t.Fatalf("expected 1 frame got %d", len(response.Frames))
 		}
 		for _, frame := range response.Frames {
-			if len(frame.Fields) != 3 {
-				t.Fatalf("expected 3 fields got %d", len(frame.Fields))
+			if len(frame.Fields) != 4 {
+				t.Fatalf("expected 4 fields got %d", len(frame.Fields))
 			}
 			if frame.Fields[1].At(0) != v {
 				t.Fatalf("unexpected value %v", frame.Fields[1].At(0))
@@ -579,7 +593,14 @@ func TestDatasourceStreamQueryRequest(t *testing.T) {
 		b, _ := labelsToJSON(labels)
 
 		labelsField.Append(b)
-		frame := data.NewFrame("", timeFd, lineField, labelsField)
+		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+		idField.Name = gIDField
+		idField.Append(buildLogID(
+			time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC),
+			"123",
+			`{application="logs-benchmark-Apache.log-1708437847",hostname="e28a622d7792"}`,
+		))
+		frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 		frame.Meta = &data.FrameMeta{PreferredVisualization: logsVisualisation}
 
 		return frame
@@ -631,7 +652,14 @@ func TestDatasourceStreamQueryRequest(t *testing.T) {
 		b, _ := labelsToJSON(labels)
 
 		labelsField.Append(b)
-		frame := data.NewFrame("", timeFd, lineField, labelsField)
+		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+		idField.Name = gIDField
+		idField.Append(buildLogID(
+			time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC),
+			"123",
+			`{application="logs-benchmark-Apache.log-1708437847",hostname="e28a622d7792"}`,
+		))
+		frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 		frame.Meta = &data.FrameMeta{PreferredVisualization: logsVisualisation}
 		return frame
 	}
@@ -783,7 +811,14 @@ func TestDatasourceStreamRequestWithRetry(t *testing.T) {
 		b, _ := labelsToJSON(labels)
 
 		labelsField.Append(b)
-		frame := data.NewFrame("", timeFd, lineField, labelsField)
+		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+		idField.Name = gIDField
+		idField.Append(buildLogID(
+			time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC),
+			"123",
+			`{application="logs-benchmark-Apache.log-1708437847",hostname="e28a622d7792"}`,
+		))
+		frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 		frame.Meta = &data.FrameMeta{PreferredVisualization: logsVisualisation}
 
 		return frame
@@ -835,7 +870,14 @@ func TestDatasourceStreamRequestWithRetry(t *testing.T) {
 		b, _ := labelsToJSON(labels)
 
 		labelsField.Append(b)
-		frame := data.NewFrame("", timeFd, lineField, labelsField)
+		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+		idField.Name = gIDField
+		idField.Append(buildLogID(
+			time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC),
+			"123",
+			`{application="logs-benchmark-Apache.log-1708437847",hostname="e28a622d7792"}`,
+		))
+		frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 		frame.Meta = &data.FrameMeta{PreferredVisualization: logsVisualisation}
 		return frame
 	}

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"strconv"
 	"time"
@@ -28,9 +29,22 @@ const (
 	gTimeField   = "Time"
 	gLineField   = "Line"
 	gValueField  = "Value"
+	gIDField     = "id"
 
 	logsVisualisation = "logs"
 )
+
+// buildLogID returns a stable identifier for a log row, used by Grafana's
+// Logs panel to enable per-row permalinks ("Copy shortlink").
+func buildLogID(ts time.Time, msg, stream string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(strconv.FormatInt(ts.UnixNano(), 10)))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(msg))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(stream))
+	return strconv.FormatUint(h.Sum64(), 16)
+}
 
 var nowFunc = time.Now
 
@@ -46,6 +60,9 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 
 	lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 	lineField.Name = gLineField
+
+	idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+	idField.Name = gIDField
 
 	br := bufio.NewReaderSize(reader, 64*1024)
 	var parser fastjson.Parser
@@ -75,9 +92,16 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 			return newResponseError(fmt.Errorf("error decode response: %s", err), backend.StatusInternal)
 		}
 
+		var (
+			rowMsg    string
+			rowStream string
+			rowTime   time.Time
+		)
+
 		if value.Exists(messageField) {
 			message := value.GetStringBytes(messageField)
-			lineField.Append(string(message))
+			rowMsg = string(message)
+			lineField.Append(rowMsg)
 		}
 		if value.Exists(timeField) {
 			t := value.GetStringBytes(timeField)
@@ -85,13 +109,15 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 			if err != nil {
 				return newResponseError(fmt.Errorf("error parse time from _time field: %s", err), backend.StatusInternal)
 			}
-			timeFd.Append(getTime)
+			rowTime = getTime
+			timeFd.Append(rowTime)
 		}
 
 		labels := data.Labels{}
 		if value.Exists(streamField) {
 			stream := value.GetStringBytes(streamField)
-			stf, err := utils.ParseStreamFields(string(stream))
+			rowStream = string(stream)
+			stf, err := utils.ParseStreamFields(rowStream)
 			if err != nil {
 				return newResponseError(fmt.Errorf("%s", err), backend.StatusInternal)
 			}
@@ -123,6 +149,7 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 			return newResponseError(err, backend.StatusInternal)
 		}
 		labelsField.Append(d)
+		idField.Append(buildLogID(rowTime, rowMsg, rowStream))
 	}
 
 	// Grafana expects lineFields to be always non-empty.
@@ -141,7 +168,7 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 		}
 	}
 
-	frame := data.NewFrame("", timeFd, lineField, labelsField)
+	frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 	rsp := backend.DataResponse{}
 	frame.Meta = &data.FrameMeta{}
@@ -169,6 +196,9 @@ func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
 		lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		lineField.Name = gLineField
 
+		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+		idField.Name = gIDField
+
 		b, err := br.ReadBytes('\n')
 		if err != nil {
 			if errors.Is(err, bufio.ErrBufferFull) {
@@ -193,9 +223,16 @@ func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
 			return fmt.Errorf("error decode response: %s", err)
 		}
 
+		var (
+			rowMsg    string
+			rowStream string
+			rowTime   time.Time
+		)
+
 		if value.Exists(messageField) {
 			message := value.GetStringBytes(messageField)
-			lineField.Append(string(message))
+			rowMsg = string(message)
+			lineField.Append(rowMsg)
 		}
 		if value.Exists(timeField) {
 			t := value.GetStringBytes(timeField)
@@ -203,13 +240,15 @@ func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
 			if err != nil {
 				return fmt.Errorf("error parse time from _time field: %s", err)
 			}
-			timeFd.Append(getTime)
+			rowTime = getTime
+			timeFd.Append(rowTime)
 		}
 
 		labels := data.Labels{}
 		if value.Exists(streamField) {
 			stream := value.GetStringBytes(streamField)
-			stf, err := utils.ParseStreamFields(string(stream))
+			rowStream = string(stream)
+			stf, err := utils.ParseStreamFields(rowStream)
 			if err != nil {
 				return err
 			}
@@ -238,6 +277,7 @@ func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
 			return err
 		}
 		labelsField.Append(d)
+		idField.Append(buildLogID(rowTime, rowMsg, rowStream))
 
 		// Grafana expects lineFields to be always non-empty.
 		if lineField.Len() == 0 {
@@ -255,7 +295,7 @@ func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
 			}
 		}
 
-		frame := data.NewFrame("", timeFd, lineField, labelsField)
+		frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 		// this is necessary information because the logs visualization is preferred
 		frame.Meta = &data.FrameMeta{PreferredVisualization: logsVisualisation}
 

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -17,6 +17,67 @@ import (
 	"github.com/VictoriaMetrics/victorialogs-datasource/pkg/utils"
 )
 
+// newIDField creates an id field pre-populated for the provided rows.
+// Each row is described by its raw (timestamp, _msg, _stream) tuple — the
+// same inputs that buildLogID receives in production code.
+func newIDField(rows ...struct {
+	ts     time.Time
+	msg    string
+	stream string
+}) *data.Field {
+	f := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+	f.Name = gIDField
+	for _, r := range rows {
+		f.Append(buildLogID(r.ts, r.msg, r.stream))
+	}
+	return f
+}
+
+type row = struct {
+	ts     time.Time
+	msg    string
+	stream string
+}
+
+func Test_buildLogID(t *testing.T) {
+	ts := time.Date(2024, 2, 20, 14, 4, 27, 0, time.UTC)
+
+	// stability: same input produces same id
+	id1 := buildLogID(ts, "hello", `{a="1"}`)
+	id2 := buildLogID(ts, "hello", `{a="1"}`)
+	if id1 != id2 {
+		t.Errorf("buildLogID is not stable: %s != %s", id1, id2)
+	}
+
+	// uniqueness: differing inputs produce different ids
+	cases := []struct {
+		name string
+		ts   time.Time
+		msg  string
+		stm  string
+	}{
+		{"baseline", ts, "hello", `{a="1"}`},
+		{"different time", ts.Add(time.Nanosecond), "hello", `{a="1"}`},
+		{"different msg", ts, "hello!", `{a="1"}`},
+		{"different stream", ts, "hello", `{a="2"}`},
+	}
+	seen := make(map[string]string, len(cases))
+	for _, c := range cases {
+		id := buildLogID(c.ts, c.msg, c.stm)
+		if prev, ok := seen[id]; ok {
+			t.Errorf("buildLogID collision between %q and %q -> %s", prev, c.name, id)
+		}
+		seen[id] = c.name
+	}
+
+	// boundary safety: prefix-shifted msg/stream must not collide
+	a := buildLogID(ts, "ab", "cd")
+	b := buildLogID(ts, "a", "bcd")
+	if a == b {
+		t.Errorf("buildLogID collides across msg/stream boundary: %s", a)
+	}
+}
+
 func Test_parseInstantResponse(t *testing.T) {
 	now := time.Now()
 	nowFunc = func() time.Time {
@@ -82,7 +143,9 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			idField := newIDField()
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -133,7 +196,8 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2024, 02, 20, 00, 00, 00, 0, time.UTC))
+			ts := time.Date(2024, 02, 20, 00, 00, 00, 0, time.UTC)
+			timeFd.Append(ts)
 
 			lineField.Append("")
 
@@ -142,7 +206,10 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ := labelsToJSON(labels)
 
 			labelsField.Append(b)
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			idField := newIDField(row{ts, "", "{}"})
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -166,7 +233,8 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
+			ts := time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC)
+			timeFd.Append(ts)
 
 			lineField.Append("123")
 
@@ -178,7 +246,11 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ := labelsToJSON(labels)
 
 			labelsField.Append(b)
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			stream := `{application="logs-benchmark-Apache.log-1708437847",hostname="e28a622d7792"}`
+			idField := newIDField(row{ts, "123", stream})
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -202,7 +274,8 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
+			ts := time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC)
+			timeFd.Append(ts)
 
 			lineField.Append("123")
 
@@ -215,7 +288,11 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ := labelsToJSON(labels)
 
 			labelsField.Append(b)
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			stream := `{application="logs-benchmark-Apache.log-1708437847",hostname="e28a622d7792"}`
+			idField := newIDField(row{ts, "123", stream})
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -259,7 +336,15 @@ func Test_parseInstantResponse(t *testing.T) {
 			}
 			b, _ = labelsToJSON(labels)
 			labelsField.Append(b)
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			// _time absent → rowTime is zero in buildLogID; nowFunc is only used to
+			// pad timeFd for visualization purposes.
+			idField := newIDField(
+				row{time.Time{}, "", ""},
+				row{time.Time{}, "", ""},
+			)
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -294,7 +379,9 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ := labelsToJSON(labels)
 			labelsField.Append(b)
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			idField := newIDField(row{time.Time{}, "", ""})
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -318,8 +405,10 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2024, 06, 26, 13, 00, 00, 0, time.UTC))
-			timeFd.Append(time.Date(2024, 06, 26, 14, 00, 00, 0, time.UTC))
+			ts1 := time.Date(2024, 06, 26, 13, 00, 00, 0, time.UTC)
+			ts2 := time.Date(2024, 06, 26, 14, 00, 00, 0, time.UTC)
+			timeFd.Append(ts1)
+			timeFd.Append(ts2)
 
 			lineField.Append(`{"logs":"1400"}`)
 			lineField.Append(`{"logs":"374"}`)
@@ -338,7 +427,15 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ = labelsToJSON(labels)
 			labelsField.Append(b)
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			// No _msg and no _stream in this fixture — lineField is later
+			// filled from labelsField by the parseInstantResponse fallback,
+			// but buildLogID was called with empty rowMsg/rowStream before that.
+			idField := newIDField(
+				row{ts1, "", ""},
+				row{ts2, "", ""},
+			)
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -362,9 +459,11 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2024, 06, 26, 13, 15, 15, 0, time.UTC))
+			ts := time.Date(2024, 06, 26, 13, 15, 15, 0, time.UTC)
+			timeFd.Append(ts)
 
-			lineField.Append(`\x1b[2m2024-06-26T13:15:15.004Z\x1b[0;39m \x1b[32mTRACE\x1b[0;39m \x1b[35m1\x1b[0;39m \x1b[2m---\x1b[0;39m \x1b[2m[    parallel-19]\x1b[0;39m \x1b[36mo.s.c.g.f.WeightCalculatorWebFilter     \x1b[0;39m \x1b[2m:\x1b[0;39m Weights attr: {} `)
+			msg := `\x1b[2m2024-06-26T13:15:15.004Z\x1b[0;39m \x1b[32mTRACE\x1b[0;39m \x1b[35m1\x1b[0;39m \x1b[2m---\x1b[0;39m \x1b[2m[    parallel-19]\x1b[0;39m \x1b[36mo.s.c.g.f.WeightCalculatorWebFilter     \x1b[0;39m \x1b[2m:\x1b[0;39m Weights attr: {} `
+			lineField.Append(msg)
 
 			labels := data.Labels{
 				"compose_project": "app",
@@ -375,7 +474,10 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ := labelsToJSON(labels)
 			labelsField.Append(b)
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			stream := `{compose_project="app",compose_service="gateway"}`
+			idField := newIDField(row{ts, msg, stream})
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -399,16 +501,19 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2024, 06, 26, 13, 20, 34, 0, time.UTC))
+			ts := time.Date(2024, 06, 26, 13, 20, 34, 0, time.UTC)
+			timeFd.Append(ts)
 
 			value, err := fastjson.Parse(`{"_msg":"\u001b[2m2024-06-26T13:20:34.608Z\u001b[0;39m \u001b[33m WARN\u001b[0;39m \u001b[35m1\u001b[0;39m \u001b[2m---\u001b[0;39m \u001b[2m[           main]\u001b[0;39m \u001b[36mjakarta.persistence.spi                 \u001b[0;39m \u001b[2m:\u001b[0;39m jakarta.persistence.spi::No valid providers found. "}`)
 			if err != nil {
 				t.Fatalf("error decode response: %s", err)
 			}
 
+			var msg string
 			if value.Exists(messageField) {
 				message := value.GetStringBytes(messageField)
-				lineField.Append(string(message))
+				msg = string(message)
+				lineField.Append(msg)
 			}
 
 			labels := data.Labels{
@@ -419,7 +524,10 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ := labelsToJSON(labels)
 			labelsField.Append(b)
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			stream := `{compose_project="app",compose_service="gateway"}`
+			idField := newIDField(row{ts, msg, stream})
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -454,7 +562,9 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ := labelsToJSON(labels)
 			labelsField.Append(b)
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			idField := newIDField(row{time.Time{}, "507", ""})
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -478,9 +588,12 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2024, 9, 10, 12, 24, 38, 124811000, time.UTC))
-			timeFd.Append(time.Date(2024, 9, 10, 12, 36, 10, 664553169, time.UTC))
-			timeFd.Append(time.Date(2024, 9, 10, 13, 06, 56, 451470000, time.UTC))
+			ts1 := time.Date(2024, 9, 10, 12, 24, 38, 124811000, time.UTC)
+			ts2 := time.Date(2024, 9, 10, 12, 36, 10, 664553169, time.UTC)
+			ts3 := time.Date(2024, 9, 10, 13, 06, 56, 451470000, time.UTC)
+			timeFd.Append(ts1)
+			timeFd.Append(ts2)
+			timeFd.Append(ts3)
 
 			lineField.Append("1")
 
@@ -518,7 +631,15 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ = labelsToJSON(labels)
 			labelsField.Append(b)
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			stream1and3 := `{path="/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log",stream="stderr"}`
+			stream2 := `{stream="stream1"}`
+			idField := newIDField(
+				row{ts1, "1", stream1and3},
+				row{ts2, "2", stream2},
+				row{ts3, "3", stream1and3},
+			)
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -542,7 +663,8 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2024, 9, 10, 12, 36, 10, 664553169, time.UTC))
+			ts := time.Date(2024, 9, 10, 12, 36, 10, 664553169, time.UTC)
+			timeFd.Append(ts)
 
 			// string with more than 1MB
 			str := strings.Repeat("1", 1024*1024*2)
@@ -559,7 +681,10 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ := labelsToJSON(labels)
 			labelsField.Append(b)
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			stream := `{stream="stream1"}`
+			idField := newIDField(row{ts, str, stream})
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -583,7 +708,8 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
+			ts := time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC)
+			timeFd.Append(ts)
 
 			lineField.Append("123")
 
@@ -597,7 +723,11 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ := labelsToJSON(labels)
 
 			labelsField.Append(b)
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			stream := `{Dino Species="Stegosaurus",kubernetes.labels.app.kubernetes.io/instance="123",kubernetes.labels.app.kubernetes.io/name="vmagent",kubernetes.namespace_name="monitoring"}`
+			idField := newIDField(row{ts, "123", stream})
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -621,7 +751,8 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC))
+			ts := time.Date(2024, 02, 20, 14, 04, 27, 0, time.UTC)
+			timeFd.Append(ts)
 
 			lineField.Append("123")
 
@@ -635,7 +766,11 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ := labelsToJSON(labels)
 
 			labelsField.Append(b)
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+
+			stream := `{kubernetes.host="host1",kubernetes.labels.app.kubernetes.io/instance="123",kubernetes.labels.app.kubernetes.io/name="vmagent",kubernetes.namespace_name="monitoring"}`
+			idField := newIDField(row{ts, "123", stream})
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -659,8 +794,10 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2025, 7, 8, 9, 16, 54, 721591656, time.UTC))
-			timeFd.Append(time.Date(2025, 7, 8, 9, 16, 54, 734626217, time.UTC))
+			ts1 := time.Date(2025, 7, 8, 9, 16, 54, 721591656, time.UTC)
+			ts2 := time.Date(2025, 7, 8, 9, 16, 54, 734626217, time.UTC)
+			timeFd.Append(ts1)
+			timeFd.Append(ts2)
 
 			lineField.Append("some new message")
 
@@ -690,7 +827,14 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ = labelsToJSON(labels)
 			labelsField.Append(b)
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			stream1 := `{container.id="1",container.name="1"}`
+			stream2 := `{container.id="2",container.name="2"}`
+			idField := newIDField(
+				row{ts1, "some new message", stream1},
+				row{ts2, "", stream2},
+			)
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -748,7 +892,13 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ = labelsToJSON(labels)
 			labelsField.Append(b)
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			idField := newIDField(
+				row{time.Time{}, "", `{az_id="use1-az2",source="vector",vpc_id="vpc"}`},
+				row{time.Time{}, "", `{namespace="ops-monitoring-ns"}`},
+				row{time.Time{}, "", `{}`},
+			)
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}
@@ -771,10 +921,13 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 			lineField.Name = gLineField
 
-			timeFd.Append(time.Date(2025, 9, 23, 14, 26, 33, 559652000, time.UTC))
-			timeFd.Append(time.Date(2025, 9, 23, 14, 26, 33, 559441000, time.UTC))
+			ts1 := time.Date(2025, 9, 23, 14, 26, 33, 559652000, time.UTC)
+			ts2 := time.Date(2025, 9, 23, 14, 26, 33, 559441000, time.UTC)
+			timeFd.Append(ts1)
+			timeFd.Append(ts2)
 
-			lineField.Append("2025-09-23 14:26:33.559569822  172.16.0.110 - - [23/Sep/2025:14:26:33 +0000] \"GET /health HTTP/1.1\" 200 10168 \"-\" \"kube-probe/1.34\" ")
+			msg := "2025-09-23 14:26:33.559569822  172.16.0.110 - - [23/Sep/2025:14:26:33 +0000] \"GET /health HTTP/1.1\" 200 10168 \"-\" \"kube-probe/1.34\" "
+			lineField.Append(msg)
 
 			labels := data.Labels{
 				"_stream_id":                "00000000000000000899b9a9578ea0f11a8a45c1b4cc8e34",
@@ -794,7 +947,13 @@ func Test_parseInstantResponse(t *testing.T) {
 			b, _ = labelsToJSON(labels)
 			labelsField.Append(b)
 
-			frame := data.NewFrame("", timeFd, lineField, labelsField)
+			stream1 := `{kubernetes.container_name="frigate",stream="stdout"}`
+			idField := newIDField(
+				row{ts1, msg, stream1},
+				row{ts2, "", `{}`},
+			)
+
+			frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 			rsp := backend.DataResponse{}
 			frame.Meta = &data.FrameMeta{}


### PR DESCRIPTION
Related issue: #344 

### Describe Your Changes

Grafana's built-in "Copy shortlink" action next to each log line is gated on the presence of a stable `id` field in the data frame. `parseInstantResponse` and `parseStreamResponse` now compute `id = FNV-1a64 hex of (_time | _msg | _stream)` and emit it alongside `Time/Line/labels`. The hash uses a NUL separator between fields to avoid prefix-boundary collisions and is deterministic across re-queries, so a copied permalink resolves to the same log row.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stable per-row `id` to log frames so Grafana’s “Copy shortlink” shows next to every log line and links to the same row across re-queries. Addresses #344.

- **New Features**
  - Compute `id` as FNV-1a 64-bit hex of `_time`, `_msg`, and `_stream` with NUL separators for boundary safety and deterministic results.
  - Include `id` in instant and stream frames (`parseInstantResponse`, `parseStreamResponse`); update tests to cover stability and new frame shape.

<sup>Written for commit 90516a76c9a49fa30a28167de7ab0ddb1828465e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/victorialogs-datasource/pull/654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

