### PR TITLE
feat(query builder): add keyboard hints to the query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: the visual query builder now shows context-aware keyboard hints at the bottom of its dropdowns, so the available shortcuts (select, navigate, confirm, run) are visible while you build a query. See [pr #683](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/683).
+
 ## v0.29.0
 
 * FEATURE: keep log fields in the order returned by VictoriaLogs (for example the order from `| fields a, b, c`) instead of sorting them alphabetically. See [#563](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/563).

--- a/src/components/QueryEditor/TemplateBuilder/KeyboardHintsBar.tsx
+++ b/src/components/QueryEditor/TemplateBuilder/KeyboardHintsBar.tsx
@@ -1,0 +1,85 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Stack, Text, useStyles2 } from '@grafana/ui';
+
+import { Hint } from './keyboardHints';
+
+interface Props {
+  hints: Hint[];
+}
+
+/**
+ * Key of a hint. If multiple keys are provided, they are joined with a '+'
+ */
+const Key = ({ keys, className }: {keys: Hint['keys'], className?: string}) => {
+  return <Stack direction='row' gap={0.5} alignItems='center'>
+    {keys.map((key, index) => (
+      <React.Fragment key={key}>
+        {index > 0 && (
+          <Text color='secondary' variant='bodySmall'>
+            +
+          </Text>
+        )}
+        <span className={className}>{key}</span>
+      </React.Fragment>
+    ))}
+  </Stack>;
+};
+
+/**
+ * A footer of context-aware keyboard hints, pinned to the bottom of an open dropdown
+ */
+export const KeyboardHintsBar: React.FC<Props> = ({ hints }) => {
+  const styles = useStyles2(getStyles);
+
+  if (hints.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.bar}>
+      {hints.map((hint, hintIndex) => (
+        <React.Fragment key={hint.label}>
+          {hintIndex > 0 && <span className={styles.separator} aria-hidden='true' />}
+          <Stack direction='row' gap={0.5} alignItems='center'>
+            <Key keys={hint.keys} className={styles.key} />
+            <Text color='secondary' variant='bodySmall'>
+              {hint.label}
+            </Text>
+          </Stack>
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  bar: css({
+    flexShrink: 0,
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.5, 1),
+    padding: theme.spacing(0.5, 1),
+    backgroundColor: theme.colors.background.secondary,
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+  }),
+  separator: css({
+    flex: 'none',
+    width: 1,
+    height: 12,
+    backgroundColor: theme.colors.border.medium,
+  }),
+  key: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(0, 0.25),
+    color: theme.colors.text.secondary,
+    backgroundColor: theme.colors.background.primary,
+  }),
+});

--- a/src/components/QueryEditor/TemplateBuilder/PipeTypeSearchMenu/PipeTypeSearchPopup.tsx
+++ b/src/components/QueryEditor/TemplateBuilder/PipeTypeSearchMenu/PipeTypeSearchPopup.tsx
@@ -4,7 +4,9 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useStyles2 } from '@grafana/ui';
 
 import { FloatingDropdown } from '../FloatingDropdown';
+import { KeyboardHintsBar } from '../KeyboardHintsBar';
 import { useDropdownNavigation } from '../hooks/useDropdownNavigation';
+import { getPipeMenuHints } from '../keyboardHints';
 import { MenuGroup } from '../templates/registry';
 
 import { getStyles } from './styles';
@@ -140,6 +142,7 @@ export const PipeTypeSearchPopup: React.FC<Props> = ({
         ))}
         {navItems.length === 0 && <div className={styles.pipeSearchEmpty}>No matches</div>}
       </div>
+      <KeyboardHintsBar hints={getPipeMenuHints()} />
     </FloatingDropdown>
   );
 };

--- a/src/components/QueryEditor/TemplateBuilder/PlaceholderChip/ChipDropdown.tsx
+++ b/src/components/QueryEditor/TemplateBuilder/PlaceholderChip/ChipDropdown.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { ComboboxOption, useStyles2 } from '@grafana/ui';
 
 import { FloatingDropdown } from '../FloatingDropdown';
+import { KeyboardHintsBar } from '../KeyboardHintsBar';
+import { getPlaceholderHints } from '../keyboardHints';
 
 import { getStyles } from './styles';
 import { OptionGroup } from './useOptionLoading';
