### PR TITLE
feat(logs): highlight LogsQL search terms in log lines (#519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * FEATURE: keep log fields in the order returned by VictoriaLogs (for example the order from `| fields a, b, c`) instead of sorting them alphabetically. See [#563](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/563).
+* FEATURE: highlight the terms you search for directly in the matching log lines for LogsQL queries — word filters (e.g. `error`), quoted phrases, `_msg:` filters, and `filter` pipes. See [#519](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/519).
 
 * BUGFIX: lower the default datasource `Maximum lines` limit from 1000 to 50 to reduce browser rendering load and prevent the page from freezing on heavy log results. You can change this value in the datasource configuration. See [Line limits](https://docs.victoriametrics.com/victorialogs/integrations/grafana/#line-limits) docs and [#669](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/669).
 

--- a/src/LogsQL/extractMsgSearchWords.test.ts
+++ b/src/LogsQL/extractMsgSearchWords.test.ts
@@ -73,6 +73,54 @@ describe('extractMsgSearchWords', () => {
     expect(extractMsgSearchWords('_msg:~"err.*"')).toEqual(['err.*']);
   });
 
+  describe('function-style filters', () => {
+    it('does not highlight the filter function name', () => {
+      expect(extractMsgSearchWords('i(error)')).toEqual(['error']);
+      expect(extractMsgSearchWords('exact(error)')).toEqual(['error']);
+    });
+    it('does not highlight the function name of an explicit _msg filter', () => {
+      expect(extractMsgSearchWords('_msg:i(error)')).toEqual(['error']);
+      expect(extractMsgSearchWords('_msg: i(error)')).toEqual(['error']);
+      expect(extractMsgSearchWords('_msg:exact(error)')).toEqual(['error']);
+    });
+    it('skips a function-style filter on a non-_msg field', () => {
+      expect(extractMsgSearchWords('app:i(error)')).toEqual([]);
+    });
+    it('skips a negated function-style filter entirely', () => {
+      expect(extractMsgSearchWords('-i(debug) warn')).toEqual(['warn']);
+      expect(extractMsgSearchWords('NOT exact(debug) warn')).toEqual(['warn']);
+    });
+  });
+
+  describe('grouped values after a field', () => {
+    it('skips a grouped value of a non-_msg field', () => {
+      expect(extractMsgSearchWords('app:(buggy_app OR foobar)')).toEqual([]);
+      expect(extractMsgSearchWords('level:(error OR warn)')).toEqual([]);
+    });
+    it('still highlights a grouped value of the _msg field', () => {
+      expect(extractMsgSearchWords('_msg:(a OR b)')).toEqual(['a', 'b']);
+    });
+    it('handles a space before the grouped value', () => {
+      expect(extractMsgSearchWords('app: (buggy_app OR foobar)')).toEqual([]);
+    });
+    it('skips a negated grouped value of a non-_msg field', () => {
+      expect(extractMsgSearchWords('-app:(buggy_app) warn')).toEqual(['warn']);
+    });
+  });
+
+  describe('comments', () => {
+    it('strips a trailing comment', () => {
+      expect(extractMsgSearchWords('error # debug')).toEqual(['error']);
+    });
+    it('strips a comment but keeps the next line', () => {
+      expect(extractMsgSearchWords('error # debug\nwarn')).toEqual(['error', 'warn']);
+    });
+    it('does not treat a # inside a quoted value as a comment', () => {
+      expect(extractMsgSearchWords('_msg:"a#b"')).toEqual(['a#b']);
+      expect(extractMsgSearchWords('"a # b"')).toEqual(['a # b']);
+    });
+  });
+
   describe('segments after the first pipe', () => {
     it('does not highlight bare words inside non-filter pipes', () => {
       expect(extractMsgSearchWords('* | stats count()')).toEqual([]);

--- a/src/LogsQL/extractMsgSearchWords.test.ts
+++ b/src/LogsQL/extractMsgSearchWords.test.ts
@@ -90,6 +90,12 @@ describe('extractMsgSearchWords', () => {
       expect(extractMsgSearchWords('-i(debug) warn')).toEqual(['warn']);
       expect(extractMsgSearchWords('NOT exact(debug) warn')).toEqual(['warn']);
     });
+    it('skips a negated _msg function-style filter without leaking inner terms', () => {
+      expect(extractMsgSearchWords('-_msg:i(error)')).toEqual([]);
+      expect(extractMsgSearchWords('!_msg:i(error)')).toEqual([]);
+      expect(extractMsgSearchWords('NOT _msg:i(error)')).toEqual([]);
+      expect(extractMsgSearchWords('NOT _msg:i(error) warn')).toEqual(['warn']);
+    });
   });
 
   describe('grouped values after a field', () => {
@@ -105,6 +111,12 @@ describe('extractMsgSearchWords', () => {
     });
     it('skips a negated grouped value of a non-_msg field', () => {
       expect(extractMsgSearchWords('-app:(buggy_app) warn')).toEqual(['warn']);
+    });
+    it('skips a negated _msg grouped value without leaking inner terms', () => {
+      expect(extractMsgSearchWords('-_msg:(a OR b)')).toEqual([]);
+      expect(extractMsgSearchWords('!_msg:(a OR b)')).toEqual([]);
+      expect(extractMsgSearchWords('NOT _msg:(a OR b)')).toEqual([]);
+      expect(extractMsgSearchWords('-_msg:(a OR b) warn')).toEqual(['warn']);
     });
   });
 

--- a/src/LogsQL/extractMsgSearchWords.test.ts
+++ b/src/LogsQL/extractMsgSearchWords.test.ts
@@ -1,0 +1,141 @@
+import { extractMsgSearchWords } from './extractMsgSearchWords';
+
+describe('extractMsgSearchWords', () => {
+  it('highlights a bare word as a literal _msg term', () => {
+    expect(extractMsgSearchWords('error')).toEqual(['error']);
+  });
+  it('returns empty array for empty or match-all query', () => {
+    expect(extractMsgSearchWords('')).toEqual([]);
+    expect(extractMsgSearchWords('*')).toEqual([]);
+  });
+  it('strips trailing * from a prefix filter', () => {
+    expect(extractMsgSearchWords('error*')).toEqual(['error']);
+  });
+  it('skips the {...} stream selector block', () => {
+    expect(extractMsgSearchWords('error {app="x"}')).toEqual(['error']);
+  });
+  it('highlights a quoted phrase as a literal term', () => {
+    expect(extractMsgSearchWords('"error message"')).toEqual(['error message']);
+  });
+  it('handles escaped quotes inside a phrase', () => {
+    expect(extractMsgSearchWords('"he said \\"hi\\""')).toEqual(['he said "hi"']);
+  });
+  it('highlights the value of an explicit _msg filter', () => {
+    expect(extractMsgSearchWords('_msg:error')).toEqual(['error']);
+  });
+  it('highlights a quoted _msg value', () => {
+    expect(extractMsgSearchWords('_msg:"exact val"')).toEqual(['exact val']);
+  });
+  it('skips values of non-_msg fields', () => {
+    expect(extractMsgSearchWords('level:error host:foo')).toEqual([]);
+  });
+  it('treats a _msg regexp filter as a raw regex term', () => {
+    expect(extractMsgSearchWords('_msg:~"err.*"')).toEqual(['err.*']);
+  });
+  it('treats a bare regexp filter as a raw regex term', () => {
+    expect(extractMsgSearchWords('~"err.*"')).toEqual(['err.*']);
+  });
+  it('treats a bare exact filter as a literal term', () => {
+    expect(extractMsgSearchWords('="exact val"')).toEqual(['exact val']);
+  });
+  it('keeps terms joined by AND / OR', () => {
+    expect(extractMsgSearchWords('error AND warn')).toEqual(['error', 'warn']);
+    expect(extractMsgSearchWords('error OR warn')).toEqual(['error', 'warn']);
+  });
+  it('excludes a NOT-negated term', () => {
+    expect(extractMsgSearchWords('error NOT debug')).toEqual(['error']);
+  });
+  it('excludes a dash-negated term', () => {
+    expect(extractMsgSearchWords('-debug warn')).toEqual(['warn']);
+  });
+  it('excludes a bang-negated term', () => {
+    expect(extractMsgSearchWords('!debug warn')).toEqual(['warn']);
+  });
+  it('skips a negated group', () => {
+    expect(extractMsgSearchWords('warn NOT (debug OR trace)')).toEqual(['warn']);
+  });
+  it('escapes regex special characters in literal terms', () => {
+    expect(extractMsgSearchWords('a.b+c')).toEqual(['a\\.b\\+c']);
+  });
+  it('excludes a negated _msg value', () => {
+    expect(extractMsgSearchWords('_msg:-foo')).toEqual([]);
+    expect(extractMsgSearchWords('_msg:!foo')).toEqual([]);
+  });
+  it('preserves backslash escapes in a regexp term', () => {
+    expect(extractMsgSearchWords('_msg:~"\\d+"')).toEqual(['\\d+']);
+    expect(extractMsgSearchWords('~"\\d+"')).toEqual(['\\d+']);
+  });
+  it('matches the _msg field exactly, not as a prefix or substring', () => {
+    expect(extractMsgSearchWords('_msg2:foo')).toEqual([]);
+    expect(extractMsgSearchWords('my_msg:foo')).toEqual([]);
+  });
+  it('still highlights a normal _msg regexp without escapes', () => {
+    expect(extractMsgSearchWords('_msg:~"err.*"')).toEqual(['err.*']);
+  });
+
+  describe('segments after the first pipe', () => {
+    it('does not highlight bare words inside non-filter pipes', () => {
+      expect(extractMsgSearchWords('* | stats count()')).toEqual([]);
+      expect(extractMsgSearchWords('error | fields foo')).toEqual(['error']);
+      expect(extractMsgSearchWords('* | sort by (_time) | fields foo')).toEqual([]);
+    });
+    it('highlights a bare word value of a filter pipe', () => {
+      expect(extractMsgSearchWords('* | filter warn')).toEqual(['warn']);
+    });
+    it('highlights a quoted value of a filter pipe', () => {
+      expect(extractMsgSearchWords('* | filter "io timeout"')).toEqual(['io timeout']);
+    });
+    it('applies the full filter logic inside a filter pipe', () => {
+      expect(extractMsgSearchWords('* | filter error AND warn NOT debug')).toEqual(['error', 'warn']);
+      expect(extractMsgSearchWords('* | filter _msg:~"err.*"')).toEqual(['err.*']);
+      expect(extractMsgSearchWords('* | filter level:error')).toEqual([]);
+    });
+    it('matches the filter keyword only as a whole word', () => {
+      expect(extractMsgSearchWords('* | filterX foo')).toEqual([]);
+    });
+    it('treats a segment starting with a quoted phrase as a filter', () => {
+      expect(extractMsgSearchWords('* | "value1" value2')).toEqual(['value1', 'value2']);
+    });
+    it('treats a segment starting with an explicit _msg filter as a filter', () => {
+      expect(extractMsgSearchWords('* | _msg:error value2')).toEqual(['error', 'value2']);
+      expect(extractMsgSearchWords('* | _msg:"exact"')).toEqual(['exact']);
+    });
+    it('does not highlight quoted patterns of non-filter pipes', () => {
+      expect(extractMsgSearchWords('* | extract "ip=<ip>"')).toEqual([]);
+      expect(extractMsgSearchWords('* | format "<a> <b>"')).toEqual([]);
+    });
+    it('collects terms across the first segment and later filter pipes', () => {
+      expect(extractMsgSearchWords('error | stats count() | filter warn')).toEqual(['error', 'warn']);
+    });
+    it('treats a segment starting with any field filter as a filter', () => {
+      expect(extractMsgSearchWords('* | otherField: value _msg: value2')).toEqual(['value2']);
+      expect(extractMsgSearchWords('* | otherField:value _msg:value2')).toEqual(['value2']);
+    });
+  });
+
+  describe('spaces after a field colon bind the value to its field', () => {
+    it('does not highlight a non-_msg field value written with a space', () => {
+      expect(extractMsgSearchWords('level: error')).toEqual([]);
+    });
+    it('highlights an _msg value written with a space', () => {
+      expect(extractMsgSearchWords('_msg: error')).toEqual(['error']);
+      expect(extractMsgSearchWords('_msg: "exact val"')).toEqual(['exact val']);
+    });
+  });
+
+  describe('newlines are treated as whitespace', () => {
+    it('handles a newline between the filter keyword and its value', () => {
+      expect(extractMsgSearchWords('* | filter\nvalue')).toEqual(['value']);
+      expect(extractMsgSearchWords('* | filter\n"io timeout"')).toEqual(['io timeout']);
+    });
+    it('handles a newline before a top-level pipe', () => {
+      expect(extractMsgSearchWords('error\n| filter warn')).toEqual(['error', 'warn']);
+    });
+    it('treats a newline as a term separator', () => {
+      expect(extractMsgSearchWords('error\nwarn')).toEqual(['error', 'warn']);
+    });
+    it('handles a newline after a field colon', () => {
+      expect(extractMsgSearchWords('_msg:\nvalue')).toEqual(['value']);
+    });
+  });
+});

--- a/src/LogsQL/extractMsgSearchWords.ts
+++ b/src/LogsQL/extractMsgSearchWords.ts
@@ -3,6 +3,7 @@ import { escapeRegExp } from 'lodash';
 import { skipBalanced } from '../utils';
 
 import { splitByPipes } from './splitByPipes';
+import { stripComments } from './stripComments';
 
 // Tabs/newlines are normalized to spaces in extractMsgSearchWords, so a plain space is enough here
 const TERM_SEPARATORS = [' ', ':', '|', '(', ')', '{', '}'];
@@ -204,9 +205,33 @@ function scanFilterSegment(segment: string): string[] {
       while (segment[i] === ' ') {
         i++; // a space after the colon still binds the value to its field
       }
+      // grouped value: `field:(...)` — the whole group binds to the field
+      if (segment[i] === '(') {
+        if (word === '_msg') {
+          continue; // scan the group as default _msg context
+        }
+        i = skipBalanced(segment, i, '(', ')'); // group filters a non-_msg field — skip it
+        negateNext = false;
+        continue;
+      }
       const { term, next } = readValueTerm(segment, i);
       i = next;
+      // function-style value: `field:fn(...)` — the value word is a function name, not a term
+      if (segment[i] === '(') {
+        if (word === '_msg') {
+          continue; // scan the function args as default _msg context
+        }
+        i = skipBalanced(segment, i, '(', ')'); // function filters a non-_msg field — skip it
+        negateNext = false;
+        continue;
+      }
       emit(word === '_msg' ? term : null);
+      continue;
+    }
+
+    // function-style filter call: `word(...)` — the word is a function name, not a term
+    // (e.g. i(error), exact(error)); the group itself is scanned as default _msg context
+    if (segment[i] === '(') {
       continue;
     }
 
@@ -253,8 +278,9 @@ function filterBodyOfPipe(segment: string): string | null {
  * regexp filters are returned raw.
  */
 export function extractMsgSearchWords(expr = ''): string[] {
-  // Normalize tabs/newlines to spaces up front so the scanner only deals with one whitespace kind
-  const segments = splitByPipes(expr.replace(/[\t\n\r]/g, ' '));
+  const exprWithoutComments = stripComments(expr);
+  const normalizedExpr = exprWithoutComments.replace(/[\t\n\r]/g, ' ');
+  const segments = splitByPipes(normalizedExpr);
   const results: string[] = [];
 
   segments.forEach((segment, index) => {

--- a/src/LogsQL/extractMsgSearchWords.ts
+++ b/src/LogsQL/extractMsgSearchWords.ts
@@ -1,0 +1,272 @@
+import { escapeRegExp } from 'lodash';
+
+import { skipBalanced } from '../utils';
+
+import { splitByPipes } from './splitByPipes';
+
+// Tabs/newlines are normalized to spaces in extractMsgSearchWords, so a plain space is enough here
+const TERM_SEPARATORS = [' ', ':', '|', '(', ')', '{', '}'];
+
+/**
+ * Reads a quoted string starting at `openIdx` (quote char at that index)
+ * Returns the unescaped inner content and the index just past the closing quote.
+ */
+function readQuoted(s: string, openIdx: number): { value: string; next: number } {
+  const quote = s[openIdx];
+  let value = '';
+  let i = openIdx + 1;
+  for (; i < s.length; i++) {
+    const c = s[i];
+    if (c === '\\' && i + 1 < s.length) {
+      value += s[i + 1];
+      i++;
+      continue;
+    }
+    if (c === quote) {
+      return { value, next: i + 1 };
+    }
+    value += c;
+  }
+  return { value, next: i };
+}
+
+/**
+ * Reads a quoted string starting at `openIdx` without unescaping its content
+ * Returns the raw inner text (backslashes preserved) and the index past the closing quote.
+ */
+function readRawQuoted(s: string, openIdx: number): { value: string; next: number } {
+  const quote = s[openIdx];
+  let i = openIdx + 1;
+  for (; i < s.length; i++) {
+    if (s[i] === '\\') {
+      i++; // keep the escaped char in the span
+      continue;
+    }
+    if (s[i] === quote) {
+      return { value: s.slice(openIdx + 1, i), next: i + 1 };
+    }
+  }
+  return { value: s.slice(openIdx + 1), next: i };
+}
+
+/**
+ * Reads a single filter value at `i` (after a `field:` prefix or as a bare value)
+ * A leading `-` or `!` marks the value as negated, so it is consumed but yields no term.
+ */
+function readValueTerm(s: string, i: number): { term: string | null; isRegex: boolean; next: number } {
+  let negated = false;
+  if (s[i] === '-' || s[i] === '!') {
+    negated = true;
+    i++;
+  }
+  const result = readValueTermInner(s, i);
+  return negated ? { ...result, term: null } : result;
+}
+
+/**
+ * Reads a single non-negated filter value at `i`
+ * Returns the regex-ready term (or null), whether it is a raw regexp, and the index past the value.
+ */
+function readValueTermInner(s: string, i: number): { term: string | null; isRegex: boolean; next: number } {
+  // regexp value:  ~"re"
+  if (s[i] === '~') {
+    let j = i + 1;
+    while (j < s.length && s[j] === ' ') {
+      j++;
+    }
+    if (s[j] === '"' || s[j] === "'" || s[j] === '`') {
+      const backticked = s[j] === '`';
+      const { value, next } = readRawQuoted(s, j);
+      const term = backticked ? value : value.replace(/\\\\/g, '\\');
+      return { term: term || null, isRegex: true, next };
+    }
+    return { term: null, isRegex: false, next: j };
+  }
+
+  // exact value:  ="exact" or =word
+  let j = i;
+  if (s[j] === '=') {
+    j++;
+  }
+
+  // quoted value
+  if (s[j] === '"' || s[j] === "'" || s[j] === '`') {
+    const { value, next } = readQuoted(s, j);
+    return { term: value ? escapeRegExp(value) : null, isRegex: false, next };
+  }
+
+  // bare word value, stripping a trailing prefix star
+  const start = j;
+  while (j < s.length && !TERM_SEPARATORS.includes(s[j])) {
+    j++;
+  }
+  let word = s.slice(start, j);
+  if (word.endsWith('*')) {
+    word = word.slice(0, -1);
+  }
+  return { term: word ? escapeRegExp(word) : null, isRegex: false, next: j };
+}
+
+/**
+ * Scans a single filter sub-query and returns regex-ready `_msg` search terms.
+ * The same grammar applies to the first query segment and to filter pipes.
+ */
+function scanFilterSegment(segment: string): string[] {
+  const results: string[] = [];
+  let i = 0;
+  let negateNext = false;
+
+  const emit = (term: string | null) => {
+    if (term && !negateNext) {
+      results.push(term);
+    }
+    negateNext = false;
+  };
+
+  while (i < segment.length) {
+    const ch = segment[i];
+
+    if (ch === ' ') {
+      i++;
+      continue;
+    }
+
+    // skip the {...} stream selector entirely
+    if (ch === '{') {
+      i = skipBalanced(segment, i, '{', '}');
+      negateNext = false;
+      continue;
+    }
+
+    // grouping parens
+    if (ch === '(') {
+      if (negateNext) {
+        i = skipBalanced(segment, i, '(', ')');
+        negateNext = false;
+      } else {
+        i++;
+      }
+      continue;
+    }
+    if (ch === ')') {
+      i++;
+      continue;
+    }
+
+    // negation prefixes
+    if (ch === '-' || ch === '!') {
+      negateNext = true;
+      i++;
+      continue;
+    }
+
+    // match-all star is not a search term
+    if (ch === '*') {
+      i++;
+      negateNext = false;
+      continue;
+    }
+
+    // quoted phrase on the default _msg field
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const { value, next } = readQuoted(segment, i);
+      i = next;
+      emit(value ? escapeRegExp(value) : null);
+      continue;
+    }
+
+    // bare regexp/exact filter on _msg:  ~"re"  or  ="exact"
+    if (ch === '~' || ch === '=') {
+      const { term, next } = readValueTerm(segment, i);
+      i = next;
+      emit(term);
+      continue;
+    }
+
+    // identifier — operator keyword, field reference, or bare _msg word
+    const start = i;
+    while (i < segment.length && !TERM_SEPARATORS.includes(segment[i])) {
+      i++;
+    }
+    let word = segment.slice(start, i);
+
+    const upper = word.toUpperCase();
+    if (upper === 'AND' || upper === 'OR') {
+      continue;
+    }
+    if (upper === 'NOT') {
+      negateNext = true;
+      continue;
+    }
+
+    if (segment[i] === ':') {
+      i++; // consume ':'
+      while (segment[i] === ' ') {
+        i++; // a space after the colon still binds the value to its field
+      }
+      const { term, next } = readValueTerm(segment, i);
+      i = next;
+      emit(word === '_msg' ? term : null);
+      continue;
+    }
+
+    // bare word filter on _msg
+    if (word.endsWith('*')) {
+      word = word.slice(0, -1);
+    }
+    emit(word ? escapeRegExp(word) : null);
+  }
+
+  return results;
+}
+
+const FILTER_PIPE = /^filter(\s|$)/i;
+// A leading `<field>:` token — the unambiguous sign of a filter expression
+const FIELD_FILTER = /^[^\s:|(){}]+:/;
+const ALLOWED_START_FILTER_PIPE_QUOTES = ['"', "'", '`'];
+/**
+ * For a pipe segment (anything after the first top-level `|`), returns the filter
+ * sub-query to scan, or null when the segment is not a filter and must be skipped.
+ * A segment counts as a filter when it starts with the `filter` keyword, a quoted
+ * phrase, or a `<field>:` filter (including `_msg:`) — bare words elsewhere are
+ * field/function names of pipe operations and must not be highlighted.
+ */
+function filterBodyOfPipe(segment: string): string | null {
+  if (FILTER_PIPE.test(segment)) {
+    return segment.slice('filter'.length);
+  }
+  const ch = segment[0];
+  if (ALLOWED_START_FILTER_PIPE_QUOTES.includes(ch)) {
+    return segment;
+  }
+  if (FIELD_FILTER.test(segment)) {
+    return segment;
+  }
+  return null;
+}
+
+/**
+ * Extracts regex-ready search terms targeting the default `_msg` field from a LogsQL query,
+ * for use in Grafana `frame.meta.searchWords` highlighting. The first segment (before the first
+ * top-level `|`) is always scanned as a filter; later segments are scanned only when they are
+ * filter pipes (start with `filter`, a quoted phrase, or `_msg:`). Literal terms are escaped;
+ * regexp filters are returned raw.
+ */
+export function extractMsgSearchWords(expr = ''): string[] {
+  // Normalize tabs/newlines to spaces up front so the scanner only deals with one whitespace kind
+  const segments = splitByPipes(expr.replace(/[\t\n\r]/g, ' '));
+  const results: string[] = [];
+
+  segments.forEach((segment, index) => {
+    if (index === 0) {
+      results.push(...scanFilterSegment(segment));
+      return;
+    }
+    const body = filterBodyOfPipe(segment);
+    if (body !== null) {
+      results.push(...scanFilterSegment(body));
+    }
+  });
+
+  return results;
+}

--- a/src/LogsQL/stripComments.test.ts
+++ b/src/LogsQL/stripComments.test.ts
@@ -1,0 +1,86 @@
+import { stripComments } from './stripComments';
+
+describe('stripComments', () => {
+  it('returns empty string unchanged', () => {
+    expect(stripComments('')).toBe('');
+  });
+
+  it('returns text without comments unchanged', () => {
+    expect(stripComments('_msg:error')).toBe('_msg:error');
+  });
+
+  it('drops a trailing line comment', () => {
+    expect(stripComments('_msg:error # this is a comment')).toBe('_msg:error ');
+  });
+
+  it('drops a comment that spans to the end of input without a newline', () => {
+    expect(stripComments('foo # bar')).toBe('foo ');
+  });
+
+  it('drops a comment occupying the whole line', () => {
+    expect(stripComments('# just a comment')).toBe('');
+  });
+
+  it('keeps the newline that terminates a comment', () => {
+    expect(stripComments('foo # comment\nbar')).toBe('foo \nbar');
+  });
+
+  it('strips comments on multiple lines independently', () => {
+    expect(stripComments('foo # c1\nbar # c2\nbaz')).toBe('foo \nbar \nbaz');
+  });
+
+  describe('inside quoted spans', () => {
+    it('keeps # inside double quotes', () => {
+      expect(stripComments('_msg:"a # b"')).toBe('_msg:"a # b"');
+    });
+
+    it('keeps # inside single quotes', () => {
+      expect(stripComments("_msg:'a # b'")).toBe("_msg:'a # b'");
+    });
+
+    it('keeps # inside backticks', () => {
+      expect(stripComments('_msg:`a # b`')).toBe('_msg:`a # b`');
+    });
+
+    it('strips a comment that follows a closed quoted span', () => {
+      expect(stripComments('"a # b" # real comment')).toBe('"a # b" ');
+    });
+
+    it('does not treat a # inside one quote type as ending another', () => {
+      expect(stripComments('"a # b" \'c # d\'')).toBe('"a # b" \'c # d\'');
+    });
+  });
+
+  describe('escaping', () => {
+    it('does not close a double-quoted span on an escaped quote', () => {
+      expect(stripComments('"a\\"# still in" # comment')).toBe('"a\\"# still in" ');
+    });
+
+    it('preserves the backslash-escaped pair verbatim', () => {
+      expect(stripComments('"a\\nb"')).toBe('"a\\nb"');
+    });
+
+    it('treats backslash literally inside backticks (raw string)', () => {
+      // The backtick closes at the first backtick; the backslash is not an escape
+      expect(stripComments('`a\\` # comment')).toBe('`a\\` ');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('copies an unterminated quoted span to the end', () => {
+      expect(stripComments('"abc')).toBe('"abc');
+    });
+
+    it('handles a trailing backslash at end of input', () => {
+      expect(stripComments('"abc\\')).toBe('"abc\\');
+    });
+
+    it('handles a # immediately at end of input', () => {
+      expect(stripComments('foo#')).toBe('foo');
+    });
+
+    it('keeps an empty quoted span', () => {
+      expect(stripComments('""')).toBe('""');
+    });
+  });
+});

--- a/src/LogsQL/stripComments.ts
+++ b/src/LogsQL/stripComments.ts
@@ -1,0 +1,40 @@
+/**
+ * Removes LogsQL `# ...` line comments while preserving `#` inside quoted/backticked spans.
+ * Runs before newline normalization so a comment can be terminated by its end-of-line.
+ */
+export function stripComments(s: string): string {
+  let out = '';
+  let i = 0;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      const raw = c === '`'; // backtick strings do not process backslash escapes
+      out += c;
+      i++;
+      while (i < s.length) {
+        if (!raw && s[i] === '\\' && i + 1 < s.length) {
+          out += s[i] + s[i + 1];
+          i += 2;
+          continue;
+        }
+        out += s[i];
+        if (s[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    if (c === '#') {
+      while (i < s.length && s[i] !== '\n') {
+        i++; // drop the comment up to (but not including) the end of line
+      }
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}

--- a/src/queryUtils.ts
+++ b/src/queryUtils.ts
@@ -1,72 +1,9 @@
-import { SyntaxNode } from '@lezer/common';
-import { escapeRegExp } from 'lodash';
+import { extractMsgSearchWords } from './LogsQL/extractMsgSearchWords';
 
-import { Filter, FilterOp, LineFilter, OrFilter, parser, PipeExact, PipeMatch, String } from '@grafana/lezer-logql';
-
-export function getNodesFromQuery(query: string, nodeTypes?: number[]): SyntaxNode[] {
-  const nodes: SyntaxNode[] = [];
-  const tree = parser.parse(query);
-  tree.iterate({
-    enter: (node): false | void => {
-      if (nodeTypes === undefined || nodeTypes.includes(node.type.id)) {
-        nodes.push(node.node);
-      }
-    },
-  });
-  return nodes;
-}
-
-export function getStringsFromLineFilter(filter: SyntaxNode): SyntaxNode[] {
-  const nodes: SyntaxNode[] = [];
-  let node: SyntaxNode | null = filter;
-  do {
-    const string = node.getChild(String);
-    if (string && !node.getChild(FilterOp)) {
-      nodes.push(string);
-    }
-    node = node.getChild(OrFilter);
-  } while (node != null);
-
-  return nodes;
-}
-
+/**
+ * Returns regex-ready search terms (targeting the `_msg` field) for Grafana
+ * `frame.meta.searchWords` highlighting, parsed from a LogsQL query
+ */
 export function getHighlighterExpressionsFromQuery(input = ''): string[] {
-  const results = [];
-
-  const filters = getNodesFromQuery(input, [LineFilter]);
-
-  for (const filter of filters) {
-    const pipeExact = filter.getChild(Filter)?.getChild(PipeExact);
-    const pipeMatch = filter.getChild(Filter)?.getChild(PipeMatch);
-    const strings = getStringsFromLineFilter(filter);
-
-    if ((!pipeExact && !pipeMatch) || !strings.length) {
-      continue;
-    }
-
-    for (const string of strings) {
-      const filterTerm = input.substring(string.from, string.to).trim();
-      const backtickedTerm = filterTerm[0] === '`';
-      const unwrappedFilterTerm = filterTerm.substring(1, filterTerm.length - 1);
-
-      if (!unwrappedFilterTerm) {
-        continue;
-      }
-
-      let resultTerm;
-
-      // Only filter expressions with |~ operator are treated as regular expressions
-      if (pipeMatch) {
-        resultTerm = backtickedTerm ? unwrappedFilterTerm : unwrappedFilterTerm.replace(/\\\\/g, '\\');
-      } else {
-        // We need to escape this string so it is not matched as regular expression
-        resultTerm = escapeRegExp(unwrappedFilterTerm);
-      }
-
-      if (resultTerm) {
-        results.push(resultTerm);
-      }
-    }
-  }
-  return results;
+  return extractMsgSearchWords(input);
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './string';

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -1,0 +1,1 @@
+export { skipBalanced } from './skipBalanced/skipBalanced';

--- a/src/utils/string/skipBalanced/skipBalanced.test.ts
+++ b/src/utils/string/skipBalanced/skipBalanced.test.ts
@@ -1,0 +1,46 @@
+import { skipBalanced } from './skipBalanced';
+
+describe('skipBalanced', () => {
+  it('returns the index just past a simple block', () => {
+    expect(skipBalanced('{a}', 0, '{', '}')).toBe(3);
+    expect(skipBalanced('(a)', 0, '(', ')')).toBe(3);
+  });
+
+  it('handles an empty block', () => {
+    expect(skipBalanced('{}', 0, '{', '}')).toBe(2);
+  });
+
+  it('handles nested blocks', () => {
+    expect(skipBalanced('{a{b}c}', 0, '{', '}')).toBe(7);
+    expect(skipBalanced('(a(b)(c))d', 0, '(', ')')).toBe(9);
+  });
+
+  it('lets the result slice off the block, leaving the remainder', () => {
+    const expr = '{app="x"} | stats count()';
+    expect(expr.slice(skipBalanced(expr, 0, '{', '}'))).toBe(' | stats count()');
+  });
+
+  it('ignores close chars inside double-quoted strings', () => {
+    expect(skipBalanced('{a"}"b}', 0, '{', '}')).toBe(7);
+    expect(skipBalanced('{app="a}b"}', 0, '{', '}')).toBe(11);
+  });
+
+  it('ignores close chars inside single-quoted and backtick strings', () => {
+    expect(skipBalanced("(a')'b)", 0, '(', ')')).toBe(7);
+    expect(skipBalanced('{a`}`b}', 0, '{', '}')).toBe(7);
+  });
+
+  it('treats a backslash inside a quote as escaping the next char', () => {
+    // `{"\""}` — the escaped quote must not end the string early
+    expect(skipBalanced('{"\\""}', 0, '{', '}')).toBe(6);
+  });
+
+  it('returns the string length when the block is never closed', () => {
+    expect(skipBalanced('{abc', 0, '{', '}')).toBe(4);
+    expect(skipBalanced('{a{b}c', 0, '{', '}')).toBe(6);
+  });
+
+  it('starts scanning at openIdx, ignoring earlier characters', () => {
+    expect(skipBalanced('foo{a}', 3, '{', '}')).toBe(6);
+  });
+});

--- a/src/utils/string/skipBalanced/skipBalanced.ts
+++ b/src/utils/string/skipBalanced/skipBalanced.ts
@@ -1,0 +1,46 @@
+/**
+ * Scans from `openIdx` (which should sit on an `open` char) and returns the index just past the
+ * matching `close` char, accounting for nested `open`/`close` pairs.
+ *
+ * Quote characters (`"`, `'`, `` ` ``) open a quoted span in which `open`/`close` are ignored, so
+ * brackets inside strings never unbalance the block; a backslash inside a quote escapes the next
+ * character. If the block is never closed, `s.length` is returned.
+ *
+ * @param s - the string to scan
+ * @param openIdx - index to start scanning from, normally the position of an `open` char
+ * @param open - the opening bracket character (e.g. `{` or `(`)
+ * @param close - the matching closing bracket character (e.g. `}` or `)`)
+ * @returns the index immediately after the matching `close`, or `s.length` if unterminated
+ *
+ * @example
+ *   skipBalanced('{a{b}c}', 0, '{', '}') // 7
+ *   skipBalanced('(a)b', 0, '(', ')')    // 3
+ *   '{a}b'.slice(skipBalanced('{a}b', 0, '{', '}')) // 'b'
+ */
+export function skipBalanced(s: string, openIdx: number, open: string, close: string): number {
+  let depth = 0;
+  let quote: string | null = null;
+  let i = openIdx;
+  for (; i < s.length; i++) {
+    const c = s[i];
+    if (quote) {
+      if (c === '\\') {
+        i++;
+      } else if (c === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      quote = c;
+    } else if (c === open) {
+      depth++;
+    } else if (c === close) {
+      depth--;
+      if (depth === 0) {
+        return i + 1;
+      }
+    }
+  }
+  return i;
+}


### PR DESCRIPTION
Related issue: #519 

### Describe Your Changes

Added highlight LogsQL search terms in log lines for cases:
1. `msgValue ...` , `"msgValue"` 
2. `_msg: msgValue`, `_msg: "msgValue"`
3. for pipes filter : ` * | filter msgValue`, ` * | filter "msgValue"`, ` * | "msgValue"`, ` * | field: value _msg: "msgValue"`

The search words are set to the custom metadata `searchWords` in [this line](https://github.com/VictoriaMetrics/victorialogs-datasource/blob/d452d8c457023225adbaca6b1755fd2698d9ff8f/src/transformers/frameProcessors/streamFrameProcessor.ts).

<img width="1550" height="1298" alt="image" src="https://github.com/user-attachments/assets/6af68bf7-13c1-4405-82e7-0342c4e2f801" />


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
