### PR TITLE
feat(derivedFields): support linking to a VictoriaLogs datasource (logs → logs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * FEATURE: keep log fields in the order returned by VictoriaLogs (for example the order from `| fields a, b, c`) instead of sorting them alphabetically. See [#563](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/563).
+* FEATURE: derived fields can now link to another VictoriaLogs datasource (logs → logs). Clicking such a field opens Explore with a ready LogsQL query, letting you pivot from a value like `trace_id` or `request_id` to all related logs. See [#671](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/671).
 
 * BUGFIX: lower the default datasource `Maximum lines` limit from 1000 to 50 to reduce browser rendering load and prevent the page from freezing on heavy log results. You can change this value in the datasource configuration. See [Line limits](https://docs.victoriametrics.com/victorialogs/integrations/grafana/#line-limits) docs and [#669](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/669).
 

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -15,8 +15,29 @@ datasources:
       # Default maximum number of log lines returned per query.
       # Defaults to 50, maximum allowed value is 10000.
       #maxLines: 50
+
       # Multitenancy settings, see https://docs.victoriametrics.com/victorialogs/#multitenancy
       # to use the multitenancy uncomment lines below: AccountID and ProjectID
       multitenancyHeaders:
         #AccountID: 0
         #ProjectID: 0
+
+      # Derived Fields turn a value inside a log message into a clickable link.
+      # The example below extracts a `trace_id` and links to a Tempo datasource
+      # to open the matching trace. The target can be a tracing datasource
+      # (Tempo, Jaeger, Zipkin) or another VictoriaLogs datasource (logs -> logs).
+      # `datasourceUid` must match the `uid` of the target datasource.
+      #derivedFields:
+      #  - name: trace_id
+      #    # Take the value from the `trace_id` log field:
+      #    matcherType: label
+      #    matcherRegex: trace_id
+      #    # ...or extract it from the raw log line instead:
+      #    # matcherType: regex
+      #    # matcherRegex: 'trace_id=(\w+)'
+      #    # Value handed to the target datasource. For a tracing datasource this
+      #    # is the trace ID; for logs -> logs use a LogsQL query, e.g.
+      #    # 'trace_id:${__value.raw}'.
+      #    url: '${__value.raw}'
+      #    urlDisplayLabel: View trace
+      #    datasourceUid: tempo

--- a/src/README.md
+++ b/src/README.md
@@ -377,6 +377,34 @@ open a Jaeger datasource and search for the `trace_id` value:
 If the trace ID is not stored in a separate field but in a log message itself, then use `Regex in log line` option
 to specify a regex expression for extracting the trace value from log message.
 
+The target of a Derived Field can be a tracing datasource (Tempo, Jaeger, Zipkin) or another VictoriaLogs datasource
+(logs → logs). When the target is VictoriaLogs, set `url` to a LogsQL query such as `trace_id:${__value.raw}`, and
+clicking the field opens Explore with that query — letting you pivot from a value like `trace_id` or `request_id`
+to all related logs.
+
+Derived Fields can also be configured via provisioning:
+
+```yaml
+apiVersion: 1
+datasources:
+  - name: VictoriaLogs
+    type: victoriametrics-logs-datasource
+    url: http://victorialogs:9428
+    jsonData:
+      derivedFields:
+        - name: trace_id
+          # Take the value from the `trace_id` log field (or use matcherType: regex
+          # with a capture group to extract it from the raw log line instead).
+          matcherType: label
+          matcherRegex: trace_id
+          # Value handed to the target datasource: the trace ID for a tracing
+          # datasource, or a LogsQL query like 'trace_id:${__value.raw}' for logs → logs.
+          url: '${__value.raw}'
+          urlDisplayLabel: View trace
+          # `uid` of the target datasource (a tracing or VictoriaLogs datasource).
+          datasourceUid: tempo
+```
+
 Learn more about [Derived Fields in Grafana](https://grafana.com/docs/grafana/next/datasources/loki/configure-loki-data-source/#derived-fields).
 
 ## License

--- a/src/configuration/DerivedField.tsx
+++ b/src/configuration/DerivedField.tsx
@@ -18,6 +18,7 @@ import {
   useTheme2,
 } from '@grafana/ui';
 
+import { PLUGIN_ID } from '../constants';
 import { DerivedFieldConfig } from '../types';
 
 type MatcherType = 'label' | 'regex';
@@ -190,7 +191,7 @@ export const DerivedField = (props: Props) => {
         {showInternalLink && (
           <Field label='' className={styles.dataSource}>
             <DataSourcePicker
-              tracing={true}
+              filter={(ds: DataSourceInstanceSettings) => Boolean(ds.meta.tracing) || ds.type === PLUGIN_ID}
               onChange={(ds: DataSourceInstanceSettings) =>
                 onChange({
                   ...value,

--- a/src/transformers/fields/derivedField.test.ts
+++ b/src/transformers/fields/derivedField.test.ts
@@ -1,0 +1,69 @@
+import { DataFrame, Field, FieldType } from '@grafana/data';
+
+import { PLUGIN_ID } from '../../constants';
+import { DerivedFieldConfig } from '../../types';
+
+import { getDerivedFields } from './derivedField';
+
+const getInstanceSettings = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  getDataSourceSrv: () => ({
+    getInstanceSettings: (uid: string) => getInstanceSettings(uid),
+  }),
+}));
+
+function makeLogsFrame(lines: string[]): DataFrame {
+  return {
+    name: 'logs',
+    length: lines.length,
+    fields: [
+      {
+        name: 'Line',
+        type: FieldType.string,
+        config: {},
+        values: lines,
+      } as Field,
+    ],
+  };
+}
+
+describe('getDerivedFields', () => {
+  beforeEach(() => {
+    getInstanceSettings.mockReset();
+  });
+
+  it('builds an `expr`-based internal query for a VictoriaLogs target (logs -> logs)', () => {
+    getInstanceSettings.mockReturnValue({ type: PLUGIN_ID, name: 'VictoriaLogs' });
+
+    const config: DerivedFieldConfig = {
+      name: 'request_id',
+      matcherRegex: 'request_id=(\\w+)',
+      url: '*:${__value.raw}',
+      datasourceUid: 'logs-uid',
+    };
+
+    const fields = getDerivedFields(makeLogsFrame(['request_id=abc123']), [config]);
+    const internal = fields[0].config.links?.[0].internal;
+
+    expect(internal?.datasourceUid).toBe('logs-uid');
+    expect(internal?.query).toEqual({ expr: '*:${__value.raw}', refId: 'A' });
+  });
+
+  it('keeps the `query`/`queryType` internal query for a trace target (regression)', () => {
+    getInstanceSettings.mockReturnValue({ type: 'tempo', name: 'Tempo' });
+
+    const config: DerivedFieldConfig = {
+      name: 'trace_id',
+      matcherRegex: 'trace_id=(\\w+)',
+      url: '${__value.raw}',
+      datasourceUid: 'tempo-uid',
+    };
+
+    const fields = getDerivedFields(makeLogsFrame(['trace_id=def456']), [config]);
+    const internal = fields[0].config.links?.[0].internal;
+
+    expect(internal?.datasourceUid).toBe('tempo-uid');
+    expect(internal?.query).toEqual({ query: '${__value.raw}', queryType: 'traceql' });
+  });
+});

--- a/src/transformers/fields/derivedField.ts
+++ b/src/transformers/fields/derivedField.ts
@@ -1,8 +1,9 @@
 import { groupBy } from 'lodash';
 
-import { FieldType, DataFrame, DataLink, Field } from '@grafana/data';
+import { FieldType, DataFrame, DataLink, Field, DataSourceInstanceSettings } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
+import { PLUGIN_ID } from '../../constants';
 import { DerivedFieldConfig } from '../../types';
 
 export function getDerivedFields(dataFrame: DataFrame, derivedFieldConfigs: DerivedFieldConfig[]): Field[] {
@@ -64,6 +65,41 @@ export function getDerivedFields(dataFrame: DataFrame, derivedFieldConfigs: Deri
   return newFields;
 }
 
+const buildDefaultQuery = (url: string | undefined, type?: string)=> {
+  return { query: url ?? 'Need to provide url in the datasource settings', queryType: type };
+};
+
+const buildInternalLink = (derivedFieldConfig: DerivedFieldConfig, dsSettings: DataSourceInstanceSettings | undefined, datasourceUid: string): DataLink => {
+  let query;
+  switch (dsSettings?.type) {
+    case 'tempo': {
+      query = buildDefaultQuery(derivedFieldConfig.url, 'traceql');
+      break;
+    }
+    case 'grafana-x-ray-datasource': {
+      query = buildDefaultQuery(derivedFieldConfig.url, 'getTrace');
+      break;
+    }
+    case PLUGIN_ID: {
+      query = { expr: derivedFieldConfig.url, refId: 'A' };
+      break;
+    }
+    default: {
+      query = buildDefaultQuery(derivedFieldConfig.url);
+    }
+  }
+
+  return {
+    // Will be filled out later
+    title: derivedFieldConfig.urlDisplayLabel || '',
+    url: '',
+    internal: {
+      query: query,
+      datasourceUid,
+      datasourceName: dsSettings?.name ?? 'Data source not found',
+    },
+  };
+};
 
 function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]): Field {
   const dataSourceSrv = getDataSourceSrv();
@@ -72,28 +108,7 @@ function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]):
     // Having field.datasourceUid means it is an internal link.
     if (derivedFieldConfig.datasourceUid) {
       const dsSettings = dataSourceSrv.getInstanceSettings(derivedFieldConfig.datasourceUid);
-      const queryType = (type: string | undefined): string | undefined => {
-        switch (type) {
-          case 'tempo':
-            return 'traceql';
-          case 'grafana-x-ray-datasource':
-            return 'getTrace';
-          default:
-            return undefined;
-        }
-      };
-
-      acc.push({
-        // Will be filled out later
-        title: derivedFieldConfig.urlDisplayLabel || '',
-        url: '',
-        // This is hardcoded for Jaeger or Zipkin not way right now to specify datasource specific query object
-        internal: {
-          query: { query: derivedFieldConfig.url, queryType: queryType(dsSettings?.type) },
-          datasourceUid: derivedFieldConfig.datasourceUid,
-          datasourceName: dsSettings?.name ?? 'Data source not found',
-        },
-      });
+      acc.push(buildInternalLink(derivedFieldConfig, dsSettings, derivedFieldConfig.datasourceUid));
     } else if (derivedFieldConfig.url) {
       acc.push({
         // We do not know what title to give here so we count on presentation layer to create a title from metadata.


### PR DESCRIPTION
Related issue: #671 

### Describe Your Changes

Add VL DS to the allowed DS list in the derived fields configuration.
- Build the internal Explore query as `expr`/`refId` when the derived field target is a VictoriaLogs datasource, so LogsQL is actually populated; keep `query`/`queryType` for tracing datasources (Tempo, Jaeger, X-Ray)
- Allow selecting a VictoriaLogs datasource (alongside tracing ones) in the derived field datasource picker

Demo, how to show all logs related to `trace_id`: 

https://github.com/user-attachments/assets/06129ac2-006d-4e9a-a425-c9898e57f56d



### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
