### PR TITLE
fix(raw logs): restore the `_stream` label in log query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * FEATURE: add a `:` (word filter) operator to Log Level Rules, matching a field value by whole word like LogsQL (e.g. `error` matches the word `error`, not `terror`). See [#611](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/611).
 * FEATURE: the visual query builder now shows context-aware keyboard hints at the bottom of its dropdowns, so the available shortcuts (select, navigate, confirm, run) are visible while you build a query. See [pr #683](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/683).
 
+* BUGFIX: restore the `_stream` label in log query results. Previously, it was hidden from the log line labels. See [pr #685](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/685).
+
 ## v0.29.0
 
 * FEATURE: keep log fields in the order returned by VictoriaLogs (for example the order from `| fields a, b, c`) instead of sorting them alphabetically. See [#563](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/563).

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -194,7 +194,7 @@ func TestDatasourceQueryRequest(t *testing.T) {
 		}
 		timeFd.Append(ts)
 
-		labelsField.Append(json.RawMessage(`{}`))
+		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
@@ -206,6 +206,7 @@ func TestDatasourceQueryRequest(t *testing.T) {
 
 		rsp := backend.DataResponse{}
 		frame.Meta = &data.FrameMeta{
+			PreferredVisualization: logsVisualisation,
 			Custom: map[string]any{
 				"streamIds": []string{""},
 				"streams":   []map[string]string{{"application": "logs-benchmark-Apache.log-1708437847", "hostname": "e28a622d7792"}},
@@ -283,7 +284,7 @@ func TestDatasourceQueryRequest(t *testing.T) {
 		lineRaw := "123"
 		lineField.Append(lineRaw)
 
-		labelsField.Append(json.RawMessage(`{"job":"vlogs"}`))
+		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
@@ -295,6 +296,7 @@ func TestDatasourceQueryRequest(t *testing.T) {
 
 		rsp := backend.DataResponse{}
 		frame.Meta = &data.FrameMeta{
+			PreferredVisualization: logsVisualisation,
 			Custom: map[string]any{
 				"streamIds": []string{""},
 				"streams":   []map[string]string{{"application": "logs-benchmark-Apache.log-1708437847", "hostname": "e28a622d7792"}},
@@ -587,7 +589,7 @@ func TestDatasourceStreamQueryRequest(t *testing.T) {
 		lineRaw := "123"
 		lineField.Append(lineRaw)
 
-		labelsField.Append(json.RawMessage(`{}`))
+		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
@@ -650,7 +652,7 @@ func TestDatasourceStreamQueryRequest(t *testing.T) {
 		lineRaw := "123"
 		lineField.Append(lineRaw)
 
-		labelsField.Append(json.RawMessage(`{"job":"vlogs"}`))
+		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
@@ -814,7 +816,7 @@ func TestDatasourceStreamRequestWithRetry(t *testing.T) {
 		lineRaw := "123"
 		lineField.Append(lineRaw)
 
-		labelsField.Append(json.RawMessage(`{}`))
+		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
@@ -877,7 +879,7 @@ func TestDatasourceStreamRequestWithRetry(t *testing.T) {
 		lineRaw := "123"
 		lineField.Append(lineRaw)
 
-		labelsField.Append(json.RawMessage(`{"job":"vlogs"}`))
+		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(

--- a/pkg/plugin/response_logs.go
+++ b/pkg/plugin/response_logs.go
@@ -34,8 +34,6 @@ func buildLogID(ts, msg, streamId []byte) string {
 	return strconv.FormatUint(h.Sum64(), 16)
 }
 
-var nowFunc = time.Now
-
 // streamFieldsToMap turns the parsed `_stream` fields into a label->value map
 // for meta.custom.streams, consumed by the "Show context" stream label selector
 func streamFieldsToMap(stf []utils.StreamField) map[string]string {
@@ -46,10 +44,31 @@ func streamFieldsToMap(stf []utils.StreamField) map[string]string {
 	return m
 }
 
-// parseStreamResponse reads data from the reader and collects
-// fields and frame with necessary information
-func parseInstantResponse(reader io.Reader) backend.DataResponse {
+type LogRow struct {
+	Time     time.Time
+	Line     string
+	ID       string
+	Labels   json.RawMessage
+	StreamID string
+	Stream   map[string]string
+}
 
+type LogFrame struct {
+	frame     *data.Frame
+	streamIds []string
+	streams   []map[string]string
+}
+
+// append adds a row to the frame
+func (b *LogFrame) append(r LogRow) {
+	// order of fields must match the order of fields in the frame
+	b.frame.AppendRow(r.Time, r.Line, r.ID, r.Labels)
+	b.streamIds = append(b.streamIds, r.StreamID)
+	b.streams = append(b.streams, r.Stream)
+}
+
+// newLogFrame creates a new frame with the necessary fields
+func newLogFrame() *LogFrame {
 	labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
 	labelsField.Name = gLabelsField
 
@@ -62,10 +81,85 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 	idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 	idField.Name = gIDField
 
-	// per-row data for the "Show context" stream label selector
-	streamIds := make([]string, 0)
-	streams := make([]map[string]string, 0)
+	return &LogFrame{
+		frame:     data.NewFrame("", timeFd, lineField, idField, labelsField),
+		streams:   make([]map[string]string, 0),
+		streamIds: make([]string, 0),
+	}
+}
 
+// parseLogLine trims, decodes and validates that the line is a JSON object.
+func parseLogLine(parser *fastjson.Parser, b []byte) (*fastjson.Value, error) {
+	b = bytes.Trim(b, "\n")
+	value, err := parser.ParseBytes(b)
+	if err != nil {
+		return nil, fmt.Errorf("error decode response: %s", err)
+	}
+	if value.Type() != fastjson.TypeObject {
+		return nil, fmt.Errorf("error get object from decoded response: value doesn't contain object; it contains %s", value.Type())
+	}
+	return value, nil
+}
+
+// getLogRow processes one parsed log object
+func getLogRow(value *fastjson.Value) (LogRow, error) {
+	// Time field
+	var ts time.Time
+	rawTime := value.GetStringBytes(timeField)
+	if rawTime != nil {
+		t, err := utils.GetTime(string(rawTime))
+		if err != nil {
+			return LogRow{}, fmt.Errorf("error parse time from _time field: %s", err)
+		}
+		ts = t
+	} else {
+		// No `_time` in the row: fall back to the zero time on purpose. Do NOT substitute
+		// nowFunc()/time.Now() here — a current timestamp looks plausible and would silently
+		// mislead the user into trusting a fabricated time. The zero time is an obvious signal
+		// that the timestamp is missing. In practice `_time` is always present for log queries.
+		ts = time.Time{}
+	}
+
+	rawStreamID := value.GetStringBytes(streamIdField)
+
+	// custom.metadata stream field
+	// parse `_stream` into a per-row label map for the log context UI and
+	var streamMap map[string]string
+	if value.Exists(streamField) {
+		rawStream := string(value.GetStringBytes(streamField))
+		stf, err := utils.ParseStreamFields(rawStream)
+		if err != nil {
+			return LogRow{}, fmt.Errorf("error parse _stream field: %s", err)
+		}
+		streamMap = streamFieldsToMap(stf)
+	}
+
+	value.Del(timeField)
+
+	// Line field
+	rawMsg := value.GetStringBytes(messageField)
+	line := string(rawMsg)
+	value.Del(messageField)
+
+	// Labels field
+	labels := json.RawMessage(value.MarshalTo(nil))
+	// ID field
+	id := buildLogID(rawTime, rawMsg, rawStreamID)
+
+	return LogRow{
+		Time:     ts,
+		Line:     line,
+		Labels:   labels,
+		StreamID: string(rawStreamID),
+		Stream:   streamMap,
+		ID:       id,
+	}, nil
+}
+
+// parseInstantResponse reads data from the reader and collects
+// fields and frame with necessary information
+func parseInstantResponse(reader io.Reader) backend.DataResponse {
+	logFrame := newLogFrame()
 	br := bufio.NewReaderSize(reader, 64*1024)
 	var parser fastjson.Parser
 	var finishedReading bool
@@ -88,92 +182,28 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 			continue
 		}
 
-		b = bytes.Trim(b, "\n")
-		value, err := parser.ParseBytes(b)
+		value, err := parseLogLine(&parser, b)
 		if err != nil {
-			return newResponseError(fmt.Errorf("error decode response: %s", err), backend.StatusInternal)
+			return newResponseError(err, backend.StatusInternal)
 		}
 
-		if value.Type() != fastjson.TypeObject {
-			return newResponseError(fmt.Errorf("error get object from decoded response: value doesn't contain object; it contains %s", value.Type()), backend.StatusInternal)
+		logRow, err := getLogRow(value)
+		if err != nil {
+			return newResponseError(err, backend.StatusInternal)
 		}
 
-		var (
-			rowMsg      []byte
-			rowStreamId []byte
-			rowTime     []byte
-		)
-
-		if value.Exists(messageField) {
-			rowMsg = value.GetStringBytes(messageField)
-			lineField.Append(string(rowMsg))
-			value.Del(messageField)
-		} else {
-			// pad lineField on rows without _msg to keep frame fields equal length
-			lineField.Append("")
-		}
-
-		if value.Exists(timeField) {
-			rowTime = value.GetStringBytes(timeField)
-			getTime, err := utils.GetTime(string(rowTime))
-			if err != nil {
-				return newResponseError(fmt.Errorf("error parse time from _time field: %s", err), backend.StatusInternal)
-			}
-			timeFd.Append(getTime)
-			value.Del(timeField)
-		}
-
-		if value.Exists(streamIdField) {
-			rowStreamId = value.GetStringBytes(streamIdField)
-		}
-
-		// parse `_stream` into a per-row label map for the log context UI and
-		// drop it from the row so it does not show up among the log labels.
-		// A missing `_stream` field yields a nil map (JSON null) so the frontend
-		// can tell "field absent" apart from "field empty" and fall back to `_stream_id`
-		var streamMap map[string]string
-		if value.Exists(streamField) {
-			rowStream := string(value.GetStringBytes(streamField))
-			value.Del(streamField)
-			stf, err := utils.ParseStreamFields(rowStream)
-			if err != nil {
-				return newResponseError(fmt.Errorf("error parse _stream field: %s", err), backend.StatusInternal)
-			}
-			streamMap = streamFieldsToMap(stf)
-		}
-		streamIds = append(streamIds, string(rowStreamId))
-		streams = append(streams, streamMap)
-
-		labelsField.Append(json.RawMessage(value.MarshalTo(nil)))
-		idField.Append(buildLogID(rowTime, rowMsg, rowStreamId))
+		logFrame.append(logRow)
 	}
-
-	// Grafana expects lineFields to be always non-empty.
-	if lineField.Len() == 0 {
-		for i := 0; i < labelsField.Len(); i++ {
-			label := labelsField.At(i)
-			lineField.Append(fmt.Sprintf("%s", label))
-		}
-	}
-
-	// Grafana expects time field to be always non-empty.
-	if timeFd.Len() == 0 {
-		now := nowFunc()
-		for i := 0; i < lineField.Len(); i++ {
-			timeFd.Append(now)
-		}
-	}
-
-	frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 
 	rsp := backend.DataResponse{}
-	frame.Meta = &data.FrameMeta{
+	logFrame.frame.Meta = &data.FrameMeta{
+		PreferredVisualization: logsVisualisation,
 		Custom: map[string]any{
-			"streamIds": streamIds,
-			"streams":   streams,
+			"streamIds": logFrame.streamIds,
+			"streams":   logFrame.streams,
 		},
 	}
-	rsp.Frames = append(rsp.Frames, frame)
+	rsp.Frames = append(rsp.Frames, logFrame.frame)
 
 	return rsp
 }
@@ -183,26 +213,11 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 // it looks like the parseInstantResponse function, but it reads data and continuously
 // parse the lines from the reader and we need to collect only one data.Frame
 func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
-
 	br := bufio.NewReaderSize(reader, 64*1024)
 	var parser fastjson.Parser
 	var finishedReading bool
 	for n := 0; !finishedReading; n++ {
-		labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
-		labelsField.Name = gLabelsField
-
-		timeFd := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
-		timeFd.Name = gTimeField
-
-		lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-		lineField.Name = gLineField
-
-		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
-		idField.Name = gIDField
-
-		// per-row data for the "Show context" stream label selector
-		streamIds := make([]string, 0)
-		streams := make([]map[string]string, 0)
+		logFrame := newLogFrame()
 
 		b, err := br.ReadBytes('\n')
 		if err != nil {
@@ -222,87 +237,27 @@ func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
 			continue
 		}
 
-		b = bytes.Trim(b, "\n")
-		value, err := parser.ParseBytes(b)
+		value, err := parseLogLine(&parser, b)
 		if err != nil {
-			return fmt.Errorf("error decode response: %s", err)
-		}
-		if value.Type() != fastjson.TypeObject {
-			return fmt.Errorf("error get object from decoded response: value doesn't contain object; it contains %s", value.Type())
+			return err
 		}
 
-		var (
-			rowMsg      []byte
-			rowStreamId []byte
-			rowTime     []byte
-		)
-
-		if value.Exists(messageField) {
-			rowMsg = value.GetStringBytes(messageField)
-			lineField.Append(string(rowMsg))
-			value.Del(messageField)
-		}
-		if value.Exists(timeField) {
-			rowTime = value.GetStringBytes(timeField)
-			getTime, err := utils.GetTime(string(rowTime))
-			if err != nil {
-				return fmt.Errorf("error parse time from _time field: %s", err)
-			}
-			timeFd.Append(getTime)
-			value.Del(timeField)
+		logRow, err := getLogRow(value)
+		if err != nil {
+			return err
 		}
 
-		if value.Exists(streamIdField) {
-			rowStreamId = value.GetStringBytes(streamIdField)
-		}
-
-		// parse `_stream` into a per-row label map for the log context UI and
-		// drop it from the row so it does not show up among the log labels.
-		// A missing `_stream` field yields a nil map (JSON null) so the frontend
-		// can tell "field absent" apart from "field empty" and fall back to `_stream_id`
-		var streamMap map[string]string
-		if value.Exists(streamField) {
-			rowStream := string(value.GetStringBytes(streamField))
-			value.Del(streamField)
-			stf, err := utils.ParseStreamFields(rowStream)
-			if err != nil {
-				return fmt.Errorf("error parse _stream field: %s", err)
-			}
-			streamMap = streamFieldsToMap(stf)
-		}
-		streamIds = append(streamIds, string(rowStreamId))
-		streams = append(streams, streamMap)
-
-		labelsField.Append(json.RawMessage(value.MarshalTo(nil)))
-		idField.Append(buildLogID(rowTime, rowMsg, rowStreamId))
-
-		// Grafana expects lineFields to be always non-empty.
-		if lineField.Len() == 0 {
-			for i := 0; i < labelsField.Len(); i++ {
-				label := labelsField.At(i)
-				lineField.Append(fmt.Sprintf("%s", label))
-			}
-		}
-
-		// Grafana expects time field to be always non-empty.
-		if timeFd.Len() == 0 {
-			now := nowFunc()
-			for i := 0; i < lineField.Len(); i++ {
-				timeFd.Append(now)
-			}
-		}
-
-		frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
+		logFrame.append(logRow)
 		// this is necessary information because the logs visualization is preferred
-		frame.Meta = &data.FrameMeta{
+		logFrame.frame.Meta = &data.FrameMeta{
 			PreferredVisualization: logsVisualisation,
 			Custom: map[string]any{
-				"streamIds": streamIds,
-				"streams":   streams,
+				"streamIds": logFrame.streamIds,
+				"streams":   logFrame.streams,
 			},
 		}
 
-		ch <- frame
+		ch <- logFrame.frame
 	}
 
 	return nil

--- a/pkg/plugin/response_logs.go
+++ b/pkg/plugin/response_logs.go
@@ -44,7 +44,7 @@ func streamFieldsToMap(stf []utils.StreamField) map[string]string {
 	return m
 }
 
-type LogRow struct {
+type logRow struct {
 	Time     time.Time
 	Line     string
 	ID       string
@@ -53,22 +53,22 @@ type LogRow struct {
 	Stream   map[string]string
 }
 
-type LogFrame struct {
-	frame     *data.Frame
+type logFrame struct {
+	dataFrame *data.Frame
 	streamIds []string
 	streams   []map[string]string
 }
 
 // append adds a row to the frame
-func (b *LogFrame) append(r LogRow) {
+func (b *logFrame) append(r logRow) {
 	// order of fields must match the order of fields in the frame
-	b.frame.AppendRow(r.Time, r.Line, r.ID, r.Labels)
+	b.dataFrame.AppendRow(r.Time, r.Line, r.ID, r.Labels)
 	b.streamIds = append(b.streamIds, r.StreamID)
 	b.streams = append(b.streams, r.Stream)
 }
 
 // newLogFrame creates a new frame with the necessary fields
-func newLogFrame() *LogFrame {
+func newLogFrame() *logFrame {
 	labelsField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
 	labelsField.Name = gLabelsField
 
@@ -81,15 +81,15 @@ func newLogFrame() *LogFrame {
 	idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 	idField.Name = gIDField
 
-	return &LogFrame{
-		frame:     data.NewFrame("", timeFd, lineField, idField, labelsField),
+	return &logFrame{
+		dataFrame: data.NewFrame("", timeFd, lineField, idField, labelsField),
 		streams:   make([]map[string]string, 0),
 		streamIds: make([]string, 0),
 	}
 }
 
-// parseLogLine trims, decodes and validates that the line is a JSON object.
-func parseLogLine(parser *fastjson.Parser, b []byte) (*fastjson.Value, error) {
+// parseJsonLine trims, decodes and validates that the line is a JSON object.
+func parseJsonLine(parser *fastjson.Parser, b []byte) (*fastjson.Value, error) {
 	b = bytes.Trim(b, "\n")
 	value, err := parser.ParseBytes(b)
 	if err != nil {
@@ -102,14 +102,14 @@ func parseLogLine(parser *fastjson.Parser, b []byte) (*fastjson.Value, error) {
 }
 
 // getLogRow processes one parsed log object
-func getLogRow(value *fastjson.Value) (LogRow, error) {
+func getLogRow(value *fastjson.Value) (logRow, error) {
 	// Time field
 	var ts time.Time
 	rawTime := value.GetStringBytes(timeField)
 	if rawTime != nil {
 		t, err := utils.GetTime(string(rawTime))
 		if err != nil {
-			return LogRow{}, fmt.Errorf("error parse time from _time field: %s", err)
+			return logRow{}, fmt.Errorf("error parse time from _time field: %s", err)
 		}
 		ts = t
 	} else {
@@ -129,7 +129,7 @@ func getLogRow(value *fastjson.Value) (LogRow, error) {
 		rawStream := string(value.GetStringBytes(streamField))
 		stf, err := utils.ParseStreamFields(rawStream)
 		if err != nil {
-			return LogRow{}, fmt.Errorf("error parse _stream field: %s", err)
+			return logRow{}, fmt.Errorf("error parse _stream field: %s", err)
 		}
 		streamMap = streamFieldsToMap(stf)
 	}
@@ -146,7 +146,7 @@ func getLogRow(value *fastjson.Value) (LogRow, error) {
 	// ID field
 	id := buildLogID(rawTime, rawMsg, rawStreamID)
 
-	return LogRow{
+	return logRow{
 		Time:     ts,
 		Line:     line,
 		Labels:   labels,
@@ -159,7 +159,7 @@ func getLogRow(value *fastjson.Value) (LogRow, error) {
 // parseInstantResponse reads data from the reader and collects
 // fields and frame with necessary information
 func parseInstantResponse(reader io.Reader) backend.DataResponse {
-	logFrame := newLogFrame()
+	frame := newLogFrame()
 	br := bufio.NewReaderSize(reader, 64*1024)
 	var parser fastjson.Parser
 	var finishedReading bool
@@ -182,28 +182,28 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 			continue
 		}
 
-		value, err := parseLogLine(&parser, b)
+		value, err := parseJsonLine(&parser, b)
 		if err != nil {
 			return newResponseError(err, backend.StatusInternal)
 		}
 
-		logRow, err := getLogRow(value)
+		row, err := getLogRow(value)
 		if err != nil {
 			return newResponseError(err, backend.StatusInternal)
 		}
 
-		logFrame.append(logRow)
+		frame.append(row)
 	}
 
 	rsp := backend.DataResponse{}
-	logFrame.frame.Meta = &data.FrameMeta{
+	frame.dataFrame.Meta = &data.FrameMeta{
 		PreferredVisualization: logsVisualisation,
 		Custom: map[string]any{
-			"streamIds": logFrame.streamIds,
-			"streams":   logFrame.streams,
+			"streamIds": frame.streamIds,
+			"streams":   frame.streams,
 		},
 	}
-	rsp.Frames = append(rsp.Frames, logFrame.frame)
+	rsp.Frames = append(rsp.Frames, frame.dataFrame)
 
 	return rsp
 }
@@ -217,7 +217,7 @@ func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
 	var parser fastjson.Parser
 	var finishedReading bool
 	for n := 0; !finishedReading; n++ {
-		logFrame := newLogFrame()
+		frame := newLogFrame()
 
 		b, err := br.ReadBytes('\n')
 		if err != nil {
@@ -237,27 +237,27 @@ func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
 			continue
 		}
 
-		value, err := parseLogLine(&parser, b)
+		value, err := parseJsonLine(&parser, b)
 		if err != nil {
 			return err
 		}
 
-		logRow, err := getLogRow(value)
+		row, err := getLogRow(value)
 		if err != nil {
 			return err
 		}
 
-		logFrame.append(logRow)
+		frame.append(row)
 		// this is necessary information because the logs visualization is preferred
-		logFrame.frame.Meta = &data.FrameMeta{
+		frame.dataFrame.Meta = &data.FrameMeta{
 			PreferredVisualization: logsVisualisation,
 			Custom: map[string]any{
-				"streamIds": logFrame.streamIds,
-				"streams":   logFrame.streams,
+				"streamIds": frame.streamIds,
+				"streams":   frame.streams,
 			},
 		}
 
-		ch <- logFrame.frame
+		ch <- frame.dataFrame
 	}
 
 	return nil

--- a/pkg/plugin/response_logs_test.go
+++ b/pkg/plugin/response_logs_test.go
@@ -74,14 +74,6 @@ func Test_buildLogID(t *testing.T) {
 }
 
 func Test_parseInstantResponse(t *testing.T) {
-	now := time.Now()
-	nowFunc = func() time.Time {
-		return now
-	}
-	defer func() {
-		nowFunc = time.Now
-	}()
-
 	// mustTime parses a raw _time string the same way production does.
 	getTimeType := func(s string) time.Time {
 		tt, err := utils.GetTime(s)
@@ -96,6 +88,7 @@ func Test_parseInstantResponse(t *testing.T) {
 	newFrame := func(timeFd, lineField, idField, labelsField *data.Field, streamIds []string, streams []map[string]string) backend.DataResponse {
 		frame := data.NewFrame("", timeFd, lineField, idField, labelsField)
 		frame.Meta = &data.FrameMeta{
+			PreferredVisualization: logsVisualisation,
 			Custom: map[string]any{
 				"streamIds": streamIds,
 				"streams":   streams,
@@ -209,7 +202,7 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			msgRaw := ""
 			lineField.Append(msgRaw)
-			labelsField.Append(json.RawMessage(`{}`))
+			labelsField.Append(json.RawMessage(`{"_stream":"{}"}`))
 
 			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msgRaw, ""}), labelsField, []string{""}, []map[string]string{{}})
 		},
@@ -229,7 +222,7 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			msgRaw := "123"
 			lineField.Append(msgRaw)
-			labelsField.Append(json.RawMessage(`{}`))
+			labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`))
 
 			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msgRaw, ""}), labelsField, []string{""}, []map[string]string{{"application": "logs-benchmark-Apache.log-1708437847", "hostname": "e28a622d7792"}})
 		},
@@ -249,7 +242,7 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			msgRaw := "123"
 			lineField.Append(msgRaw)
-			labelsField.Append(json.RawMessage(`{"job":"vlogs"}`))
+			labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`))
 
 			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msgRaw, ""}), labelsField, []string{""}, []map[string]string{{"application": "logs-benchmark-Apache.log-1708437847", "hostname": "e28a622d7792"}})
 		},
@@ -264,8 +257,8 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := newField(data.FieldTypeString, gLineField)
 			labelsField := newField(data.FieldTypeJSON, gLabelsField)
 
-			timeFd.Append(now)
-			timeFd.Append(now)
+			timeFd.Append(time.Time{})
+			timeFd.Append(time.Time{})
 			lineField.Append("")
 			lineField.Append("")
 			labelsField.Append(json.RawMessage(`{"stream":"stderr","count(*)":"394"}`))
@@ -288,7 +281,7 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := newField(data.FieldTypeString, gLineField)
 			labelsField := newField(data.FieldTypeJSON, gLabelsField)
 
-			timeFd.Append(now)
+			timeFd.Append(time.Time{})
 			lineField.Append("")
 			labelsField.Append(json.RawMessage(`{"level":""}`))
 
@@ -333,7 +326,7 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			timeFd.Append(getTimeType(tsRaw))
 			lineField.Append(msg)
-			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000009eaf29866f70976a098adc735393deb1","compose_project":"app","compose_service":"gateway"}`))
+			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000009eaf29866f70976a098adc735393deb1","_stream":"{compose_project=\"app\",compose_service=\"gateway\"}","compose_project":"app","compose_service":"gateway"}`))
 
 			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msg, streamID}), labelsField, []string{streamID}, []map[string]string{{"compose_project": "app", "compose_service": "gateway"}})
 		},
@@ -358,7 +351,7 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			timeFd.Append(getTimeType(tsRaw))
 			lineField.Append(msg)
-			labelsField.Append(json.RawMessage(`{"compose_project":"app","compose_service":"gateway"}`))
+			labelsField.Append(json.RawMessage(`{"_stream":"{compose_project=\"app\",compose_service=\"gateway\"}","compose_project":"app","compose_service":"gateway"}`))
 
 			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msg, ""}), labelsField, []string{""}, []map[string]string{{"compose_project": "app", "compose_service": "gateway"}})
 		},
@@ -373,7 +366,7 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := newField(data.FieldTypeString, gLineField)
 			labelsField := newField(data.FieldTypeJSON, gLabelsField)
 
-			timeFd.Append(now)
+			timeFd.Append(time.Time{})
 			lineField.Append("507")
 			labelsField.Append(json.RawMessage(`{"count":"507"}`))
 
@@ -402,9 +395,9 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField.Append("1")
 			lineField.Append("2")
 			lineField.Append("3")
-			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000002e3bd2bdc376279a6418761ca20c417c","path":"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log","stream":"stderr","time":"2024-09-10T12:24:38.124811792Z"}`))
-			labelsField.Append(json.RawMessage(`{"_stream_id":"0000000000000000356bfe9e3c71128c750d94c15df6b908","date":"0","stream":"stream1","log.level":"info"}`))
-			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000002e3bd2bdc376279a6418761ca20c417c","path":"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log","stream":"stderr","time":"2024-09-10T13:06:56.451470093Z"}`))
+			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000002e3bd2bdc376279a6418761ca20c417c","_stream":"{path=\"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log\",stream=\"stderr\"}","path":"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log","stream":"stderr","time":"2024-09-10T12:24:38.124811792Z"}`))
+			labelsField.Append(json.RawMessage(`{"_stream_id":"0000000000000000356bfe9e3c71128c750d94c15df6b908","_stream":"{stream=\"stream1\"}","date":"0","stream":"stream1","log.level":"info"}`))
+			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000002e3bd2bdc376279a6418761ca20c417c","_stream":"{path=\"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log\",stream=\"stderr\"}","path":"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log","stream":"stderr","time":"2024-09-10T13:06:56.451470093Z"}`))
 
 			pathValue := "/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log"
 			return newFrame(timeFd, lineField, newIDField(
@@ -435,7 +428,7 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			timeFd.Append(getTimeType(tsRaw))
 			lineField.Append(str)
-			labelsField.Append(json.RawMessage(`{"_stream_id":"0000000000000000356bfe9e3c71128c750d94c15df6b908","date":"0","stream":"stream1","log.level":"info"}`))
+			labelsField.Append(json.RawMessage(`{"_stream_id":"0000000000000000356bfe9e3c71128c750d94c15df6b908","_stream":"{stream=\"stream1\"}","date":"0","stream":"stream1","log.level":"info"}`))
 
 			return newFrame(timeFd, lineField, newIDField(row{tsRaw, str, streamID}), labelsField, []string{streamID}, []map[string]string{{"stream": "stream1"}})
 		},
@@ -453,7 +446,7 @@ func Test_parseInstantResponse(t *testing.T) {
 			tsRaw := "2024-02-20T14:04:27Z"
 			timeFd.Append(getTimeType(tsRaw))
 			lineField.Append("123")
-			labelsField.Append(json.RawMessage(`{}`))
+			labelsField.Append(json.RawMessage(`{"_stream":"{Dino Species=\"Stegosaurus\",kubernetes.labels.app.kubernetes.io/instance=\"123\",kubernetes.labels.app.kubernetes.io/name=\"vmagent\",kubernetes.namespace_name=\"monitoring\"}"}`))
 
 			return newFrame(timeFd, lineField, newIDField(row{tsRaw, "123", ""}), labelsField, []string{""}, []map[string]string{{
 				"Dino Species": "Stegosaurus",
@@ -476,7 +469,7 @@ func Test_parseInstantResponse(t *testing.T) {
 			tsRaw := "2024-02-20T14:04:27Z"
 			timeFd.Append(getTimeType(tsRaw))
 			lineField.Append("123")
-			labelsField.Append(json.RawMessage(`{}`))
+			labelsField.Append(json.RawMessage(`{"_stream":"{kubernetes.host=\"host1\",kubernetes.labels.app.kubernetes.io/instance=\"123\",kubernetes.labels.app.kubernetes.io/name=\"vmagent\",kubernetes.namespace_name=\"monitoring\"}"}`))
 
 			return newFrame(timeFd, lineField, newIDField(row{tsRaw, "123", ""}), labelsField, []string{""}, []map[string]string{{
 				"kubernetes.host": "host1",
@@ -502,8 +495,8 @@ func Test_parseInstantResponse(t *testing.T) {
 			timeFd.Append(getTimeType(ts2))
 			lineField.Append("some new message")
 			lineField.Append("")
-			labelsField.Append(json.RawMessage(`{"_stream_id":"1","container.id":"1","container.name":"1","fluent.tag":"2fa06040a011","severity":"Unspecified","source":"stdout"}`))
-			labelsField.Append(json.RawMessage(`{"_stream_id":"2","container.id":"2","container.name":"2","fluent.tag":"2fa06040a011","severity":"Unspecified","source":"stdout"}`))
+			labelsField.Append(json.RawMessage(`{"_stream_id":"1","_stream":"{container.id=\"1\",container.name=\"1\"}","container.id":"1","container.name":"1","fluent.tag":"2fa06040a011","severity":"Unspecified","source":"stdout"}`))
+			labelsField.Append(json.RawMessage(`{"_stream_id":"2","_stream":"{container.id=\"2\",container.name=\"2\"}","container.id":"2","container.name":"2","fluent.tag":"2fa06040a011","severity":"Unspecified","source":"stdout"}`))
 
 			return newFrame(timeFd, lineField, newIDField(
 				row{ts1, "some new message", "1"},
@@ -523,15 +516,15 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField := newField(data.FieldTypeString, gLineField)
 			labelsField := newField(data.FieldTypeJSON, gLabelsField)
 
-			timeFd.Append(now)
-			timeFd.Append(now)
-			timeFd.Append(now)
+			timeFd.Append(time.Time{})
+			timeFd.Append(time.Time{})
+			timeFd.Append(time.Time{})
 			lineField.Append("")
 			lineField.Append("")
 			lineField.Append("")
-			labelsField.Append(json.RawMessage(`{"logs":"69275"}`))
-			labelsField.Append(json.RawMessage(`{"logs":"5022"}`))
-			labelsField.Append(json.RawMessage(`{"logs":"194"}`))
+			labelsField.Append(json.RawMessage(`{"logs":"69275","_stream":"{az_id=\"use1-az2\",source=\"vector\",vpc_id=\"vpc\"}"}`))
+			labelsField.Append(json.RawMessage(`{"logs":"5022","_stream":"{namespace=\"ops-monitoring-ns\"}"}`))
+			labelsField.Append(json.RawMessage(`{"logs":"194","_stream":"{}"}`))
 
 			return newFrame(timeFd, lineField, newIDField(
 				row{"", "", ""},
@@ -587,8 +580,8 @@ func Test_parseInstantResponse(t *testing.T) {
 			timeFd.Append(getTimeType(ts2))
 			lineField.Append(msg)
 			lineField.Append("")
-			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000000899b9a9578ea0f11a8a45c1b4cc8e34","stream":"stdout"}`))
-			labelsField.Append(json.RawMessage(`{"_stream_id":"0000000000000000e934a84adb05276890d7f7bfcadabe92"}`))
+			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000000899b9a9578ea0f11a8a45c1b4cc8e34","_stream":"{kubernetes.container_name=\"frigate\",stream=\"stdout\"}","stream":"stdout"}`))
+			labelsField.Append(json.RawMessage(`{"_stream_id":"0000000000000000e934a84adb05276890d7f7bfcadabe92","_stream":"{}"}`))
 
 			return newFrame(timeFd, lineField, newIDField(
 				row{ts1, msg, "00000000000000000899b9a9578ea0f11a8a45c1b4cc8e34"},


### PR DESCRIPTION
### Describe Your Changes

1. Restored the `_stream` field in both raw and live logs. Now it has the same behavior as the vmui.
2. Refactored the `response_log`, moved the common functionality to a separate function. 
3. Fixed tests by adding the missing `_stream` filter.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
