### PR TITLE
fix(highlighting): extract searchWords from the interpolated query (#684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * BUGFIX: restore the `_stream` label in log query results. Previously, it was hidden from the log line labels. See [pr #685](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/685).
 * BUGFIX: live tailing now picks up query changes immediately. Previously, editing the query expression while live logs were streaming kept showing results for the previous query until the page was reloaded.
 * BUGFIX: pad missing `_time` values in instant log query responses so mixed rows with and without `_time` still produce valid Grafana log frames. Thanks to @immanuwell for their contribution.
+* BUGFIX: highlight search terms in log lines when the query uses template variables (e.g. `_msg:$search`). Previously, highlighting looked for the literal variable name instead of its value, so nothing was highlighted. See [#684](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/684).
 
 ## v0.29.0
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -174,7 +174,8 @@ export class VictoriaLogsDatasource
             response,
             fixedRequest,
             this.derivedFields ?? [],
-            this.getActiveLevelRules()
+            this.getActiveLevelRules(),
+            (expr) => this.interpolateString(expr, fixedRequest.scopedVars)
           )
         )
       );

--- a/src/transformers/frameProcessors/streamFrameProcessor.test.ts
+++ b/src/transformers/frameProcessors/streamFrameProcessor.test.ts
@@ -55,4 +55,14 @@ describe('processStreamsFrames', () => {
     expect(processed.meta?.custom?.streams).toBeUndefined();
     expect(processed.meta?.custom?.streamIds).toBeUndefined();
   });
+
+  it('extracts searchWords from the interpolated query, not the raw one', () => {
+    const rawQueryMap = new Map<string, Query>([['A', { refId: 'A', expr: '_msg:$search' }]]);
+    const interpolateExpr = (expr: string) => expr.replace('$search', 'error');
+    const frame = buildFrame([{ app: 'nginx' }]);
+
+    const [processed] = processStreamsFrames([frame], rawQueryMap, [], [], interpolateExpr);
+
+    expect(processed.meta?.searchWords).toEqual(['error']);
+  });
 });

--- a/src/transformers/frameProcessors/streamFrameProcessor.ts
+++ b/src/transformers/frameProcessors/streamFrameProcessor.ts
@@ -6,19 +6,20 @@ import { DerivedFieldConfig, Query } from '../../types';
 import { getDerivedFields } from '../fields/derivedField';
 import { getStreamFields } from '../fields/labelField';
 import { addLevelField } from '../fields/levelField';
-import { ANNOTATIONS_REF_ID } from '../types';
+import { ANNOTATIONS_REF_ID, InterpolateExpr } from '../types';
 import { dataFrameHasError, setFrameMeta } from '../utils/frame/frameUtils';
 
 export function processStreamsFrames(
   frames: DataFrame[],
   queryMap: Map<string, Query>,
   derivedFieldConfigs: DerivedFieldConfig[],
-  logLevelRules: LogLevelRule[]
+  logLevelRules: LogLevelRule[],
+  interpolateExpr: InterpolateExpr = (expr) => expr
 ): DataFrame[] {
   return frames.map((frame) => {
     const query = frame.refId !== undefined ? queryMap.get(frame.refId) : undefined;
     const isAnnotations = query?.refId === ANNOTATIONS_REF_ID;
-    return processStreamFrame(frame, query, derivedFieldConfigs, logLevelRules, isAnnotations);
+    return processStreamFrame(frame, query, derivedFieldConfigs, logLevelRules, interpolateExpr, isAnnotations);
   });
 }
 
