### PR TITLE
fix(live tailing): pick up query changes during live tailing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * FEATURE: add a `:` (word filter) operator to Log Level Rules, matching a field value by whole word like LogsQL (e.g. `error` matches the word `error`, not `terror`). See [#611](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/611).
 * FEATURE: the visual query builder now shows context-aware keyboard hints at the bottom of its dropdowns, so the available shortcuts (select, navigate, confirm, run) are visible while you build a query. See [pr #683](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/683).
 
+* BUGFIX: live tailing now picks up query changes immediately. Previously, editing the query expression while live logs were streaming kept showing results for the previous query until the page was reloaded.
+
 ## v0.29.0
 
 * FEATURE: keep log fields in the order returned by VictoriaLogs (for example the order from `| fields a, b, c`) instead of sorting them alphabetically. See [#563](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/563).

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -228,20 +228,20 @@ func (d *Datasource) RunStream(ctx context.Context, req *backend.RunStreamReques
 	// request.Path is created in the frontend by LiveChannelPathProvider (used in
 	// runLiveQueryThroughBackend), path format:
 	// `${request.requestId}/${query.refId}/${generation}-${queryHash}`
-	ch, ok := di.liveModeResponses.Load(req.Path)
+	// A channel lives for exactly one RunStream call: every query edit produces
+	// a new channel path, so without this cleanup entries would accumulate until
+	// Dispose. LoadAndDelete transfers channel ownership from the map to this
+	// RunStream call, so a re-subscribe that stores a new channel under the same
+	// path cannot prevent the old channel from being closed, and Dispose can
+	// never double-close (or close mid-write) a channel owned by a running stream.
+	ch, ok := di.liveModeResponses.LoadAndDelete(req.Path)
 	if !ok {
 		return fmt.Errorf("failed to find the channel for the query: %s", req.Path)
 	}
 	livestream := ch.(chan *data.Frame)
-	// A channel lives for exactly one RunStream call: every query edit produces a new
-	// channel path, so without this cleanup entries would accumulate until Dispose.
-	// CompareAndDelete guards against a double close when Dispose runs concurrently
-	// or when a re-subscribe has already replaced the entry with a new channel.
-	defer func() {
-		if di.liveModeResponses.CompareAndDelete(req.Path, ch) {
-			close(livestream)
-		}
-	}()
+	// closing the channel stops the frame-forwarding goroutine below;
+	// safe because streamQuery (the only writer) has already returned
+	defer close(livestream)
 	go func() {
 		prev := data.FrameJSONCache{}
 		var canceled bool
@@ -287,8 +287,9 @@ func (di *DatasourceInstance) Dispose() {
 	// Clean up datasource instance resources.
 	di.httpClient.CloseIdleConnections()
 	di.httpStreamingClient.CloseIdleConnections()
-	// close all live channels; LoadAndDelete guards against a double close
-	// when RunStream cleans up its own channel concurrently
+	// close live channels that were subscribed but never picked up by RunStream;
+	// running streams already took their channel out of the map via LoadAndDelete,
+	// so no channel can be closed twice or while it is still being written to
 	di.liveModeResponses.Range(func(key, _ interface{}) bool {
 		if ch, loaded := di.liveModeResponses.LoadAndDelete(key); loaded {
 			close(ch.(chan *data.Frame))

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -225,19 +225,34 @@ func (d *Datasource) RunStream(ctx context.Context, req *backend.RunStreamReques
 	if err != nil {
 		return err
 	}
-	// request.Path is created in the frontend. Please check this function in the frontend
-	// runLiveQueryThroughBackend where the path is created.
-	// path: `${request.requestId}/${query.refId}`
+	// request.Path is created in the frontend by LiveChannelPathProvider (used in
+	// runLiveQueryThroughBackend), path format:
+	// `${request.requestId}/${query.refId}/${generation}-${queryHash}`
 	ch, ok := di.liveModeResponses.Load(req.Path)
 	if !ok {
 		return fmt.Errorf("failed to find the channel for the query: %s", req.Path)
 	}
 	livestream := ch.(chan *data.Frame)
+	// A channel lives for exactly one RunStream call: every query edit produces a new
+	// channel path, so without this cleanup entries would accumulate until Dispose.
+	// CompareAndDelete guards against a double close when Dispose runs concurrently
+	// or when a re-subscribe has already replaced the entry with a new channel.
+	defer func() {
+		if di.liveModeResponses.CompareAndDelete(req.Path, ch) {
+			close(livestream)
+		}
+	}()
 	go func() {
 		prev := data.FrameJSONCache{}
-		var err error
+		var canceled bool
 		for frame := range livestream {
+			if canceled {
+				// keep draining so streamQuery never blocks on send;
+				// the loop ends when RunStream closes the channel on return
+				continue
+			}
 			next, _ := data.FrameToJSONCache(frame)
+			var err error
 			if next.SameSchema(&prev) {
 				err = sender.SendBytes(next.Bytes(data.IncludeAll))
 			} else {
@@ -250,14 +265,15 @@ func (d *Datasource) RunStream(ctx context.Context, req *backend.RunStreamReques
 				// so just check the error message
 				if strings.Contains(err.Error(), "rpc error: code = Canceled desc = context canceled") {
 					backend.Logger.Debug("Client has canceled the request")
-					break
+					canceled = true
+					continue
 				}
 				backend.Logger.Error("Failed send frame", "error", err)
 			}
 		}
 	}()
 
-	if err := di.streamQuery(ctx, req); err != nil {
+	if err := di.streamQuery(ctx, req, livestream); err != nil {
 		return fmt.Errorf("failed to parse stream response: %w", err)
 	}
 
@@ -271,14 +287,14 @@ func (di *DatasourceInstance) Dispose() {
 	// Clean up datasource instance resources.
 	di.httpClient.CloseIdleConnections()
 	di.httpStreamingClient.CloseIdleConnections()
-	// close all channels before clear the map
-	di.liveModeResponses.Range(func(key, value interface{}) bool {
-		ch := value.(chan *data.Frame)
-		close(ch)
+	// close all live channels; LoadAndDelete guards against a double close
+	// when RunStream cleans up its own channel concurrently
+	di.liveModeResponses.Range(func(key, _ interface{}) bool {
+		if ch, loaded := di.liveModeResponses.LoadAndDelete(key); loaded {
+			close(ch.(chan *data.Frame))
+		}
 		return true
 	})
-	// clear the map
-	di.liveModeResponses.Clear()
 }
 
 // QueryData handles multiple queries and returns multiple responses.
@@ -322,8 +338,9 @@ func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataReques
 	return response, nil
 }
 
-// streamQuery sends a query to the datasource and parse the tail results.
-func (di *DatasourceInstance) streamQuery(ctx context.Context, request *backend.RunStreamRequest) error {
+// streamQuery sends a query to the datasource and parses the tail results
+// into the livestream channel owned by the calling RunStream.
+func (di *DatasourceInstance) streamQuery(ctx context.Context, request *backend.RunStreamRequest, livestream chan *data.Frame) error {
 	q, err := getQueryFromRaw(request.Data, false)
 	if err != nil {
 		return err
@@ -345,12 +362,6 @@ func (di *DatasourceInstance) streamQuery(ctx context.Context, request *backend.
 		}
 	}()
 
-	ch, ok := di.liveModeResponses.Load(request.Path)
-	if !ok {
-		return fmt.Errorf("failed to find the channel for the query: %s", request.Path)
-	}
-
-	livestream := ch.(chan *data.Frame)
 	return parseStreamResponse(r, livestream)
 }
 

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -757,6 +757,112 @@ func TestRunStreamCleansUpLiveChannel(t *testing.T) {
 	}
 }
 
+func TestRunStreamClosesReplacedChannel(t *testing.T) {
+	// a re-subscribe to the same path replaces the map entry with a new
+	// channel while RunStream still owns the old one; RunStream must close
+	// its own channel anyway, otherwise the frame-forwarding goroutine
+	// blocks on receive forever
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/select/logsql/tail", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`{"_msg":"123","_stream":"{application=\"logs\"}","_time":"2024-02-20T14:04:27Z"}` + "\n")); err != nil {
+			t.Errorf("error write response: %s", err)
+		}
+		w.(http.Flusher).Flush()
+		close(handlerStarted)
+		// keep the tail connection open until the test has re-subscribed
+		<-releaseHandler
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx := context.Background()
+	d := NewDatasource()
+	sender := backend.NewStreamSender(&mockStreamSender{packets: []json.RawMessage{}})
+	pluginCtx := backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+			URL:      srv.URL,
+			JSONData: []byte(`{"httpMethod":"POST","customQueryParameters":""}`),
+		},
+	}
+
+	const path = "request_id/ref_id/0-abc1234"
+	if _, err := d.SubscribeStream(ctx, &backend.SubscribeStreamRequest{PluginContext: pluginCtx, Path: path}); err != nil {
+		t.Fatalf("unexpected subscribe error: %s", err)
+	}
+
+	di, err := d.getInstance(ctx, pluginCtx)
+	if err != nil {
+		t.Fatalf("unexpected instance error: %s", err)
+	}
+	chVal, ok := di.liveModeResponses.Load(path)
+	if !ok {
+		t.Fatalf("expected the channel to be registered after subscribe")
+	}
+	oldStream := chVal.(chan *data.Frame)
+
+	runStreamDone := make(chan error, 1)
+	go func() {
+		runStreamDone <- d.RunStream(ctx, &backend.RunStreamRequest{
+			PluginContext: pluginCtx,
+			Path:          path,
+			Data:          json.RawMessage(`{"expr":"*","refId":"A"}`),
+		}, sender)
+	}()
+
+	// wait until RunStream has loaded the channel and started tailing
+	select {
+	case <-handlerStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("expected the tail handler to be called")
+	}
+
+	// simulate a client reconnect: the same path gets a new channel
+	if _, err := d.SubscribeStream(ctx, &backend.SubscribeStreamRequest{PluginContext: pluginCtx, Path: path}); err != nil {
+		t.Fatalf("unexpected re-subscribe error: %s", err)
+	}
+	newVal, ok := di.liveModeResponses.Load(path)
+	if !ok {
+		t.Fatalf("expected the channel to be registered after re-subscribe")
+	}
+	newStream := newVal.(chan *data.Frame)
+	if newStream == oldStream {
+		t.Fatalf("expected re-subscribe to register a new channel")
+	}
+
+	// let the tail response end so RunStream returns
+	close(releaseHandler)
+	select {
+	case err := <-runStreamDone:
+		if err != nil {
+			t.Fatalf("unexpected stream error: %s", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("expected RunStream to return")
+	}
+
+	// the old channel is owned by the finished RunStream and must be closed
+	// even though the map entry now points to the new channel
+	deadline := time.After(5 * time.Second)
+	for closed := false; !closed; {
+		select {
+		case _, open := <-oldStream:
+			closed = !open
+		case <-deadline:
+			t.Fatalf("expected the replaced channel to be closed after RunStream returns")
+		}
+	}
+
+	// the new channel belongs to the next RunStream and must stay registered
+	if val, ok := di.liveModeResponses.Load(path); !ok {
+		t.Fatalf("expected the re-subscribed channel entry to survive the old RunStream cleanup")
+	} else if val.(chan *data.Frame) != newStream {
+		t.Fatalf("expected the map entry to still point to the re-subscribed channel")
+	}
+}
+
 func TestDatasourceStreamRequestWithRetry(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(_ http.ResponseWriter, _ *http.Request) {

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -693,6 +693,70 @@ func TestDatasourceStreamQueryRequest(t *testing.T) {
 
 }
 
+func TestRunStreamCleansUpLiveChannel(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/select/logsql/tail", func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(`{"_msg":"123","_stream":"{application=\"logs\"}","_time":"2024-02-20T14:04:27Z"}`))
+		if err != nil {
+			t.Fatalf("error write response: %s", err)
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx := context.Background()
+	d := NewDatasource()
+	sender := backend.NewStreamSender(&mockStreamSender{packets: []json.RawMessage{}})
+	pluginCtx := backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+			URL:      srv.URL,
+			JSONData: []byte(`{"httpMethod":"POST","customQueryParameters":""}`),
+		},
+	}
+
+	const path = "request_id/ref_id/0-abc1234"
+	if _, err := d.SubscribeStream(ctx, &backend.SubscribeStreamRequest{PluginContext: pluginCtx, Path: path}); err != nil {
+		t.Fatalf("unexpected subscribe error: %s", err)
+	}
+
+	di, err := d.getInstance(ctx, pluginCtx)
+	if err != nil {
+		t.Fatalf("unexpected instance error: %s", err)
+	}
+	chVal, ok := di.liveModeResponses.Load(path)
+	if !ok {
+		t.Fatalf("expected the channel to be registered after subscribe")
+	}
+
+	if err := d.RunStream(ctx, &backend.RunStreamRequest{
+		PluginContext: pluginCtx,
+		Path:          path,
+		Data:          json.RawMessage(`{"expr":"*","refId":"A"}`),
+	}, sender); err != nil {
+		t.Fatalf("unexpected stream error: %s", err)
+	}
+
+	if _, ok := di.liveModeResponses.Load(path); ok {
+		t.Fatalf("expected the channel entry to be removed after RunStream returns")
+	}
+
+	// the sender goroutine may still be draining buffered frames,
+	// so wait for the close instead of asserting an immediate one
+	livestream := chVal.(chan *data.Frame)
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case _, open := <-livestream:
+			if !open {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("expected the channel to be closed after RunStream returns")
+		}
+	}
+}
+
 func TestDatasourceStreamRequestWithRetry(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(_ http.ResponseWriter, _ *http.Request) {
@@ -741,6 +805,10 @@ func TestDatasourceStreamRequestWithRetry(t *testing.T) {
 		},
 	}
 	expErr := func(e string) {
+		_, _ = d.SubscribeStream(ctx, &backend.SubscribeStreamRequest{
+			PluginContext: pluginCtx,
+			Path:          "request_id/ref_id",
+		})
 		err := d.RunStream(ctx, &backend.RunStreamRequest{
 			PluginContext: pluginCtx,
 			Path:          "request_id/ref_id",

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -43,6 +43,7 @@ import {
 import { LOGS_LIMIT_DEFAULT, LOGS_LIMIT_HARD_CAP, TEXT_FILTER_ALL_VALUE, VARIABLE_ALL_VALUE } from './constants';
 import { escapeLabelValueInSelector } from './languageUtils';
 import LogsQlLanguageProvider from './language_provider';
+import { LiveChannelPathProvider } from './live/LiveChannelPathProvider';
 import { LogContextProvider } from './logContext/LogContextProvider';
 import { LOGS_VOLUME_BARS, queryLogsVolume } from './logsVolumeLegacy';
 import {
@@ -70,7 +71,6 @@ import {
   ToggleFilterAction,
   VariableQuery,
 } from './types';
-import { hashString } from './utils';
 import {
   resolveAdHocFilters,
   serializeChipsForBackend,
@@ -100,6 +100,7 @@ export class VictoriaLogsDatasource
   logLevelRules: LogLevelRule[];
   multitenancyHeaders?: MultitenancyHeaders;
   logContextProvider: LogContextProvider;
+  private readonly liveChannelPathProvider = new LiveChannelPathProvider();
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<Options>,
@@ -434,12 +435,8 @@ export class VictoriaLogsDatasource
             // so we need to send both for compatibility with older versions
             namespace: this.uid,
             stream: this.uid,
-            // The channel path must encode the query content. Grafana Live de-duplicates
-            // subscriptions by channel address and the backend snapshots the query from the
-            // subscribe payload only once (RunStream). Without the query hash the path stays
-            // constant across query edits, so changing `expr` reuses the existing
-            // channel and keeps streaming the previous query until a full page reload.
-            path: `${request.requestId}/${query.refId}/${hashString(JSON.stringify(query))}`,
+            // The path must change when the query content changes and stay stable
+            path: this.liveChannelPathProvider.getPath(request.requestId, query),
             data: {
               ...query,
             },

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -70,6 +70,7 @@ import {
   ToggleFilterAction,
   VariableQuery,
 } from './types';
+import { hashString } from './utils';
 import {
   resolveAdHocFilters,
   serializeChipsForBackend,
@@ -433,7 +434,12 @@ export class VictoriaLogsDatasource
             // so we need to send both for compatibility with older versions
             namespace: this.uid,
             stream: this.uid,
-            path: `${request.requestId}/${query.refId}`,
+            // The channel path must encode the query content. Grafana Live de-duplicates
+            // subscriptions by channel address and the backend snapshots the query from the
+            // subscribe payload only once (RunStream). Without the query hash the path stays
+            // constant across query edits, so changing `expr` reuses the existing
+            // channel and keeps streaming the previous query until a full page reload.
+            path: `${request.requestId}/${query.refId}/${hashString(JSON.stringify(query))}`,
             data: {
               ...query,
             },

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 import { ReactNode } from 'react';
-import { map, merge, Observable } from 'rxjs';
+import { finalize, map, merge, Observable } from 'rxjs';
 
 import {
   AdHocVariableFilter,
@@ -426,6 +426,8 @@ export class VictoriaLogsDatasource
 
   private runLiveQueryThroughBackend(request: DataQueryRequest<Query>): Observable<DataQueryResponse> {
     const observables = request.targets.map((query) => {
+      // The path must change when the query content changes and stay stable
+      const path = this.liveChannelPathProvider.getPath(request.requestId, query);
       return getGrafanaLiveSrv()
         .getDataStream({
           addr: {
@@ -435,8 +437,7 @@ export class VictoriaLogsDatasource
             // so we need to send both for compatibility with older versions
             namespace: this.uid,
             stream: this.uid,
-            // The path must change when the query content changes and stay stable
-            path: this.liveChannelPathProvider.getPath(request.requestId, query),
+            path,
             data: {
               ...query,
             },
@@ -449,7 +450,10 @@ export class VictoriaLogsDatasource
               key: `victoriametrics-logs-datasource-${request.requestId}-${query.refId}`,
               state: LoadingState.Streaming,
             };
-          })
+          }),
+          // Evict the per-channel state once the stream is torn down, so
+          // request-scoped keys do not accumulate over long Explore sessions
+          finalize(() => this.liveChannelPathProvider.release(request.requestId, query.refId, path))
         );
     });
 

--- a/src/live/LiveChannelPathProvider.test.ts
+++ b/src/live/LiveChannelPathProvider.test.ts
@@ -62,4 +62,32 @@ describe('LiveChannelPathProvider', () => {
     provider.getPath('req_1', buildQuery({ refId: 'A', expr: 'error' }));
     expect(provider.getPath('req_1', buildQuery({ refId: 'B' }))).toBe(pathB);
   });
+
+  describe('release', () => {
+    it('evicts the channel state when the released path is current', () => {
+      provider.getPath('req_1', buildQuery({ expr: 'error' }));
+      const current = provider.getPath('req_1', buildQuery({ expr: 'info' }));
+
+      provider.release('req_1', 'A', current);
+
+      // the state was dropped, so the generation counter restarts from zero
+      const fresh = provider.getPath('req_1', buildQuery({ expr: 'info' }));
+      expect(fresh).not.toBe(current);
+      expect(fresh).toContain('/0-');
+    });
+
+    it('keeps the state when a newer generation replaced the released path', () => {
+      const stale = provider.getPath('req_1', buildQuery({ expr: 'error' }));
+      const current = provider.getPath('req_1', buildQuery({ expr: 'info' }));
+
+      // a late teardown of the previous stream must not evict the active state
+      provider.release('req_1', 'A', stale);
+
+      expect(provider.getPath('req_1', buildQuery({ expr: 'info' }))).toBe(current);
+    });
+
+    it('ignores a release for an unknown channel', () => {
+      expect(() => provider.release('req_1', 'A', 'req_1/A/0-abc')).not.toThrow();
+    });
+  });
 });

--- a/src/live/LiveChannelPathProvider.test.ts
+++ b/src/live/LiveChannelPathProvider.test.ts
@@ -1,0 +1,65 @@
+import { Query } from '../types';
+import { hashString } from '../utils';
+
+import { LiveChannelPathProvider } from './LiveChannelPathProvider';
+
+function buildQuery(overrides: Partial<Query> = {}): Query {
+  return { refId: 'A', expr: '*', ...overrides } as Query;
+}
+
+describe('LiveChannelPathProvider', () => {
+  let provider: LiveChannelPathProvider;
+
+  beforeEach(() => {
+    provider = new LiveChannelPathProvider();
+  });
+
+  it('returns a stable path for the same query', () => {
+    const query = buildQuery();
+    expect(provider.getPath('req_1', query)).toBe(provider.getPath('req_1', query));
+  });
+
+  it('keeps the path stable when only editor-only fields change', () => {
+    const first = provider.getPath('req_1', buildQuery({ editorMode: 'code' } as Partial<Query>));
+    const second = provider.getPath('req_1', buildQuery({ editorMode: 'builder', legendFormat: '{{app}}' } as Partial<Query>));
+    expect(second).toBe(first);
+  });
+
+  it('changes the path when the expression changes', () => {
+    const first = provider.getPath('req_1', buildQuery({ expr: 'info' }));
+    const second = provider.getPath('req_1', buildQuery({ expr: 'error' }));
+    expect(second).not.toBe(first);
+  });
+
+  it('changes the path when extra filters change', () => {
+    const first = provider.getPath('req_1', buildQuery());
+    const second = provider.getPath('req_1', buildQuery({ extraFilters: 'level:="error"' }));
+    expect(second).not.toBe(first);
+  });
+
+  it('changes the path even when the new query collides in the 32-bit hash', () => {
+    // "Aa" and "BB" collide in the Java String.hashCode polynomial (31*'A'+'a' === 31*'B'+'B'),
+    // and the collision survives identical JSON prefixes/suffixes around the expression
+    const first = buildQuery({ expr: 'Aa' });
+    const second = buildQuery({ expr: 'BB' });
+    const firstPath = provider.getPath('req_1', first);
+    const secondPath = provider.getPath('req_1', second);
+
+    // guard: the inputs must actually collide, otherwise this test checks nothing
+    expect(hashString(JSON.stringify({ expr: 'Aa', extraFilters: undefined, extraStreamFilters: undefined })))
+      .toBe(hashString(JSON.stringify({ expr: 'BB', extraFilters: undefined, extraStreamFilters: undefined })));
+    expect(secondPath).not.toBe(firstPath);
+  });
+
+  it('tracks generations independently per requestId and refId', () => {
+    const pathA = provider.getPath('req_1', buildQuery({ refId: 'A' }));
+    const pathB = provider.getPath('req_1', buildQuery({ refId: 'B' }));
+    const pathOtherRequest = provider.getPath('req_2', buildQuery({ refId: 'A' }));
+
+    expect(pathA).not.toBe(pathB);
+    expect(pathA).not.toBe(pathOtherRequest);
+    // an edit under one key must not restart streams under the others
+    provider.getPath('req_1', buildQuery({ refId: 'A', expr: 'error' }));
+    expect(provider.getPath('req_1', buildQuery({ refId: 'B' }))).toBe(pathB);
+  });
+});

--- a/src/live/LiveChannelPathProvider.ts
+++ b/src/live/LiveChannelPathProvider.ts
@@ -4,6 +4,7 @@ import { hashString } from '../utils';
 interface ChannelState {
   payload: string;
   generation: number;
+  path: string;
 }
 
 /**
@@ -37,13 +38,30 @@ export class LiveChannelPathProvider {
   private channels = new Map<string, ChannelState>();
 
   getPath(requestId: string, query: Query): string {
-    const key = `${requestId}/${query.refId}`;
+    const key = this.buildKey(requestId, query.refId);
     const payload = serializeLiveQuery(query);
     let state = this.channels.get(key);
     if (!state || state.payload !== payload) {
-      state = { payload, generation: state ? state.generation + 1 : 0 };
+      const generation = state ? state.generation + 1 : 0;
+      state = { payload, generation, path: `${key}/${generation}-${hashString(payload)}` };
       this.channels.set(key, state);
     }
-    return `${key}/${state.generation}-${hashString(payload)}`;
+    return state.path;
+  }
+
+  /**
+   * Drops the stored channel state once the live stream for `path` ends.
+   * A stale `path` (already replaced by a newer generation) is ignored, so a
+   * late teardown of the previous stream cannot evict the active state.
+   */
+  release(requestId: string, refId: string, path: string): void {
+    const key = this.buildKey(requestId, refId);
+    if (this.channels.get(key)?.path === path) {
+      this.channels.delete(key);
+    }
+  }
+
+  private buildKey(requestId: string, refId: string): string {
+    return `${requestId}/${refId}`;
   }
 }

--- a/src/live/LiveChannelPathProvider.ts
+++ b/src/live/LiveChannelPathProvider.ts
@@ -1,0 +1,49 @@
+import { Query } from '../types';
+import { hashString } from '../utils';
+
+interface ChannelState {
+  payload: string;
+  generation: number;
+}
+
+/**
+ * Serializes the query fields that affect the backend live tail request
+ */
+function serializeLiveQuery(query: Query): string {
+  return JSON.stringify({
+    expr: query.expr,
+    extraFilters: query.extraFilters,
+    extraStreamFilters: query.extraStreamFilters,
+  });
+}
+
+/**
+ * Builds Grafana Live channel paths for live tailing.
+ *
+ * Grafana Live de-duplicates subscriptions by channel address, and the backend
+ * snapshots the query from the subscribe payload only once per channel
+ * (RunStream). The path must therefore change whenever the query content
+ * changes — otherwise editing `expr` would keep streaming the previous query —
+ * and must NOT change otherwise, or an active stream would restart and lose
+ * its accumulated log buffer.
+ *
+ * The path suffix combines a generation counter with a content hash:
+ * - the generation is bumped on every payload change (exact string comparison),
+ *   which guarantees a new path even if two payloads collide in the 32-bit hash;
+ * - the hash keeps paths content-addressed across page reloads, where the
+ *   in-memory generation counter starts over from zero.
+ */
+export class LiveChannelPathProvider {
+  private channels = new Map<string, ChannelState>();
+
+  getPath(requestId: string, query: Query): string {
+    const key = `${requestId}/${query.refId}`;
+    const payload = serializeLiveQuery(query);
+    let state = this.channels.get(key);
+    if (!state || state.payload !== payload) {
+      state = { payload, generation: state ? state.generation + 1 : 0 };
+      this.channels.set(key, state);
+    }
+    return `${key}/${state.generation}-${hashString(payload)}`;
+  }
+}

--- a/src/utils/string/hashString/hashString.test.ts
+++ b/src/utils/string/hashString/hashString.test.ts
@@ -13,24 +13,13 @@ describe('hashString', () => {
     expect(hashString('{"expr":"info"}')).not.toBe(hashString('{"expr":"error"}'));
   });
 
-  it('handles the empty string', () => {
-    expect(typeof hashString('')).toBe('string');
+  it('returns a base36 string', () => {
+    expect(hashString('some-query-payload')).toMatch(/^[0-9a-z]+$/);
   });
 
-  it('returns a fixed-length 7-character base36 string', () => {
-    expect(hashString('some-query-payload')).toMatch(/^[0-9a-z]{7}$/);
-  });
-
-  it('pads short hashes to a fixed length', () => {
-    // empty string hashes to 0 -> "0", which must be left-padded to 7 chars
-    expect(hashString('')).toBe('0000000');
-  });
-
-  it('keeps the fixed length for a single-character string', () => {
-    expect(hashString('a')).toBe('000002p');
-  });
-
-  it('keeps the fixed length for a long (50-character) string', () => {
-    expect(hashString('abc'.repeat(50))).toBe('0ih3w74');
+  it('hashes known values', () => {
+    expect(hashString('')).toBe('0');
+    expect(hashString('a')).toBe('2p');
+    expect(hashString('abc'.repeat(50))).toBe('ih3w74');
   });
 });

--- a/src/utils/string/hashString/hashString.test.ts
+++ b/src/utils/string/hashString/hashString.test.ts
@@ -1,0 +1,36 @@
+import { hashString } from './hashString';
+
+describe('hashString', () => {
+  it('is deterministic for the same input', () => {
+    expect(hashString('some-query-payload')).toBe(hashString('some-query-payload'));
+  });
+
+  it('produces different hashes for different input', () => {
+    expect(hashString('foo')).not.toBe(hashString('bar'));
+  });
+
+  it('reacts to small changes in the input', () => {
+    expect(hashString('{"expr":"info"}')).not.toBe(hashString('{"expr":"error"}'));
+  });
+
+  it('handles the empty string', () => {
+    expect(typeof hashString('')).toBe('string');
+  });
+
+  it('returns a fixed-length 7-character base36 string', () => {
+    expect(hashString('some-query-payload')).toMatch(/^[0-9a-z]{7}$/);
+  });
+
+  it('pads short hashes to a fixed length', () => {
+    // empty string hashes to 0 -> "0", which must be left-padded to 7 chars
+    expect(hashString('')).toBe('0000000');
+  });
+
+  it('keeps the fixed length for a single-character string', () => {
+    expect(hashString('a')).toBe('000002p');
+  });
+
+  it('keeps the fixed length for a long (50-character) string', () => {
+    expect(hashString('abc'.repeat(50))).toBe('0ih3w74');
+  });
+});

--- a/src/utils/string/hashString/hashString.ts
+++ b/src/utils/string/hashString/hashString.ts
@@ -1,14 +1,16 @@
 /**
- * Returns a deterministic, fixed-length 7-character base36 hash of a string.
+ * Returns a deterministic base36 hash of a string.
  *
- * Fast non-cryptographic hash (djb2-style via Math.imul), suitable for cache keys,
- * channel paths and identity checks. It is not collision-proof and not for security use.
+ * Fast non-cryptographic hash (the Java String.hashCode polynomial), suitable for
+ * cache keys, channel paths and identity checks. It is not collision-proof and not
+ * for security use.
  */
 export function hashString(str: string): string {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
-    hash = (Math.imul(31, hash) + str.charCodeAt(i)) | 0;
+    // `| 0` keeps the accumulator within 32 bits; without it the value would
+    // grow past 2^53 and lose precision
+    hash = (hash * 31 + str.charCodeAt(i)) | 0;
   }
-  // base36 of a 32-bit value is at most 7 chars; left-pad to keep the length fixed
-  return (hash >>> 0).toString(36).padStart(7, '0');
+  return (hash >>> 0).toString(36);
 }

--- a/src/utils/string/hashString/hashString.ts
+++ b/src/utils/string/hashString/hashString.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns a deterministic, fixed-length 7-character base36 hash of a string.
+ *
+ * Fast non-cryptographic hash (djb2-style via Math.imul), suitable for cache keys,
+ * channel paths and identity checks. It is not collision-proof and not for security use.
+ */
+export function hashString(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (Math.imul(31, hash) + str.charCodeAt(i)) | 0;
+  }
+  // base36 of a 32-bit value is at most 7 chars; left-pad to keep the length fixed
+  return (hash >>> 0).toString(36).padStart(7, '0');
+}

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -1,1 +1,2 @@
+export { hashString } from './hashString/hashString';
 export { skipBalanced } from './skipBalanced/skipBalanced';


### PR DESCRIPTION
### Describe Your Changes

Fixed live tailing. Previously, changing the query didn't affect the live tailing, cause we have the same channel path:
- Include a hash of the query in the Grafana Live channel path, so editing `expr` creates a new channel instead of reusing the old subscription that kept streaming the previous query until reload
- Add `hashString` utility (deterministic 7-char base36 hash) with tests

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
