### PR TITLE
feat(adhoc filters): narrow down field and value lists by selected filters (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * FEATURE: group selected values under the same stream filter field into a single chip in the Stream Filters bar and popover. Each value keeps its own remove button, and a separate remove button clears the whole field at once. See [#647](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/647).
 * FEATURE: log level filter buttons now add removable filter chips and refresh results on click, instead of editing your query text. Your query stays exactly as you wrote it, and the buttons are available in both the code and visual builder editors.
 * FEATURE: support dashboard variables in the Field of a "Field values" template variable query. See [#377](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/377).
+* FEATURE: narrow down the Ad hoc filter field and value dropdowns based on the filters you have already selected. See [#313](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/313).
 
 * BUGFIX: restore propagation of dashboard ad-hoc filters when navigating from a panel to Grafana Explore.
 * BUGFIX: disable tenant configuration inputs (`Tenant`, `AccountID`, `ProjectID`) until the datasource health check passes. Previously, entering and clearing a tenant on a freshly created (not yet saved) datasource produced a validation error. See [#639](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/639).

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1068,4 +1068,83 @@ describe('VictoriaLogsDatasource preset merge', () => {
       });
     });
   });
+
+  describe('getTagKeys / getTagValues narrow-down', () => {
+    let dsLocal: VictoriaLogsDatasource;
+    let getFieldList: jest.Mock;
+
+    beforeEach(() => {
+      const templateSrvMock = {
+        replace: jest.fn((a: string) => a),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      dsLocal = createDatasource(templateSrvMock);
+      getFieldList = jest.fn().mockResolvedValue([{ value: 'foo' }]);
+      dsLocal.languageProvider = { getFieldList } as any;
+    });
+
+    it('getTagKeys without filters sends no narrowing query', async () => {
+      await dsLocal.getTagKeys({ filters: [] });
+      expect(getFieldList.mock.calls[0][0].query).toBeUndefined();
+    });
+
+    it('getTagKeys with one filter builds LogsQL query', async () => {
+      const filters: AdHocVariableFilter[] = [{ key: 'level', operator: '=', value: 'error' }];
+      await dsLocal.getTagKeys({ filters });
+      expect(getFieldList.mock.calls[0][0].query).toBe('level:="error"');
+    });
+
+    it('getTagKeys with two filters joins them with AND', async () => {
+      const filters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+        { key: 'app', operator: '=', value: 'api' },
+      ];
+      await dsLocal.getTagKeys({ filters });
+      expect(getFieldList.mock.calls[0][0].query).toBe('level:="error" AND app:="api"');
+    });
+
+    it('getTagValues excludes filters on the queried key', async () => {
+      const filters: AdHocVariableFilter[] = [
+        { key: 'level', operator: '=', value: 'error' },
+        { key: 'app', operator: '=', value: 'api' },
+      ];
+      await dsLocal.getTagValues({ key: 'level', filters });
+      const opts = getFieldList.mock.calls[0][0];
+      expect(opts.field).toBe('level');
+      expect(opts.query).toBe('app:="api"');
+    });
+
+    it('getTagValues narrows by other-key filters', async () => {
+      const filters: AdHocVariableFilter[] = [{ key: 'level', operator: '=', value: 'error' }];
+      await dsLocal.getTagValues({ key: 'app', filters });
+      const opts = getFieldList.mock.calls[0][0];
+      expect(opts.field).toBe('app');
+      expect(opts.query).toBe('level:="error"');
+    });
+
+    it('getTagValues with only same-key filter sends no narrowing query', async () => {
+      const filters: AdHocVariableFilter[] = [{ key: 'level', operator: '=', value: 'error' }];
+      await dsLocal.getTagValues({ key: 'level', filters });
+      expect(getFieldList.mock.calls[0][0].query).toBeUndefined();
+    });
+
+    it('getTagKeys resolves a variable in the filter value', async () => {
+      const templateSrvMock = {
+        replace: jest.fn(() => 'env:="prod"'),
+        getVariables: jest.fn().mockReturnValue([]),
+      } as unknown as TemplateSrv;
+      const ds2 = createDatasource(templateSrvMock);
+      const gfl = jest.fn().mockResolvedValue([]);
+      ds2.languageProvider = { getFieldList: gfl } as any;
+      const filters: AdHocVariableFilter[] = [{ key: 'env', operator: '=', value: '$env' }];
+      await ds2.getTagKeys({ filters });
+      expect(gfl.mock.calls[0][0].query).toBe('env:="prod"');
+    });
+
+    it('getTagKeys builds regex operator filter', async () => {
+      const filters: AdHocVariableFilter[] = [{ key: 'app', operator: '=~', value: 'api.*' }];
+      await dsLocal.getTagKeys({ filters });
+      expect(getFieldList.mock.calls[0][0].query).toBe('app:~"api.*"');
+    });
+  });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -322,6 +322,7 @@ export class VictoriaLogsDatasource
       type: FilterFieldType.FieldName,
       timeRange: options?.timeRange,
       limit: DEFAULT_FIELD_DISPLAY_VALUES_LIMIT,
+      query: this.buildNarrowingQuery(options?.filters),
     }, this.customQueryParameters);
     return list
       ? list.map(({ value }) => ({ text: value || ' ' }))
@@ -329,15 +330,32 @@ export class VictoriaLogsDatasource
   }
 
   async getTagValues(options: DataSourceGetTagValuesOptions<Query>): Promise<MetricFindValue[]> {
+    // Exclude filters on the queried key so its own value can still be changed
+    const otherFilters = options.filters?.filter((f) => f.key !== options.key);
     const list = await this.languageProvider?.getFieldList({
       type: FilterFieldType.FieldValue,
       timeRange: options.timeRange,
       limit: DEFAULT_FIELD_DISPLAY_VALUES_LIMIT,
       field: options.key,
+      query: this.buildNarrowingQuery(otherFilters),
     }, this.customQueryParameters);
     return list
       ? list.map(({ value }) => ({ text: value || ' ' }))
       : [];
+  }
+
+  /**
+   * Builds a LogsQL query that narrows field/value lookups to the logs matching the
+   * already-selected Ad Hoc filters. Returns undefined when there are no filters so the
+   * caller falls back to the default `*` (all logs)
+   */
+  private buildNarrowingQuery(filters?: AdHocVariableFilter[]): string | undefined {
+    const expr = this.getExtraFilters(filters);
+    if (!expr) {
+      return undefined;
+    }
+    // Resolve template variables (incl. multi-value) before hitting the VL endpoint directly
+    return this.interpolateString(expr);
   }
 
   isAllOption(variable: TypedVariableModel): boolean {


### PR DESCRIPTION
Related issue: #313 

### Describe Your Changes

- Add buildNarrowingQuery helper that folds selected ad-hoc filters into a LogsQL query and resolves template variables
- getTagKeys/getTagValues now pass the narrowing query to field lookups so dropdowns reflect already-selected filters
<img width="677" height="180" alt="image" src="https://github.com/user-attachments/assets/095d8232-c7ad-446a-b6db-81ae4822ee9e" />


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