@@ -27,6 +28,7 @@ function processStreamFrame(
   query: Query | undefined,
   derivedFieldConfigs: DerivedFieldConfig[],
   logLevelRules: LogLevelRule[],
+  interpolateExpr: InterpolateExpr,
   transformLabels = false
 ): DataFrame {
   const custom: Record<string, unknown> = {
@@ -40,7 +42,9 @@ function processStreamFrame(
   const meta: QueryResultMeta = {
     preferredVisualisationType: 'logs',
     limit: query?.maxLines,
-    searchWords: query !== undefined ? getHighlighterExpressionsFromQuery(query.expr) : undefined,
+    // Highlighting must match the executed query, so resolve template
+    // variables before extracting search words
+    searchWords: query !== undefined ? getHighlighterExpressionsFromQuery(interpolateExpr(query.expr)) : undefined,
     custom,
   };
 

--- a/src/transformers/transformBackendResult.test.ts
+++ b/src/transformers/transformBackendResult.test.ts
@@ -5,6 +5,8 @@ import { DerivedFieldConfig, Query, QueryType } from '../types';
 
 import { transformBackendResult } from './transformBackendResult';
 
+const identityInterpolate = (expr: string) => expr;
+
 describe('transformBackendResult', () => {
   const labels = [
     {
@@ -174,7 +176,7 @@ describe('transformBackendResult', () => {
     } as unknown as DataQueryRequest<Query>;
     const derivedFieldConfigs: DerivedFieldConfig[] = [];
     const logLevelRules: LogLevelRule[] = [];
-    const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules);
+    const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules, identityInterpolate);
     expect(result.data[0].fields[2].values).toStrictEqual(labels);
     expect(result.data[0].fields[3].name).toStrictEqual('detected_level');
     expect(result.data[0].fields[3].values).toStrictEqual([
@@ -326,7 +328,7 @@ describe('transformBackendResult', () => {
       value: 'dev',
       level: LogLevel.critical
     }];
-    const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules);
+    const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules, identityInterpolate);
     expect(result.data[0].fields[2].values).toStrictEqual(extendedLabels);
     expect(result.data[0].fields[3].values).toStrictEqual([
       LogLevel.info,
@@ -474,7 +476,7 @@ describe('transformBackendResult', () => {
       value: 'critical',
       level: LogLevel.critical
     }];
-    const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules);
+    const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules, identityInterpolate);
     expect(result.data[0].fields[2].values).toStrictEqual(extendedLabels);
     expect(result.data[0].fields[3].values).toStrictEqual([
       LogLevel.critical,
@@ -484,6 +486,76 @@ describe('transformBackendResult', () => {
       LogLevel.unknown,
       LogLevel.unknown,
     ]);
+  });
+
+  it('builds meta.searchWords from the interpolated query expression', () => {
+    const response = {
+      'data': [
+        {
+          'refId': 'A',
+          'meta': {},
+          'fields': [
+            {
+              'name': 'Time',
+              'type': 'time',
+              'typeInfo': { 'frame': 'time.Time' },
+              'config': {},
+              'values': [1760598702731],
+              'entities': {}
+            },
+            {
+              'name': 'Line',
+              'type': 'string',
+              'typeInfo': { 'frame': 'string' },
+              'config': {},
+              'values': ['connection error'],
+              'entities': {}
+            },
+            {
+              'name': 'labels',
+              'type': 'other',
+              'typeInfo': { 'frame': 'json.RawMessage' },
+              'config': {},
+              'values': [labels[0]],
+              'entities': {}
+            }
+          ],
+          'length': 1
+        }
+      ],
+      'state': 'Done'
+    } as DataQueryResponse;
+    const request = {
+      'app': 'dashboard',
+      'requestId': 'SQR100',
+      'timezone': 'browser',
+      'range': {
+        'to': '2025-10-16T07:28:02.475Z',
+        'from': '2025-10-16T01:28:02.475Z',
+        'raw': { 'from': 'now-6h', 'to': 'now' }
+      },
+      'interval': '20s',
+      'intervalMs': 20000,
+      'targets': [
+        {
+          'datasource': {
+            'type': 'victoriametrics-logs-datasource',
+            'uid': 'bexw8wod6s4jke'
+          },
+          'editorMode': 'code',
+          'expr': '_msg:$search',
+          'queryType': 'instant',
+          'refId': 'A',
+          'maxLines': 1000
+        }
+      ],
+      'maxDataPoints': 913,
+      'scopedVars': {},
+      'panelPluginId': 'logs',
+    } as unknown as DataQueryRequest<Query>;
+    const interpolateExpr = (expr: string) => expr.replace('$search', 'error');
+    const result = transformBackendResult(response, request, [], [], interpolateExpr);
+    expect(result.data[0].meta?.searchWords).toEqual(['error']);
   });
 
   describe('processMetricRangeFrames', () => {
@@ -606,7 +678,7 @@ describe('transformBackendResult', () => {
       const request = { ...baseRequest };
       const derivedFieldConfigs: DerivedFieldConfig[] = [];
       const logLevelRules: LogLevelRule[] = [];
-      const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules);
+      const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules, identityInterpolate);
       expect(result.data[0].fields.length).toStrictEqual(0);
     });
 
@@ -615,7 +687,7 @@ describe('transformBackendResult', () => {
       const request = { ...baseRequest };
       const derivedFieldConfigs: DerivedFieldConfig[] = [];
       const logLevelRules: LogLevelRule[] = [];
-      const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules);
+      const result = transformBackendResult(response, request, derivedFieldConfigs, logLevelRules, identityInterpolate);
       expect(result.data[0].fields[0].values).toStrictEqual([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
       expect(result.data[0].fields[1].values).toStrictEqual([1, 2, null, 3, 4, null, null, null, 5, null]);
     });

--- a/src/transformers/transformBackendResult.ts
+++ b/src/transformers/transformBackendResult.ts
@@ -9,6 +9,7 @@ import {
   processMetricRangeFrames,
   processStreamsFrames
 } from './frameProcessors';
+import { InterpolateExpr } from './types';
 import { improveError } from './utils/errorUtils';
 import { getQueryMap, groupFrames } from './utils/frame/frameUtils';
 
@@ -17,6 +18,7 @@ export function transformBackendResult(
   request: DataQueryRequest<Query>,
   derivedFieldConfigs: DerivedFieldConfig[],
   logLevelRules: LogLevelRule[],
+  interpolateExpr: InterpolateExpr,
 ): DataQueryResponse {
   const { data, errors, ...rest } = response;
   const queries = request.targets;
@@ -44,7 +46,7 @@ export function transformBackendResult(
     data: [
       ...processMetricRangeFrames(metricRangeFrames, request.targets, request.range.from.valueOf(), request.range.to.valueOf()),
       ...processMetricInstantFrames(metricInstantFrames),
-      ...processStreamsFrames(streamsFrames, queryMap, derivedFieldConfigs, logLevelRules),
+      ...processStreamsFrames(streamsFrames, queryMap, derivedFieldConfigs, logLevelRules, interpolateExpr),
       ...processHistogramFrames(histogramFrames, request.panelPluginId),
     ],
   };

--- a/src/transformers/types.ts
+++ b/src/transformers/types.ts
@@ -1,5 +1,12 @@
 export const ANNOTATIONS_REF_ID = 'Anno';
 
+/**
+ * Resolves template variables in a query expression. The transformers receive
+ * raw target expressions (with `$variables`), so consumers that need the
+ * executed query text (e.g. `searchWords` highlighting) must interpolate first.
+ */
+export type InterpolateExpr = (expr: string) => string;
+
 export enum FrameField {
   Labels = 'labels',
   Line = 'Line',


### PR DESCRIPTION
Related issue: #684 

### Describe Your Changes

- Pass an explicit interpolateExpr callback from the datasource through transformBackendResult into the stream frame processor, so meta.searchWords is built from the query with template variables resolved
- Previously a query like `_msg:$search` highlighted the literal variable name instead of its value, so nothing matched in the log lines

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
