### PR TITLE
fix(log context): stop duplicating lines and cap rows in "Show context" (#692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * BUGFIX: live tailing now picks up query changes immediately. Previously, editing the query expression while live logs were streaming kept showing results for the previous query until the page was reloaded.
 * BUGFIX: pad missing `_time` values in instant log query responses so mixed rows with and without `_time` still produce valid Grafana log frames. Thanks to @immanuwell for their contribution.
 * BUGFIX: highlight search terms in log lines when the query uses template variables (e.g. `_msg:$search`). Previously, highlighting looked for the literal variable name instead of its value, so nothing was highlighted. See [#684](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/684).
+* BUGFIX: stop showing log lines twice in the "Show context" modal. Previously, the two context queries overlapped by one second around the selected row, so every line within that window was displayed twice; the queries now split at the selected row's timestamp with nanosecond precision. See [#692](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/692).
 
 ## v0.29.0
 

--- a/src/logContext/LogContextProvider.test.ts
+++ b/src/logContext/LogContextProvider.test.ts
@@ -35,25 +35,26 @@ describe('LogContextProvider', () => {
       },
       labels: {},
       timeEpochMs: 1700000000000,
+      timeEpochNs: '1700000000000123456',
       ...overrides,
     }) as unknown as LogRowModel;
 
   it('builds context query by _stream_id when all stream labels are enabled', async () => {
     const query = await provider.getLogRowContextQuery(buildLogRow());
-    expect(query?.expr).toBe('_stream_id:"stream-id-1" | sort by (_time) desc');
+    expect(query?.expr).toBe('_stream_id:"stream-id-1" _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50');
   });
 
   it('uses ascending sort for the forward direction', async () => {
     const query = await provider.getLogRowContextQuery(buildLogRow(), {
       direction: LogRowContextQueryDirection.Forward,
     });
-    expect(query?.expr).toBe('_stream_id:"stream-id-1" | sort by (_time) asc');
+    expect(query?.expr).toBe('_stream_id:"stream-id-1" _time:>2023-11-14T22:13:20.000123456Z | sort by (_time) asc limit 50');
   });
 
   it('builds a _stream selector from enabled labels when some are toggled off', async () => {
     provider.toggleStreamLabel('stream-id-1', 'host');
     const query = await provider.getLogRowContextQuery(buildLogRow());
-    expect(query?.expr).toBe('_stream:{app="nginx"} | sort by (_time) desc');
+    expect(query?.expr).toBe('_stream:{app="nginx"} _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50');
   });
 
   it('escapes quotes and backslashes in stream label values', async () => {
@@ -67,7 +68,7 @@ describe('LogContextProvider', () => {
     });
     provider.toggleStreamLabel('stream-id-1', 'host');
     const query = await provider.getLogRowContextQuery(row);
-    expect(query?.expr).toBe('_stream:{app="a\\"b"} | sort by (_time) desc');
+    expect(query?.expr).toBe('_stream:{app="a\\"b"} _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50');
   });
 
   it('quotes stream label keys that are not simple identifiers', async () => {
@@ -83,21 +84,21 @@ describe('LogContextProvider', () => {
     });
     provider.toggleStreamLabel('stream-id-1', 'host');
     const query = await provider.getLogRowContextQuery(row);
-    expect(query?.expr).toBe('_stream:{"Dino Species"="Stegosaurus"} | sort by (_time) desc');
+    expect(query?.expr).toBe('_stream:{"Dino Species"="Stegosaurus"} _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50');
   });
 
   it('falls back to _stream_id when the label is toggled back on', async () => {
     provider.toggleStreamLabel('stream-id-1', 'host');
     provider.toggleStreamLabel('stream-id-1', 'host');
     const query = await provider.getLogRowContextQuery(buildLogRow());
-    expect(query?.expr).toBe('_stream_id:"stream-id-1" | sort by (_time) desc');
+    expect(query?.expr).toBe('_stream_id:"stream-id-1" _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50');
   });
 
   it('falls back to _stream_id when every label is toggled off', async () => {
     provider.toggleStreamLabel('stream-id-1', 'app');
     provider.toggleStreamLabel('stream-id-1', 'host');
     const query = await provider.getLogRowContextQuery(buildLogRow());
-    expect(query?.expr).toBe('_stream_id:"stream-id-1" | sort by (_time) desc');
+    expect(query?.expr).toBe('_stream_id:"stream-id-1" _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50');
   });
 
   it('treats a null _stream (field absent) as no stream labels', () => {
@@ -124,7 +125,7 @@ describe('LogContextProvider', () => {
       },
     });
     const query = await provider.getLogRowContextQuery(row);
-    expect(query?.expr).toBe('_stream:{app="nginx",host="h-1"} | sort by (_time) desc');
+    expect(query?.expr).toBe('_stream:{app="nginx",host="h-1"} _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50');
   });
 
   it('narrows the _stream selector by enabled labels when _stream_id is missing', async () => {
@@ -139,7 +140,7 @@ describe('LogContextProvider', () => {
     // with no _stream_id the toggle state is keyed by an empty stream id
     provider.toggleStreamLabel('', 'host');
     const query = await provider.getLogRowContextQuery(row);
-    expect(query?.expr).toBe('_stream:{app="nginx"} | sort by (_time) desc');
+    expect(query?.expr).toBe('_stream:{app="nginx"} _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50');
   });
 
   it('reports no context data when both _stream and _stream_id are missing', () => {
@@ -152,6 +153,58 @@ describe('LogContextProvider', () => {
       },
     });
     expect(provider.hasContextData(row)).toBe(false);
+  });
+
+  // both direction queries used to cover [anchor, anchor + 1s], so every line in that
+  // window was fetched twice and shown twice in the "Show context" modal (issue #692).
+  // The queries must split the timeline at the anchor timestamp without overlap:
+  // backward covers (-inf, anchor], forward covers (anchor, +inf)
+  describe('context query time boundaries', () => {
+    it('bounds the backward query at the anchor timestamp inclusively', async () => {
+      const query = await provider.getLogRowContextQuery(buildLogRow(), {
+        direction: LogRowContextQueryDirection.Backward,
+      });
+      expect(query?.expr).toBe(
+        '_stream_id:"stream-id-1" _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50'
+      );
+    });
+
+    it('bounds the forward query strictly after the anchor timestamp', async () => {
+      const query = await provider.getLogRowContextQuery(buildLogRow(), {
+        direction: LogRowContextQueryDirection.Forward,
+      });
+      expect(query?.expr).toBe(
+        '_stream_id:"stream-id-1" _time:>2023-11-14T22:13:20.000123456Z | sort by (_time) asc limit 50'
+      );
+    });
+
+    it('falls back to millisecond precision when the row has no nanosecond timestamp', async () => {
+      const query = await provider.getLogRowContextQuery(buildLogRow({ timeEpochNs: undefined }), {
+        direction: LogRowContextQueryDirection.Backward,
+      });
+      expect(query?.expr).toBe(
+        '_stream_id:"stream-id-1" _time:<=2023-11-14T22:13:20.000000000Z | sort by (_time) desc limit 50'
+      );
+    });
+  });
+
+  describe('context query row limit', () => {
+    it('caps rows at the limit requested by the context modal', async () => {
+      const query = await provider.getLogRowContextQuery(buildLogRow(), {
+        direction: LogRowContextQueryDirection.Backward,
+        limit: 42,
+      });
+      expect(query?.expr).toBe(
+        '_stream_id:"stream-id-1" _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 42'
+      );
+    });
+
+    it('falls back to the default limit when the modal does not pass one', async () => {
+      const query = await provider.getLogRowContextQuery(buildLogRow());
+      expect(query?.expr).toBe(
+        '_stream_id:"stream-id-1" _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50'
+      );
+    });
   });
 
   it('keeps toggle state isolated between different streams', async () => {
@@ -167,6 +220,6 @@ describe('LogContextProvider', () => {
 
     const query = await provider.getLogRowContextQuery(otherStreamRow);
 
-    expect(query?.expr).toBe('_stream_id:"stream-id-2" | sort by (_time) desc');
+    expect(query?.expr).toBe('_stream_id:"stream-id-2" _time:<=2023-11-14T22:13:20.000123456Z | sort by (_time) desc limit 50');
   });
 });

--- a/src/logContext/LogContextProvider.tsx
+++ b/src/logContext/LogContextProvider.tsx
@@ -16,6 +16,7 @@ import {
 import type { VictoriaLogsDatasource } from '../datasource';
 import { escapeLabelValueInExactSelector, escapeLabelValueInSelector } from '../languageUtils';
 import { Query } from '../types';
+import { formatNanosEpochToISO } from '../utils/timeUtils';
 
 import { LogContextUI } from './components/LogContextUI';
 
@@ -23,6 +24,9 @@ export const REF_ID_STARTER_LOG_CONTEXT_REQUEST = 'log-context-request-';
 export const REF_ID_STARTER_LOG_CONTEXT_QUERY = 'log-context-query-';
 export const LABEL_STREAM_ID = '_stream_id';
 export const LABEL_STREAM = '_stream';
+
+// fallback row cap per direction when the context modal does not pass a limit
+export const LOG_CONTEXT_DEFAULT_LIMIT = 50;
 
 const SIMPLE_SELECTOR_KEY_REGEXP = /^[a-zA-Z_][a-zA-Z0-9_.]*$/;
 
@@ -126,9 +130,23 @@ export class LogContextProvider {
     return this.buildStreamSelector(labels, selected);
   };
 
-  private prepareLogContextQueryExpr = (row: LogRowModel, direction: LogRowContextQueryDirection): string => {
-    const sortDir = direction === LogRowContextQueryDirection.Forward ? 'asc' : 'desc';
-    return `${this.buildContextFilterExpr(row)} | sort by (_time) ${sortDir}`;
+  // returns the anchor row timestamp as RFC3339 with nanoseconds. timeEpochNs
+  // carries real nanosecond precision (the backend serializes sub-ms remainders
+  // into the time field `nanos` array); fall back to milliseconds defensively
+  private getAnchorTimestamp = (row: LogRowModel): string => {
+    return formatNanosEpochToISO(row.timeEpochNs ?? `${row.timeEpochMs}000000`);
+  };
+
+  private prepareLogContextQueryExpr = (
+    row: LogRowModel,
+    direction: LogRowContextQueryDirection,
+    limit: number,
+  ): string => {
+    const forward = direction === LogRowContextQueryDirection.Forward;
+    const timeFilter = `_time:${forward ? '>' : '<='}${this.getAnchorTimestamp(row)}`;
+    const sortDir = forward ? 'asc' : 'desc';
+    const filterExpr = [this.buildContextFilterExpr(row), timeFilter].filter(Boolean).join(' ');
+    return `${filterExpr} | sort by (_time) ${sortDir} limit ${limit}`;
   };
 
   getLogRowContext = async (
@@ -144,8 +162,9 @@ export class LogContextProvider {
     options?: LogRowContextOptions
   ): Promise<Query | null> => {
     const direction = options?.direction || LogRowContextQueryDirection.Backward;
+    const limit = options?.limit ?? LOG_CONTEXT_DEFAULT_LIMIT;
     return {
-      expr: this.prepareLogContextQueryExpr(row, direction),
+      expr: this.prepareLogContextQueryExpr(row, direction, limit),
       refId: `${REF_ID_STARTER_LOG_CONTEXT_QUERY}${row.dataFrame.refId}-${direction}`,
     };
   };
@@ -156,9 +175,10 @@ export class LogContextProvider {
 
   private makeLogContextDataRequest = (row: LogRowModel, options?: LogRowContextOptions): DataQueryRequest<Query> => {
     const direction = options?.direction || LogRowContextQueryDirection.Backward;
+    const limit = options?.limit ?? LOG_CONTEXT_DEFAULT_LIMIT;
 
     const query: Query = {
-      expr: this.prepareLogContextQueryExpr(row, direction),
+      expr: this.prepareLogContextQueryExpr(row, direction, limit),
       refId: `${REF_ID_STARTER_LOG_CONTEXT_QUERY}${row.dataFrame.refId}-${direction}`
     };
 
@@ -179,6 +199,11 @@ export class LogContextProvider {
     };
   };
 
+  // coarse scan window around the anchor; the exact boundary at the anchor
+  // timestamp is enforced by the `_time` filter in the query expr. The backward
+  // window still ends 1s after the anchor because the backend truncates the
+  // range start/end params to whole seconds — ending exactly at the anchor
+  // could clip the anchor's own second out of the scan window
   private createContextTimeRange = (rowTimeEpochMs: number, direction?: LogRowContextQueryDirection): TimeRange => {
     const offset = 2 * 60 * 60 * 1000;  // 2h
     const overlap = 1000;
@@ -191,7 +216,7 @@ export class LogContextProvider {
         }
         : {
           from: toUtc(rowTimeEpochMs),
-          to: toUtc(rowTimeEpochMs + offset) // Add 1 second to avoid missing results
+          to: toUtc(rowTimeEpochMs + offset)
         };
 
     return { ...timeRange, raw: timeRange };

--- a/src/utils/timeUtils.test.ts
+++ b/src/utils/timeUtils.test.ts
@@ -2,6 +2,7 @@ import { dateTime, TimeRange } from '@grafana/data';
 
 import {
   bucketTimeRange,
+  formatNanosEpochToISO,
   formatOffsetDuration,
   getDurationFromMilliseconds,
   getMillisecondsFromDuration,
@@ -16,6 +17,21 @@ const makeRange = (fromMs: number, toMs: number): TimeRange => {
 const DAY_MS = 86_400_000;
 
 describe('timeUtils', () => {
+  describe('formatNanosEpochToISO', () => {
+    it('formats a nanosecond-epoch string with the full 9-digit fraction', () => {
+      // the value exceeds Number.MAX_SAFE_INTEGER, precision must not be lost
+      expect(formatNanosEpochToISO('1700000000000123456')).toBe('2023-11-14T22:13:20.000123456Z');
+    });
+
+    it('keeps a zero fraction as nine zeros', () => {
+      expect(formatNanosEpochToISO('1700000000000000000')).toBe('2023-11-14T22:13:20.000000000Z');
+    });
+
+    it('formats timestamps close to the epoch start', () => {
+      expect(formatNanosEpochToISO('123456789')).toBe('1970-01-01T00:00:00.123456789Z');
+    });
+  });
+
   describe('getDurationFromMilliseconds', () => {
     it('should return "1ms" for 1 millisecond', () => {
       expect(getDurationFromMilliseconds(1)).toBe('1ms');

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -96,6 +96,20 @@ export function formatOffsetDuration(timezone: string, totalMinutes: number): st
   return `${sign}${getDurationFromMilliseconds(msec)}`;
 }
 
+/**
+ * Formats a unix nanosecond-epoch string (e.g. LogRowModel.timeEpochNs) as an RFC3339
+ * timestamp with a 9-digit fraction: "2023-11-14T22:13:20.000123456Z".
+ * The value exceeds Number.MAX_SAFE_INTEGER, so it is split as a string
+ * into seconds and the nanosecond remainder instead of doing number arithmetic
+ */
+export function formatNanosEpochToISO(timeEpochNs: string): string {
+  // at least 10 chars so there is always a seconds part and a full 9-digit fraction
+  const digits = timeEpochNs.padStart(10, '0');
+  const seconds = Number(digits.slice(0, -9));
+  const fraction = digits.slice(-9);
+  return new Date(seconds * 1000).toISOString().replace('.000Z', `.${fraction}Z`);
+}
+
 const DAY_MS = 86_400_000;
 const WEEK_MS = 7 * DAY_MS;
 


### PR DESCRIPTION
Related issue: #692

### Describe Your Changes

- split the two context queries at the selected row's timestamp with nanosecond precision so the previous 1s overlap no longer shows lines twice
- add formatNanosEpochToISO to render the anchor timestamp as RFC3339 with nanosecond precision
- limit each direction query to the line count requested by the context modal (fallback 50) instead of returning the whole 2h scan window

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
