### PR TITLE
feat(variables): allow variable as Field in Field Values query (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * FEATURE: add ability to set custom field names in dashboard variables, since fields do not necessarily exist at the time of creation or manipulation (e.g. when importing a dashboard from JSON, then editing a variable). See [pr #606](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/606). Thanks to @github-vincent-miszczak for contributing.
 * FEATURE: group selected values under the same stream filter field into a single chip in the Stream Filters bar and popover. Each value keeps its own remove button, and a separate remove button clears the whole field at once. See [#647](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/647).
 * FEATURE: log level filter buttons now add removable filter chips and refresh results on click, instead of editing your query text. Your query stays exactly as you wrote it, and the buttons are available in both the code and visual builder editors.
+* FEATURE: support dashboard variables in the Field of a "Field values" template variable query. See [#377](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/377).
 
 * BUGFIX: restore propagation of dashboard ad-hoc filters when navigating from a panel to Grafana Explore.
 * BUGFIX: disable tenant configuration inputs (`Tenant`, `AccountID`, `ProjectID`) until the datasource health check passes. Previously, entering and clearing a tenant on a freshly created (not yet saved) datasource produced a validation error. See [#639](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/639).

--- a/src/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -1,12 +1,15 @@
 import { debounce } from 'lodash';
-import React, { FormEvent, useEffect, useState } from 'react';
+import React, { FormEvent, useEffect, useMemo, useState } from 'react';
 
 import { DEFAULT_FIELD_DISPLAY_VALUES_LIMIT, QueryEditorProps, SelectableValue } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
 
 import { VictoriaLogsDatasource } from '../../datasource';
 import { FilterFieldType, Options, Query, VariableQuery } from '../../types';
 import { CompatibleCombobox } from '../CompatibleCombobox';
+
+import { FieldOption, toVariableOptions } from './variableOptions';
 
 const variableOptions = [
   { label: 'Field names', value: FilterFieldType.FieldName },
@@ -22,9 +25,12 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
   const [queryFilter, setQueryFilter] = useState<string>('');
   const [field, setField] = useState<string>('');
   const [limit, setLimit] = useState<number>(DEFAULT_FIELD_DISPLAY_VALUES_LIMIT);
-  const [fieldNames, setFieldNames] = useState<Array<{ value: string; label: string; description?: string }>>([]);
+  const [fieldNames, setFieldNames] = useState<FieldOption[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
+
+  const dashboardVariableOptions = useMemo(() => toVariableOptions(getTemplateSrv().getVariables()), []);
+  const fieldOptions = useMemo(() => [...dashboardVariableOptions, ...fieldNames], [dashboardVariableOptions, fieldNames]);
 
   const handleTypeChange = (newType: SelectableValue<FilterFieldType>) => {
     if (!newType.value) {
@@ -140,7 +146,7 @@ export const VariableQueryEditor = ({ onChange, query, datasource, range }: Prop
               placeholder='Select field'
               onChange={handleFieldChange}
               value={field || null}
-              options={fieldNames}
+              options={fieldOptions}
               width={20}
               loading={isLoading}
               createCustomValue

--- a/src/components/VariableQueryEditor/variableOptions.test.ts
+++ b/src/components/VariableQueryEditor/variableOptions.test.ts
@@ -1,0 +1,31 @@
+import { TypedVariableModel } from '@grafana/data';
+
+import { toVariableOptions } from './variableOptions';
+
+// minimal stub — only `name` is needed by toVariableOptions
+const asVariables = (names: string[]): TypedVariableModel[] =>
+  names.map((name) => ({ name })) as unknown as TypedVariableModel[];
+
+describe('toVariableOptions', () => {
+  it('returns an empty array for no variables', () => {
+    expect(toVariableOptions([])).toEqual([]);
+  });
+
+  it('maps each variable to a $-prefixed option with a description', () => {
+    expect(toVariableOptions(asVariables(['field_var']))).toEqual([
+      { label: '$field_var', value: '$field_var', description: 'Dashboard variable' },
+    ]);
+  });
+
+  it('preserves variable order', () => {
+    expect(toVariableOptions(asVariables(['a', 'b', 'c'])).map((o) => o.value)).toEqual([
+      '$a',
+      '$b',
+      '$c',
+    ]);
+  });
+
+  it('keeps special characters in the variable name', () => {
+    expect(toVariableOptions(asVariables(['my.var-1'])).map((o) => o.value)).toEqual(['$my.var-1']);
+  });
+});

--- a/src/components/VariableQueryEditor/variableOptions.ts
+++ b/src/components/VariableQueryEditor/variableOptions.ts
@@ -1,0 +1,16 @@
+import { TypedVariableModel } from '@grafana/data';
+
+export interface FieldOption {
+  label: string;
+  value: string;
+  description?: string;
+}
+
+// Maps Grafana variable models to Field-combobox options in the `$name` form
+// expected by templateSrv.replace.
+export const toVariableOptions = (variables: TypedVariableModel[]): FieldOption[] =>
+  variables.map((v) => ({
+    label: `$${v.name}`,
+    value: `$${v.name}`,
+    description: 'Dashboard variable',
+  }));


### PR DESCRIPTION
Related issue: #377 

### Describe Your Changes

Offer dashboard variables as options in the Field dropdown of the variable query editor

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable selecting a dashboard variable as the Field in “Field values” variable queries. Variables appear at the top of the Field dropdown and are passed as `$name`, addressing #377.

- **New Features**
  - List dashboard variables in the Field selector (as `$var`) before fetched field names, with a "Dashboard variable" hint.
  - Adds `toVariableOptions` (and tests) to map Grafana variables to `$name` Field options while preserving order.

<sup>Written for commit 6eda4f57379889f63ff12bcccb13f38c28e07b79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/victorialogs-datasource/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

