### PR TITLE
add a `:` (word filter) operator to Log Level Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: add a `:` (word filter) operator to Log Level Rules, matching a field value by whole word like LogsQL (e.g. `error` matches the word `error`, not `terror`). See [#611](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/611).
+
 ## v0.29.0
 
 * FEATURE: keep log fields in the order returned by VictoriaLogs (for example the order from `| fields a, b, c`) instead of sorting them alphabetically. See [#563](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/563).

--- a/src/README.md
+++ b/src/README.md
@@ -173,7 +173,7 @@ The **Log level rules** section in the datasource configuration allows you to as
 
     * **Enable switch** – enable or disable the rule.
     * **Field name** – the log field the condition will evaluate.
-    * **Operator** – choose from: `Equals`, `Not equal`, `Matches regex`, `Less than`, `Greater than`
+    * **Operator** – choose from: `Equals`, `Not equal`, `Matches regex`, `Less than`, `Greater than`, `Word filter`
     * **Value** – the value to compare the field against.
     * **Log level** – level to assign if the condition matches: `critical`, `warning`, `error`, `info`, `debug`, `trace`, `unknown`
     * **Delete button** – remove the rule.
@@ -213,7 +213,7 @@ Where:
 * `field` is the name of the log field to evaluate (e.g. `_stream_id`, `status_code`, `message`).
 * `value` is the value to compare against. Can be a string or a number, depending on the field.
 * `level` is the log level to assign if the condition matches. Valid values: `critical`, `error`, `warning`, `info`, `debug`, `trace`, `unknown`.
-* `operator` is the comparison operator to use, such as `equals`, `notEquals`, `regex`, `lessThan`, `greaterThan`.
+* `operator` is the comparison operator to use, such as `equals`, `notEquals`, `regex`, `lessThan`, `greaterThan`, `wordFilter`. The `wordFilter` operator follows [LogsQL word filter](https://docs.victoriametrics.com/victorialogs/logsql/#word-filter) semantics: the value matches whole tokens, not substrings (e.g. `error` matches `an error happened` but not `terror`).
 * `enabled` is a boolean flag to enable or disable the rule. Defaults to `true` if omitted.
 
 ### Variables

--- a/src/configuration/LogLevelRules/const.ts
+++ b/src/configuration/LogLevelRules/const.ts
@@ -15,6 +15,7 @@ export const LOG_OPERATOR_OPTIONS: LogOperatorOption[] = [
   { label: '=~', description: 'Matches regex', value: LogLevelRuleType.Regex },
   { label: '<', description: 'Less than', value: LogLevelRuleType.LessThan },
   { label: '>', description: 'Greater than', value: LogLevelRuleType.GreaterThan },
+  { label: ':', description: 'Word filter', value: LogLevelRuleType.WordFilter },
 ];
 
 export const OperatorLabels: Record<LogLevelRuleType, string> = {
@@ -24,6 +25,7 @@ export const OperatorLabels: Record<LogLevelRuleType, string> = {
   [LogLevelRuleType.Regex]: '~',
   [LogLevelRuleType.LessThan]: '<',
   [LogLevelRuleType.GreaterThan]: '>',
+  [LogLevelRuleType.WordFilter]: ':',
 };
 
 export const OperatorLabelsQueryBuilder: Record<LogLevelRuleType, (rule: LogLevelRule) => string> = {
@@ -33,6 +35,7 @@ export const OperatorLabelsQueryBuilder: Record<LogLevelRuleType, (rule: LogLeve
   [LogLevelRuleType.Regex]: (rule) => `${rule.field}:~"${rule.value}"`,
   [LogLevelRuleType.LessThan]: (rule) => `${rule.field}:<"${rule.value}"`,
   [LogLevelRuleType.GreaterThan]: (rule) => `${rule.field}:>"${rule.value}"`,
+  [LogLevelRuleType.WordFilter]: (rule) => `${rule.field}:"${rule.value}"`,
 };
 
 export const LOG_LEVEL_OPTIONS: Array<ComboboxOption<LogLevel>> = Array.from(

--- a/src/configuration/LogLevelRules/types.ts
+++ b/src/configuration/LogLevelRules/types.ts
@@ -15,4 +15,6 @@ export enum LogLevelRuleType {
   LessThan = 'lessThan',
   Regex = 'regex',
   CaseInsensitiveEquals = 'caseInsensitiveEquals',
+  // LogsQL word filter (`field:value`): matches whole tokens, not substrings
+  WordFilter = 'wordFilter',
 }

--- a/src/configuration/LogLevelRules/utils.test.ts
+++ b/src/configuration/LogLevelRules/utils.test.ts
@@ -62,7 +62,17 @@ describe('WordFilter operator (LogsQL word filter `:`)', () => {
     expect(resolve({ other: 'error' } as Labels, [matchRule])).toBe(LogLevel.unknown);
   });
 
-  it('does not match when the rule value is empty (avoids matching everything)', () => {
+  it('empty value matches a missing field (mirrors LogsQL `field:""`)', () => {
+    const rules = [rule({ field: 'msg', value: '', level: LogLevel.error })];
+    expect(resolve({ other: 'x' } as Labels, rules)).toBe(LogLevel.error);
+  });
+
+  it('empty value matches an empty-string field', () => {
+    const rules = [rule({ field: 'msg', value: '', level: LogLevel.error })];
+    expect(resolve({ msg: '' }, rules)).toBe(LogLevel.error);
+  });
+
+  it('empty value does not match a non-empty field', () => {
     const rules = [rule({ field: 'msg', value: '', level: LogLevel.error })];
     expect(resolve({ msg: 'an error happened' }, rules)).toBe(LogLevel.unknown);
   });

--- a/src/configuration/LogLevelRules/utils.test.ts
+++ b/src/configuration/LogLevelRules/utils.test.ts
@@ -1,0 +1,130 @@
+import { Labels, LogLevel } from '@grafana/data';
+
+import { LogLevelRule, LogLevelRuleType } from './types';
+import { extractLevelFromLabels } from './utils';
+
+const rule = (over: Partial<LogLevelRule>): LogLevelRule => ({
+  field: 'msg',
+  operator: LogLevelRuleType.WordFilter,
+  value: 'error',
+  level: LogLevel.error,
+  enabled: true,
+  ...over,
+});
+
+const resolve = (labels: Labels, rules: LogLevelRule[]): LogLevel => extractLevelFromLabels(labels, rules);
+
+describe('extractLevelFromLabels', () => {
+  it('prefers a valid `level` label over rules', () => {
+    const rules = [rule({ field: 'msg', value: 'error', level: LogLevel.error })];
+    expect(resolve({ level: 'debug', msg: 'an error happened' }, rules)).toBe(LogLevel.debug);
+  });
+
+  it('falls back to rules when no valid `level` label exists', () => {
+    const rules = [rule({ field: 'msg', value: 'error', level: LogLevel.error })];
+    expect(resolve({ msg: 'an error happened' }, rules)).toBe(LogLevel.error);
+  });
+
+  it('returns `unknown` when nothing matches', () => {
+    expect(resolve({ msg: 'all good' }, [])).toBe(LogLevel.unknown);
+  });
+
+  it('skips disabled rules', () => {
+    const rules = [rule({ field: 'msg', value: 'error', level: LogLevel.error, enabled: false })];
+    expect(resolve({ msg: 'an error happened' }, rules)).toBe(LogLevel.unknown);
+  });
+
+  it('applies the first matching rule in order', () => {
+    const rules = [
+      rule({ field: 'msg', value: 'warn', level: LogLevel.warning }),
+      rule({ field: 'msg', value: 'error', level: LogLevel.error }),
+    ];
+    expect(resolve({ msg: 'a warn then error' }, rules)).toBe(LogLevel.warning);
+  });
+});
+
+describe('WordFilter operator (LogsQL word filter `:`)', () => {
+  const matchRule = rule({ field: 'msg', value: 'error', level: LogLevel.error });
+  const apply = (msg: unknown) => resolve({ msg } as Labels, [matchRule]);
+
+  it.each([
+    ['an error happened', LogLevel.error],
+    ['error: cannot open file', LogLevel.error],
+    ['ERROR happened', LogLevel.unknown], // case-sensitive, mirrors LogsQL default
+    ['multiple errors occurred', LogLevel.unknown], // `errors` is a different token
+    ['terror detected', LogLevel.unknown], // `terror` is a different token
+    ['all good', LogLevel.unknown],
+  ])('value "%s" -> %s', (msg, expected) => {
+    expect(apply(msg)).toBe(expected);
+  });
+
+  it('does not match when the field is missing', () => {
+    expect(resolve({ other: 'error' } as Labels, [matchRule])).toBe(LogLevel.unknown);
+  });
+
+  it('does not match when the rule value is empty (avoids matching everything)', () => {
+    const rules = [rule({ field: 'msg', value: '', level: LogLevel.error })];
+    expect(resolve({ msg: 'an error happened' }, rules)).toBe(LogLevel.unknown);
+  });
+
+  it('matches a numeric field value coerced to string', () => {
+    const rules = [rule({ field: 'status', value: '500', level: LogLevel.error })];
+    expect(resolve({ status: 500 } as unknown as Labels, rules)).toBe(LogLevel.error);
+  });
+
+  it('matches a multi-word phrase as a substring bounded by non-word chars', () => {
+    const rules = [rule({ field: 'msg', value: 'connection refused', level: LogLevel.error })];
+    expect(resolve({ msg: 'tcp connection refused by peer' }, rules)).toBe(LogLevel.error);
+    expect(resolve({ msg: 'connection was refused' }, rules)).toBe(LogLevel.unknown);
+  });
+
+  it('matches a later occurrence when an earlier one is part of a longer word', () => {
+    const rules = [rule({ field: 'msg', value: 'error', level: LogLevel.error })];
+    expect(resolve({ msg: 'errors and an error' }, rules)).toBe(LogLevel.error);
+  });
+
+  it('does not match when the value is glued to a word char (e.g. underscore)', () => {
+    const rules = [rule({ field: 'msg', value: 'error', level: LogLevel.error })];
+    expect(resolve({ msg: 'error_code raised' }, rules)).toBe(LogLevel.unknown);
+  });
+});
+
+describe('resolveLogLevel — existing operators (regression)', () => {
+  it('Equals matches on strict equality', () => {
+    const rules = [rule({ operator: LogLevelRuleType.Equals, field: 'lvl', value: 'err', level: LogLevel.error })];
+    expect(resolve({ lvl: 'err' }, rules)).toBe(LogLevel.error);
+    expect(resolve({ lvl: 'error' }, rules)).toBe(LogLevel.unknown);
+  });
+
+  it('NotEquals matches when the value differs', () => {
+    const rules = [rule({ operator: LogLevelRuleType.NotEquals, field: 'lvl', value: 'ok', level: LogLevel.error })];
+    expect(resolve({ lvl: 'bad' }, rules)).toBe(LogLevel.error);
+    expect(resolve({ lvl: 'ok' }, rules)).toBe(LogLevel.unknown);
+  });
+
+  it('GreaterThan / LessThan compare numerically', () => {
+    const gt = [rule({ operator: LogLevelRuleType.GreaterThan, field: 'code', value: '499', level: LogLevel.error })];
+    expect(resolve({ code: '500' }, gt)).toBe(LogLevel.error);
+    expect(resolve({ code: '400' }, gt)).toBe(LogLevel.unknown);
+
+    const lt = [rule({ operator: LogLevelRuleType.LessThan, field: 'code', value: '300', level: LogLevel.info })];
+    expect(resolve({ code: '200' }, lt)).toBe(LogLevel.info);
+    expect(resolve({ code: 'not-a-number' }, lt)).toBe(LogLevel.unknown);
+  });
+
+  it('Regex matches and ignores invalid patterns', () => {
+    const ok = [rule({ operator: LogLevelRuleType.Regex, field: 'msg', value: '^err', level: LogLevel.error })];
+    expect(resolve({ msg: 'error here' }, ok)).toBe(LogLevel.error);
+
+    const broken = [rule({ operator: LogLevelRuleType.Regex, field: 'msg', value: '(', level: LogLevel.error })];
+    expect(resolve({ msg: 'error here' }, broken)).toBe(LogLevel.unknown);
+  });
+
+  it('CaseInsensitiveEquals matches regardless of case', () => {
+    const rules = [
+      rule({ operator: LogLevelRuleType.CaseInsensitiveEquals, field: 'lvl', value: 'error', level: LogLevel.error }),
+    ];
+    expect(resolve({ lvl: 'ERROR' }, rules)).toBe(LogLevel.error);
+    expect(resolve({ lvl: 'warn' }, rules)).toBe(LogLevel.unknown);
+  });
+});

--- a/src/configuration/LogLevelRules/utils.ts
+++ b/src/configuration/LogLevelRules/utils.ts
@@ -16,60 +16,79 @@ export const extractLevelFromLabels = (labels: Labels, rules: LogLevelRule[]): L
   return levelByLabel || levelByRule || LogLevel.unknown;
 };
 
-const resolveLogLevel = (log: Record<string, any>, rules: LogLevelRule[]) => {
+const resolveLogLevel = (log: Labels, rules: LogLevelRule[]): LogLevel | null => {
   for (const rule of rules) {
     if (rule.enabled === false) {
       continue;
     }
 
-    const fieldValue = log[rule.field];
-    const fieldValueNumber = Number(fieldValue);
-
-    switch (rule.operator) {
-      case LogLevelRuleType.Equals:
-        if (fieldValue === rule.value) {
-          return rule.level;
-        }
-        break;
-
-      case LogLevelRuleType.NotEquals:
-        if (fieldValue !== rule.value) {
-          return rule.level;
-        }
-        break;
-
-      case LogLevelRuleType.GreaterThan:
-        if (!isNaN(fieldValueNumber) && fieldValueNumber > Number(rule.value)) {
-          return rule.level;
-        }
-        break;
-
-      case LogLevelRuleType.LessThan:
-        if (!isNaN(fieldValueNumber) && fieldValueNumber < Number(rule.value)) {
-          return rule.level;
-        }
-        break;
-
-      case LogLevelRuleType.Regex:
-        if (typeof fieldValue === 'string') {
-          try {
-            const regex = new RegExp(String(rule.value));
-            if (regex.test(fieldValue)) {
-              return rule.level;
-            }
-          } catch {
-            // invalid regex — ignore
-          }
-        }
-        break;
-
-      case LogLevelRuleType.CaseInsensitiveEquals:
-        if (fieldValue?.toLowerCase() === rule.value) {
-          return rule.level;
-        }
-        break;
+    if (ruleMatchers[rule.operator]?.(log[rule.field], rule)) {
+      return rule.level;
     }
   }
 
   return null;
+};
+
+type RuleMatcher = (fieldValue: unknown, rule: LogLevelRule) => boolean;
+
+const ruleMatchers: Record<LogLevelRuleType, RuleMatcher> = {
+  [LogLevelRuleType.Equals]: (fieldValue, rule) => fieldValue === rule.value,
+  [LogLevelRuleType.NotEquals]: (fieldValue, rule) => fieldValue !== rule.value,
+  [LogLevelRuleType.GreaterThan]: (fieldValue, rule) => compareNumeric(fieldValue, rule.value, (a, b) => a > b),
+  [LogLevelRuleType.LessThan]: (fieldValue, rule) => compareNumeric(fieldValue, rule.value, (a, b) => a < b),
+  [LogLevelRuleType.Regex]: (fieldValue, rule) => matchesRegex(fieldValue, rule.value),
+  [LogLevelRuleType.CaseInsensitiveEquals]: (fieldValue, rule) =>
+    typeof fieldValue === 'string' && fieldValue.toLowerCase() === rule.value,
+  [LogLevelRuleType.WordFilter]: (fieldValue, rule) => matchesWordFilter(fieldValue, rule.value),
+};
+
+const compareNumeric = (
+  fieldValue: unknown,
+  ruleValue: string | number,
+  compare: (a: number, b: number) => boolean
+): boolean => {
+  const a = Number(fieldValue);
+  const b = Number(ruleValue);
+  return !isNaN(a) && !isNaN(b) && compare(a, b);
+};
+
+const matchesRegex = (fieldValue: unknown, ruleValue: string | number): boolean => {
+  if (typeof fieldValue !== 'string') {
+    return false;
+  }
+
+  try {
+    return new RegExp(String(ruleValue)).test(fieldValue);
+  } catch {
+    // invalid regex — ignore
+    return false;
+  }
+};
+
+// A char belongs to a word if it is a unicode letter, digit or underscore
+const WORD_CHAR_RE = /[\p{L}\p{N}_]/u;
+const isWordChar = (char: string | undefined): boolean => char !== undefined && WORD_CHAR_RE.test(char);
+
+const matchesWordFilter = (fieldValueRaw: unknown, ruleValueRaw: string | number): boolean => {
+  if (fieldValueRaw === undefined || ruleValueRaw === null) {
+    return false;
+  }
+
+  const fieldValue = String(fieldValueRaw);
+  const ruleValue = String(ruleValueRaw);
+
+  if (ruleValue === '') {
+    return false;
+  }
+
+  for (let at = fieldValue.indexOf(ruleValue); at !== -1; at = fieldValue.indexOf(ruleValue, at + 1)) {
+    const charBefore = fieldValue[at - 1];
+    const charAfter = fieldValue[at + ruleValue.length];
+    if (!isWordChar(charBefore) && !isWordChar(charAfter)) {
+      return true;
+    }
+  }
+
+  return false;
 };

--- a/src/configuration/LogLevelRules/utils.ts
+++ b/src/configuration/LogLevelRules/utils.ts
@@ -71,16 +71,19 @@ const WORD_CHAR_RE = /[\p{L}\p{N}_]/u;
 const isWordChar = (char: string | undefined): boolean => char !== undefined && WORD_CHAR_RE.test(char);
 
 const matchesWordFilter = (fieldValueRaw: unknown, ruleValueRaw: string | number): boolean => {
-  if (fieldValueRaw === undefined || ruleValueRaw === null) {
+  const ruleValue = String(ruleValueRaw ?? '');
+
+  // An empty word filter mirrors LogsQL `field:""`: it matches an empty or missing field
+  // (LogsQL treats empty values as non-existing).
+  if (ruleValue === '') {
+    return fieldValueRaw === undefined || fieldValueRaw === null || String(fieldValueRaw) === '';
+  }
+
+  if (fieldValueRaw === undefined || fieldValueRaw === null) {
     return false;
   }
 
   const fieldValue = String(fieldValueRaw);
-  const ruleValue = String(ruleValueRaw);
-
-  if (ruleValue === '') {
-    return false;
-  }
 
   for (let at = fieldValue.indexOf(ruleValue); at !== -1; at = fieldValue.indexOf(ruleValue, at + 1)) {
     const charBefore = fieldValue[at - 1];

--- a/src/utils/query/levelExpansion.test.ts
+++ b/src/utils/query/levelExpansion.test.ts
@@ -35,4 +35,18 @@ describe('buildLevelExprs', () => {
     ];
     expect(buildLevelExprMap(rules)[LogLevel.error]).toContain(' OR log.level:"err"');
   });
+
+  it('emits field:"" for an empty WordFilter (matches empty/missing fields, mirrors LogsQL)', () => {
+    const rules = [
+      { field: 'message', operator: LogLevelRuleType.WordFilter, value: '', level: LogLevel.error, enabled: true },
+    ];
+    expect(buildLevelExprMap(rules)[LogLevel.error]).toContain(' OR message:""');
+  });
+
+  it('includes WordFilter rules with a non-empty value', () => {
+    const rules = [
+      { field: 'message', operator: LogLevelRuleType.WordFilter, value: 'error', level: LogLevel.error, enabled: true },
+    ];
+    expect(buildLevelExprMap(rules)[LogLevel.error]).toContain(' OR message:"error"');
+  });
 });


### PR DESCRIPTION
Related issue: #611 

### Describe Your Changes

Add a `:` (word filter) operator to Log Level Rules, matching a field value by whole word like LogsQL (e.g. `error` matches the word `error`, not `terror`)

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
