### PR TITLE
feat(raw logs): add a `Pack to JSON` toggle in the query options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * FEATURE: add a `:` (word filter) operator to Log Level Rules, matching a field value by whole word like LogsQL (e.g. `error` matches the word `error`, not `terror`). See [#611](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/611).
 * FEATURE: the visual query builder now shows context-aware keyboard hints at the bottom of its dropdowns, so the available shortcuts (select, navigate, confirm, run) are visible while you build a query. See [pr #683](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/683).
-* FEATURE: add a `Pack to JSON` toggle in the query options for raw logs that shows all log labels as a single JSON object in the log line. Useful when logs have no `_msg` field. The query sent to VictoriaLogs stays unchanged — labels are packed on the frontend. See [#677](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/677).
+* FEATURE: add a `View as JSON` toggle in the query options for raw logs. When enabled, it shows all log fields as a single JSON message in the log line. It is useful for displaying all fields at once or when logs have no meaningful `_msg` field. See [#677](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/677).
 
 * BUGFIX: restore the `_stream` label in log query results. Previously, it was hidden from the log line labels. See [pr #685](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/685).
 * BUGFIX: live tailing now picks up query changes immediately. Previously, editing the query expression while live logs were streaming kept showing results for the previous query until the page was reloaded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * FEATURE: add a `:` (word filter) operator to Log Level Rules, matching a field value by whole word like LogsQL (e.g. `error` matches the word `error`, not `terror`). See [#611](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/611).
 * FEATURE: the visual query builder now shows context-aware keyboard hints at the bottom of its dropdowns, so the available shortcuts (select, navigate, confirm, run) are visible while you build a query. See [pr #683](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/683).
+* FEATURE: add a `Pack to JSON` toggle in the query options for raw logs that shows all log labels as a single JSON object in the log line. Useful when logs have no `_msg` field. The query sent to VictoriaLogs stays unchanged — labels are packed on the frontend. See [#677](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/677).
 
 * BUGFIX: restore the `_stream` label in log query results. Previously, it was hidden from the log line labels. See [pr #685](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/685).
 * BUGFIX: live tailing now picks up query changes immediately. Previously, editing the query expression while live logs were streaming kept showing results for the previous query until the page was reloaded.

--- a/src/components/QueryEditor/QueryEditorOptions.tsx
+++ b/src/components/QueryEditor/QueryEditorOptions.tsx
@@ -165,8 +165,8 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
         )}
         {queryType === QueryType.Instant && (
           <EditorField
-            label='Pack to JSON'
-            tooltip='Show all log labels as a single JSON object in the log line. Useful when logs have no _msg field'
+            label='View as JSON'
+            tooltip='Display all fields as a single JSON message. Is useful when logs have no meaningful _msg value'
           >
             <Switch
               value={query.packJson ?? false}

--- a/src/components/QueryEditor/QueryEditorOptions.tsx
+++ b/src/components/QueryEditor/QueryEditorOptions.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { CoreApp, isValidGrafanaDuration, SelectableValue } from '@grafana/data';
-import { AutoSizeInput, Input, RadioButtonGroup, TextLink } from '@grafana/ui';
+import { AutoSizeInput, Input, RadioButtonGroup, Switch, TextLink } from '@grafana/ui';
 
 import { VICTORIA_LOGS_DOCS_HOST } from '../../conf';
 import { LOGS_LIMIT_HARD_CAP, LOGS_LIMIT_WARNING_THRESHOLD } from '../../constants';
@@ -91,6 +91,11 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
     onRunQuery();
   };
 
+  const onPackJsonChange = (e: React.FormEvent<HTMLInputElement>) => {
+    onChange({ ...query, packJson: e.currentTarget.checked });
+    onRunQuery();
+  };
+
   const onLegendFormatChanged = (e: React.FormEvent<HTMLInputElement>) => {
     onChange({ ...query, legendFormat: e.currentTarget.value });
     onRunQuery();
@@ -158,6 +163,17 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
             />
           </EditorField>
         )}
+        {queryType === QueryType.Instant && (
+          <EditorField
+            label='Pack to JSON'
+            tooltip='Show all log labels as a single JSON object in the log line. Useful when logs have no _msg field'
+          >
+            <Switch
+              value={query.packJson ?? false}
+              onChange={onPackJsonChange}
+            />
+          </EditorField>
+        )}
         {queryType === QueryType.StatsRange && (
           <EditorField
             label='Step'
@@ -216,6 +232,10 @@ function getCollapsedInfo({ app, query, queryType, maxLines, isValidStep }: Coll
 
   if (queryType === QueryType.Instant && maxLines) {
     items.push(`Line limit: ${query.maxLines ?? maxLines}`);
+  }
+
+  if (queryType === QueryType.Instant && query.packJson) {
+    items.push('Pack to JSON: on');
   }
 
   if (app !== CoreApp.Explore) {

--- a/src/components/QueryEditor/QueryEditorOptions.tsx
+++ b/src/components/QueryEditor/QueryEditorOptions.tsx
@@ -235,7 +235,7 @@ function getCollapsedInfo({ app, query, queryType, maxLines, isValidStep }: Coll
   }
 
   if (queryType === QueryType.Instant && query.packJson) {
-    items.push('Pack to JSON: on');
+    items.push('View as JSON: on');
   }
 
   if (app !== CoreApp.Explore) {

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,12 +1,19 @@
+import { firstValueFrom, of } from 'rxjs';
+
 import {
   AdHocVariableFilter,
+  DataFrame,
   DataQueryRequest,
+  DataQueryResponse,
   DataSourceInstanceSettings,
+  FieldType,
   LogLevel,
   SupplementaryQueryOptions,
   SupplementaryQueryType,
 } from '@grafana/data';
+import * as grafanaRuntime from '@grafana/runtime';
 import { TemplateSrv } from '@grafana/runtime';
+
 
 // eslint-disable-next-line jest/no-mocks-import
 import { createDatasource } from './__mocks__/datasource';
@@ -1043,6 +1050,7 @@ describe('VictoriaLogsDatasource preset merge', () => {
         );
         expect(result).toBeUndefined();
       });
+
     });
 
     describe('LogsSample', () => {
@@ -1146,5 +1154,57 @@ describe('VictoriaLogsDatasource preset merge', () => {
       await dsLocal.getTagKeys({ filters });
       expect(getFieldList.mock.calls[0][0].query).toBe('app:~"api.*"');
     });
+  });
+});
+
+describe('VictoriaLogsDatasource live streaming', () => {
+  const buildStreamFrame = (): DataFrame => ({
+    refId: 'A',
+    length: 1,
+    fields: [
+      { name: 'Time', type: FieldType.time, config: {}, values: [0] },
+      { name: 'Line', type: FieldType.string, config: {}, values: ['msg'] },
+      { name: 'labels', type: FieldType.other, config: {}, values: [{ app: 'nginx' }] },
+    ],
+  });
+
+  const makeLiveRequest = (query: Partial<Query>): DataQueryRequest<Query> => ({
+    app: 'explore',
+    requestId: 'r1',
+    interval: '1s',
+    intervalMs: 1000,
+    liveStreaming: true,
+    range: {
+      from: { utcOffset: () => 0, diff: () => 3600 } as any,
+      to: { utcOffset: () => 0, diff: () => 3600 } as any,
+      raw: { from: 'now-1h', to: 'now' },
+    } as any,
+    scopedVars: {},
+    targets: [{ refId: 'A', expr: '*', queryType: QueryType.Instant, ...query } as Query],
+    timezone: 'UTC',
+    startTime: 0,
+  }) as DataQueryRequest<Query>;
+
+  const runLiveQuery = async (query: Partial<Query>): Promise<DataQueryResponse> => {
+    jest.spyOn(grafanaRuntime, 'getGrafanaLiveSrv').mockReturnValue({
+      getDataStream: jest.fn().mockReturnValue(of({ data: [buildStreamFrame()] })),
+    } as unknown as ReturnType<typeof grafanaRuntime.getGrafanaLiveSrv>);
+
+    const ds = createDatasource();
+    return firstValueFrom(ds.query(makeLiveRequest(query)));
+  };
+
+  it('packs labels into the Line field when packJson is enabled', async () => {
+    const response = await runLiveQuery({ packJson: true });
+
+    const lineField = (response.data[0] as DataFrame).fields.find((f) => f.name === 'Line');
+    expect(lineField?.values[0]).toBe('{"_msg":"msg","app":"nginx"}');
+  });
+
+  it('keeps the Line field untouched when packJson is disabled', async () => {
+    const response = await runLiveQuery({});
+
+    const lineField = (response.data[0] as DataFrame).fields.find((f) => f.name === 'Line');
+    expect(lineField?.values[0]).toBe('msg');
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -53,7 +53,7 @@ import {
 } from './modifyQuery';
 import { removeDoubleQuotesAroundVar } from './parsing';
 import { replaceOperatorWithIn, returnVariables } from './parsingUtils';
-import { transformBackendResult } from './transformers';
+import { packLabelsToLine, shouldPackLabelsToLine, transformBackendResult } from './transformers';
 import {
   DerivedFieldConfig,
   FilterActionType,
@@ -446,8 +446,10 @@ export class VictoriaLogsDatasource
         })
         .pipe(
           map((response) => {
+            const frames: DataFrame[] = response.data || [];
             return {
-              data: response.data || [],
+              // live frames skip transformBackendResult, so the packJson option is applied here
+              data: shouldPackLabelsToLine(query) ? frames.map(packLabelsToLine) : frames,
               key: `victoriametrics-logs-datasource-${request.requestId}-${query.refId}`,
               state: LoadingState.Streaming,
             };

--- a/src/transformers/fields/packJsonLineField.test.ts
+++ b/src/transformers/fields/packJsonLineField.test.ts
@@ -124,6 +124,16 @@ describe('shouldPackLabelsToLine', () => {
     ).toBe(false);
   });
 
+  // Grafana marks the cloned load-more queries of the Explore infinite scroll with
+  // supportingQueryType: 'infiniteScroll' — their results land in the same log list,
+  // so they must be packed exactly like the initial raw logs query
+  it('returns true for the infinite scroll load-more query', () => {
+    // the literal is asserted on purpose: this exact string is what Grafana core sends
+    expect(
+      shouldPackLabelsToLine({ ...baseQuery, supportingQueryType: 'infiniteScroll' as SupportingQueryType })
+    ).toBe(true);
+  });
+
   it('returns false when the query is undefined', () => {
     expect(shouldPackLabelsToLine(undefined)).toBe(false);
   });

--- a/src/transformers/fields/packJsonLineField.test.ts
+++ b/src/transformers/fields/packJsonLineField.test.ts
@@ -1,0 +1,130 @@
+import { DataFrame, FieldType } from '@grafana/data';
+
+import { Query, QueryType, SupportingQueryType } from '../../types';
+
+import { packLabelsToLine, shouldPackLabelsToLine } from './packJsonLineField';
+
+const buildFrame = (lines: string[], labels: object[]): DataFrame => ({
+  refId: 'A',
+  length: lines.length,
+  fields: [
+    { name: 'Time', type: FieldType.time, config: {}, values: lines.map((_, i) => i) },
+    { name: 'Line', type: FieldType.string, config: {}, values: lines },
+    { name: 'labels', type: FieldType.other, config: {}, values: labels },
+  ],
+});
+
+const getFieldValues = (frame: DataFrame, name: string) =>
+  frame.fields.find((f) => f.name === name)?.values;
+
+describe('packLabelsToLine', () => {
+  it('replaces the line with a JSON object of all labels when the message is empty', () => {
+    const frame = buildFrame([''], [{ app: 'nginx', level: 'info' }]);
+
+    const packed = packLabelsToLine(frame);
+
+    expect(getFieldValues(packed, 'Line')?.[0]).toBe('{"app":"nginx","level":"info"}');
+  });
+
+  it('keeps the original message in the JSON under the _msg key', () => {
+    const frame = buildFrame(['hello world'], [{ app: 'nginx' }]);
+
+    const packed = packLabelsToLine(frame);
+
+    expect(getFieldValues(packed, 'Line')?.[0]).toBe('{"_msg":"hello world","app":"nginx"}');
+  });
+
+  it('keeps a row untouched when it has no labels and no message', () => {
+    const frame = buildFrame([''], [{}]);
+
+    const packed = packLabelsToLine(frame);
+
+    expect(getFieldValues(packed, 'Line')?.[0]).toBe('');
+  });
+
+  it('packs a message-only row into JSON with the single _msg key', () => {
+    const frame = buildFrame(['hello'], [{}]);
+
+    const packed = packLabelsToLine(frame);
+
+    expect(getFieldValues(packed, 'Line')?.[0]).toBe('{"_msg":"hello"}');
+  });
+
+  it('handles a missing labels value for a row', () => {
+    const frame = buildFrame([''], [null as unknown as object]);
+
+    const packed = packLabelsToLine(frame);
+
+    expect(getFieldValues(packed, 'Line')?.[0]).toBe('');
+  });
+
+  it('does not modify the labels field', () => {
+    const labels = [{ app: 'nginx' }];
+    const frame = buildFrame([''], labels);
+
+    const packed = packLabelsToLine(frame);
+
+    expect(getFieldValues(packed, 'labels')?.[0]).toEqual({ app: 'nginx' });
+  });
+
+  it('does not mutate the original frame', () => {
+    const frame = buildFrame([''], [{ app: 'nginx' }]);
+
+    packLabelsToLine(frame);
+
+    expect(getFieldValues(frame, 'Line')?.[0]).toBe('');
+  });
+
+  it('returns the frame untouched when the Line field is missing', () => {
+    const frame: DataFrame = {
+      refId: 'A',
+      length: 1,
+      fields: [{ name: 'labels', type: FieldType.other, config: {}, values: [{ app: 'nginx' }] }],
+    };
+
+    expect(packLabelsToLine(frame)).toBe(frame);
+  });
+
+  it('returns the frame untouched when the labels field is missing', () => {
+    const frame: DataFrame = {
+      refId: 'A',
+      length: 1,
+      fields: [{ name: 'Line', type: FieldType.string, config: {}, values: ['msg'] }],
+    };
+
+    expect(packLabelsToLine(frame)).toBe(frame);
+  });
+});
+
+describe('shouldPackLabelsToLine', () => {
+  const baseQuery = { refId: 'A', expr: '*', queryType: QueryType.Instant, packJson: true } as Query;
+
+  it('returns true for a raw logs query with the packJson option enabled', () => {
+    expect(shouldPackLabelsToLine(baseQuery)).toBe(true);
+  });
+
+  it('returns false when the packJson option is disabled', () => {
+    expect(shouldPackLabelsToLine({ ...baseQuery, packJson: false })).toBe(false);
+  });
+
+  it('returns false when the packJson option is undefined', () => {
+    expect(shouldPackLabelsToLine({ ...baseQuery, packJson: undefined })).toBe(false);
+  });
+
+  it.each([QueryType.Stats, QueryType.StatsRange, QueryType.Hits])(
+    'returns false for the %s query type',
+    (queryType) => {
+      expect(shouldPackLabelsToLine({ ...baseQuery, queryType })).toBe(false);
+    }
+  );
+
+  it('returns false for supporting queries (logs sample)', () => {
+    expect(
+      shouldPackLabelsToLine({ ...baseQuery, supportingQueryType: SupportingQueryType.LogsSample })
+    ).toBe(false);
+  });
+
+  it('returns false when the query is undefined', () => {
+    expect(shouldPackLabelsToLine(undefined)).toBe(false);
+  });
+});

--- a/src/transformers/fields/packJsonLineField.ts
+++ b/src/transformers/fields/packJsonLineField.ts
@@ -1,6 +1,6 @@
 import { DataFrame } from '@grafana/data';
 
-import { Query, QueryType } from '../../types';
+import { Query, QueryType, SupportingQueryType } from '../../types';
 import { FrameField } from '../types';
 
 const MSG_KEY = '_msg';
@@ -8,12 +8,16 @@ const MSG_KEY = '_msg';
 /**
  * Tells whether log labels should be packed into the `Line` field for the given query.
  * Applied only to plain raw logs queries with the `Pack to JSON` option enabled —
- * stats, hits (logs volume) and supporting queries (logs sample) are left untouched
+ * stats, hits (logs volume) and supporting queries (logs sample) are left untouched.
+ * The infinite scroll load-more queries feed the same log list as the original raw
+ * logs query, so they are packed too
  */
 export function shouldPackLabelsToLine(query: Query | undefined): boolean {
-  return Boolean(
-    query?.packJson && query.queryType === QueryType.Instant && !query.supportingQueryType
-  );
+  if (!query?.packJson || query.queryType !== QueryType.Instant) {
+    return false;
+  }
+
+  return !query.supportingQueryType || query.supportingQueryType === SupportingQueryType.InfiniteScroll;
 }
 
 /**

--- a/src/transformers/fields/packJsonLineField.ts
+++ b/src/transformers/fields/packJsonLineField.ts
@@ -1,0 +1,47 @@
+import { DataFrame } from '@grafana/data';
+
+import { Query, QueryType } from '../../types';
+import { FrameField } from '../types';
+
+const MSG_KEY = '_msg';
+
+/**
+ * Tells whether log labels should be packed into the `Line` field for the given query.
+ * Applied only to plain raw logs queries with the `Pack to JSON` option enabled —
+ * stats, hits (logs volume) and supporting queries (logs sample) are left untouched
+ */
+export function shouldPackLabelsToLine(query: Query | undefined): boolean {
+  return Boolean(
+    query?.packJson && query.queryType === QueryType.Instant && !query.supportingQueryType
+  );
+}
+
+/**
+ * Replaces the `Line` field values with a JSON object of all log labels, so the log viewer
+ * shows all labels as the log line even when the `_msg` field is missing. The original
+ * message (if any) is kept in the JSON under the `_msg` key. The `labels` field itself
+ * is left untouched, so filtering by labels keeps working
+ */
+export function packLabelsToLine(frame: DataFrame): DataFrame {
+  const lineField = frame.fields.find((f) => f.name === FrameField.Line);
+  const labelsField = frame.fields.find((f) => f.name === FrameField.Labels);
+
+  if (!lineField || !labelsField) {
+    return frame;
+  }
+
+  const packedValues = lineField.values.map((line, i) => {
+    const labels = (labelsField.values[i] ?? {}) as Record<string, unknown>;
+    if (!line && Object.keys(labels).length === 0) {
+      return line;
+    }
+    return JSON.stringify(line ? { [MSG_KEY]: line, ...labels } : labels);
+  });
+
+  return {
+    ...frame,
+    fields: frame.fields.map((field) =>
+      field === lineField ? { ...field, values: packedValues } : field
+    ),
+  };
+}

--- a/src/transformers/frameProcessors/streamFrameProcessor.test.ts
+++ b/src/transformers/frameProcessors/streamFrameProcessor.test.ts
@@ -1,6 +1,6 @@
 import { DataFrame, FieldType } from '@grafana/data';
 
-import { Query } from '../../types';
+import { Query, QueryType, SupportingQueryType } from '../../types';
 
 import { processStreamsFrames } from './streamFrameProcessor';
 
@@ -64,5 +64,42 @@ describe('processStreamsFrames', () => {
     const [processed] = processStreamsFrames([frame], rawQueryMap, [], [], interpolateExpr);
 
     expect(processed.meta?.searchWords).toEqual(['error']);
+  });
+
+  describe('packJson option', () => {
+    const makeQueryMap = (query: Partial<Query>) =>
+      new Map<string, Query>([['A', { refId: 'A', expr: '*', queryType: QueryType.Instant, ...query } as Query]]);
+
+    it('packs labels and the message into the Line field when packJson is enabled', () => {
+      const frame = buildFrame([{ app: 'nginx' }]);
+
+      const [processed] = processStreamsFrames([frame], makeQueryMap({ packJson: true }), [], []);
+
+      const lineField = processed.fields.find((f) => f.name === 'Line');
+      expect(lineField?.values[0]).toBe('{"_msg":"msg","app":"nginx"}');
+    });
+
+    it('keeps the Line field untouched when packJson is disabled', () => {
+      const frame = buildFrame([{ app: 'nginx' }]);
+
+      const [processed] = processStreamsFrames([frame], makeQueryMap({}), [], []);
+
+      const lineField = processed.fields.find((f) => f.name === 'Line');
+      expect(lineField?.values[0]).toBe('msg');
+    });
+
+    it('keeps the Line field untouched for supporting queries (logs sample)', () => {
+      const frame = buildFrame([{ app: 'nginx' }]);
+
+      const [processed] = processStreamsFrames(
+        [frame],
+        makeQueryMap({ packJson: true, supportingQueryType: SupportingQueryType.LogsSample }),
+        [],
+        []
+      );
+
+      const lineField = processed.fields.find((f) => f.name === 'Line');
+      expect(lineField?.values[0]).toBe('msg');
+    });
   });
 });

--- a/src/transformers/frameProcessors/streamFrameProcessor.ts
+++ b/src/transformers/frameProcessors/streamFrameProcessor.ts
@@ -6,6 +6,7 @@ import { DerivedFieldConfig, Query } from '../../types';
 import { getDerivedFields } from '../fields/derivedField';
 import { getStreamFields } from '../fields/labelField';
 import { addLevelField } from '../fields/levelField';
+import { packLabelsToLine, shouldPackLabelsToLine } from '../fields/packJsonLineField';
 import { ANNOTATIONS_REF_ID, InterpolateExpr } from '../types';
 import { dataFrameHasError, setFrameMeta } from '../utils/frame/frameUtils';
 
@@ -54,11 +55,14 @@ function processStreamFrame(
   const derivedFields = getDerivedFields(frameWithLevel, derivedFieldConfigs);
   const baseFields = getStreamFields(frameWithLevel.fields, transformLabels);
 
-  return {
+  const processedFrame = {
     ...frameWithLevel,
     fields: [
       ...baseFields,
       ...derivedFields
     ]
   };
+
+  // packing goes last so the log level and derived fields are extracted from the original message
+  return shouldPackLabelsToLine(query) ? packLabelsToLine(processedFrame) : processedFrame;
 }

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,1 +1,2 @@
+export { packLabelsToLine, shouldPackLabelsToLine } from './fields/packJsonLineField';
 export { transformBackendResult } from './transformBackendResult';

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export type QueryDirection = (typeof QUERY_DIRECTION)[keyof typeof QUERY_DIRECTI
 
 export enum SupportingQueryType {
   DataSample = 'dataSample',
+  // set by Grafana core on the cloned load-more queries of the Explore infinite scroll
+  InfiniteScroll = 'infiniteScroll',
   LogsSample = 'logsSample',
   LogsVolume = 'logsVolume',
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,8 @@ export interface Query extends DataQuery {
   legendFormat?: string;
   maxLines?: number;
   step?: string;
+  /** When enabled, all log labels are shown as a single JSON object in the Line field */
+  packJson?: boolean;
   /** Editor state — structured ad-hoc filter chips. Source of truth in editor; serialized to `extraFilters` only on the request boundary */
   adHocFilters?: AdHocFilter[];
   /** serialized adHocFilters for extra_filters query param (set during applyTemplateVariables) */


### PR DESCRIPTION
Related issue: #677 

### Describe Your Changes

Added a `Pack to JSON` toggle in the query options for raw logs that packs all log labels into a single JSON object shown in the `Line` field:
 - pack labels to JSON on the DS backend, cause ` | pack_json` pipe takes a lot of time on the large time range.
 - refactored `parseInstantResponse` and `parseStreamResponse` - moved out the common logic into separate functions.
 - fixed a bug when live logs work on the previous query state.

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