@@ -19,6 +21,8 @@ interface Props {
   floatingRef: (el: HTMLElement | null) => void;
   floatingStyles: React.CSSProperties;
   listRef: React.RefObject<HTMLDivElement | null>;
+  /** Multi-value chip */
+  isMulti?: boolean;
 }
 
 /**
@@ -34,6 +38,7 @@ export const ChipDropdown: React.FC<Props> = ({
   floatingRef,
   floatingStyles,
   listRef,
+  isMulti,
 }) => {
   const styles = useStyles2(getStyles);
 
@@ -53,7 +58,7 @@ export const ChipDropdown: React.FC<Props> = ({
 
   return (
     <FloatingDropdown floatingRef={floatingRef} floatingStyles={floatingStyles} className={styles.optionsList}>
-      <div ref={listRef} onMouseDown={(e) => e.preventDefault()}>
+      <div ref={listRef} className={styles.optionsScroll} onMouseDown={(e) => e.preventDefault()}>
         {optionGroups ? (
           // Grouped rendering — flat index is pre-computed via options order
           optionGroups.map((group) => (
@@ -70,6 +75,7 @@ export const ChipDropdown: React.FC<Props> = ({
           options.map((opt, index) => renderOption(opt, index))
         )}
       </div>
+      <KeyboardHintsBar hints={getPlaceholderHints({ isMulti, hasHighlightedOption: highlightedIndex >= 0 })} />
     </FloatingDropdown>
   );
 };

--- a/src/components/QueryEditor/TemplateBuilder/PlaceholderChip/PlaceholderChip.tsx
+++ b/src/components/QueryEditor/TemplateBuilder/PlaceholderChip/PlaceholderChip.tsx
@@ -153,6 +153,7 @@ export const PlaceholderChip: React.FC<Props> = ({
           floatingRef={setFloating}
           floatingStyles={floatingStyles}
           listRef={listRef}
+          isMulti={isMulti}
         />
       )}
     </>

--- a/src/components/QueryEditor/TemplateBuilder/PlaceholderChip/styles.ts
+++ b/src/components/QueryEditor/TemplateBuilder/PlaceholderChip/styles.ts
@@ -56,8 +56,16 @@ export const getStyles = (theme: GrafanaTheme2) => ({
     borderRadius: theme.shape.radius.default,
     boxShadow: theme.shadows.z2,
     maxHeight: 240,
-    overflowY: 'auto',
     minWidth: 160,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  }),
+  // Only the options list scrolls, so the hints footer stays full-width below the scrollbar
+  optionsScroll: css({
+    flex: 1,
+    minHeight: 0,
+    overflowY: 'auto',
   }),
   optionItem: css({
     display: 'flex',

--- a/src/components/QueryEditor/TemplateBuilder/keyboardHints.test.ts
+++ b/src/components/QueryEditor/TemplateBuilder/keyboardHints.test.ts
@@ -1,0 +1,48 @@
+import { getPipeMenuHints, getPlaceholderHints } from './keyboardHints';
+
+describe('getPipeMenuHints', () => {
+  it('returns the pipe menu hints in order', () => {
+    expect(getPipeMenuHints()).toEqual([
+      { keys: ['Enter'], label: 'Add' },
+      { keys: ['Shift', 'Enter'], label: 'Run' },
+    ]);
+  });
+});
+
+describe('getPlaceholderHints', () => {
+  it('returns the base hints in order', () => {
+    expect(getPlaceholderHints()).toEqual([
+      { keys: ['Enter'], label: 'Select' },
+      { keys: ['Tab'], label: 'Next' },
+    ]);
+  });
+
+  it('appends the Backspace remove hint for a multi-value placeholder', () => {
+    expect(getPlaceholderHints({ isMulti: true })).toEqual([
+      { keys: ['Enter'], label: 'Select' },
+      { keys: ['Tab'], label: 'Next' },
+      { keys: ['Backspace'], label: 'Remove' },
+    ]);
+  });
+
+  it('does not add the Backspace hint for a single-value placeholder', () => {
+    expect(getPlaceholderHints({ isMulti: false })).toEqual([
+      { keys: ['Enter'], label: 'Select' },
+      { keys: ['Tab'], label: 'Next' },
+    ]);
+  });
+
+  it('hides the Tab hint for a multi-value chip when an option is highlighted', () => {
+    expect(getPlaceholderHints({ isMulti: true, hasHighlightedOption: true })).toEqual([
+      { keys: ['Enter'], label: 'Select' },
+      { keys: ['Backspace'], label: 'Remove' },
+    ]);
+  });
+
+  it('keeps the Tab hint for a single-value chip even when an option is highlighted', () => {
+    expect(getPlaceholderHints({ isMulti: false, hasHighlightedOption: true })).toEqual([
+      { keys: ['Enter'], label: 'Select' },
+      { keys: ['Tab'], label: 'Next' },
+    ]);
+  });
+});

--- a/src/components/QueryEditor/TemplateBuilder/keyboardHints.ts
+++ b/src/components/QueryEditor/TemplateBuilder/keyboardHints.ts
@@ -1,0 +1,36 @@
+export interface Hint {
+  keys: string[];
+  label: string;
+}
+
+/** Hints for the "Add pipe step" search menu */
+export function getPipeMenuHints(): Hint[] {
+  return [
+    { keys: ['Enter'], label: 'Add' },
+    { keys: ['Shift', 'Enter'], label: 'Run' },
+  ];
+}
+
+interface PlaceholderHintState {
+  /** Multi-value chip — surfaces the `Backspace` (remove last value) hint */
+  isMulti?: boolean;
+  /** A list option is highlighted — Tab picks it instead of just advancing */
+  hasHighlightedOption?: boolean;
+}
+
+/** Hints for the placeholder value dropdown, tailored to the chip's current state */
+export function getPlaceholderHints({ isMulti, hasHighlightedOption }: PlaceholderHintState = {}): Hint[] {
+  const hints: Hint[] = [{ keys: ['Enter'], label: 'Select' }];
+
+  // In a multi-value chip with a highlighted option, Tab picks that value first
+  // rather than advancing to the next segment — the "Next" hint would mislead, so omit it
+  if (!(isMulti && hasHighlightedOption)) {
+    hints.push({ keys: ['Tab'], label: 'Next' });
+  }
+
+  if (isMulti) {
+    hints.push({ keys: ['Backspace'], label: 'Remove' });
+  }
+
+  return hints;
+}


### PR DESCRIPTION
### Describe Your Changes

 The visual query builder now shows context-aware keyboard hints at the bottom of its dropdowns, so the available shortcuts (select, navigate, confirm, run) are visible while you build a query:

Simple select:
<img width="548" height="360" alt="image" src="https://github.com/user-attachments/assets/029ee8d1-4775-4133-bf34-166f1c42741d" />

Multi values: 
<img width="337" height="361" alt="image" src="https://github.com/user-attachments/assets/70365915-a437-4209-bede-9c4e05e3077e" />

Pipe menu: 
<img width="287" height="343" alt="image" src="https://github.com/user-attachments/assets/8671223d-e18c-42cf-9fd0-e907d92f56fb" />


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
