### PR TITLE
.github: add explicit persist-credentials for checkout action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           path: __vl-datasource
+          persist-credentials: false
 
       - name: Checkout docs code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
@@ -28,6 +29,7 @@ jobs:
           repository: VictoriaMetrics/vmdocs
           ref: main
           token: ${{ secrets.VM_BOT_GH_TOKEN }}
+          persist-credentials: true  # required by the "Push to docs repo" step below
           path: __vm-docs
 
       - name: Import GPG key

--- a/.github/workflows/pr-checks-backend.yml
+++ b/.github/workflows/pr-checks-backend.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
       - name: Restore binaries from cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
@@ -65,6 +67,8 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:

--- a/.github/workflows/pr-checks-frontend.yml
+++ b/.github/workflows/pr-checks-frontend.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0

--- a/.github/workflows/pr-checks-plugin.yml
+++ b/.github/workflows/pr-checks-plugin.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0

--- a/.github/workflows/pr-codeql-backend.yml
+++ b/.github/workflows/pr-codeql-backend.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0

--- a/.github/workflows/pr-codeql-frontend.yml
+++ b/.github/workflows/pr-codeql-frontend.yml
@@ -36,6 +36,7 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       with:
         fetch-depth: 2
+        persist-credentials: false
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2

--- a/.github/workflows/pr-test-build.yaml
+++ b/.github/workflows/pr-test-build.yaml
@@ -147,6 +147,7 @@ jobs:
           repository: ${{ needs.check-permissions.outputs.pr-repo }}
           ref: ${{ needs.check-permissions.outputs.pr-ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Run OSV Scanner
         id: osv-scan
@@ -82,6 +84,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: true  # required by the "Prepare release notes if tag not exists" and "Automatic changelog update" steps below
       - name: Restore binaries from cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:

--- a/.github/workflows/wait-for-publish.yaml
+++ b/.github/workflows/wait-for-publish.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
       
       - name: Get issues with 'waiting for publish' label
         id: get-issues


### PR DESCRIPTION

### Describe Your Changes

Add explicit `persist-credentials` as it's `true` by default.

More Info: https://github.com/actions/checkout/issues/485

cc: @arkid15r

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
