### PR TITLE
feat(logs volume): derive log levels server-side via format pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * FEATURE: `Filter for value` / `Filter out value` in log details now adds the value to the `Stream filters` when the clicked field is a stream field. Stream filters are resolved via the stream index, so such filters run noticeably faster on large volumes. See [#691](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/691).
+* FEATURE: speed up the logs volume histogram when log level rules reference high-cardinality fields like `_msg`. See [#700](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/700).
 
 * BUGFIX: keep the selected values of multi-value ad-hoc filter operators (`one of`, `not one of`) when serializing the query. Previously, such dashboard filters produced an empty `in()` filter, and the panel showed no results.
 * BUGFIX: interpolate dashboard variables into the query builder state and stream filter values when jumping from a dashboard panel to Explore. Previously, the raw variable names (e.g., `$app`) leaked back into the query on the first editor interaction, and the query returned no results.

--- a/src/components/QueryEditor/TemplateBuilder/serialization.ts
+++ b/src/components/QueryEditor/TemplateBuilder/serialization.ts
@@ -1,4 +1,4 @@
-import { quoteLogsQLValue } from '../../../utils/query/logsqlEscape';
+import { quoteLogsQLFieldName, quoteLogsQLValue } from '../../../utils/query/logsqlEscape';
 
 import { getTemplate } from './templates/registry';
 import { Pipe, PlaceholderSegment, Segment, TemplateQueryModel } from './types';
@@ -9,9 +9,6 @@ const needsQuotes = (role: string): boolean =>
 const isFieldNameRole = (role: string): boolean =>
   role === 'fieldName' || role === 'streamFieldName';
 
-const needsFieldNameQuotes = (value: string): boolean =>
-  !/^[a-zA-Z0-9_.]+$/.test(value);
-
 const formatValue = (value: string, segment: PlaceholderSegment): string => {
   if (value === '*') {
     return '*';
@@ -19,8 +16,8 @@ const formatValue = (value: string, segment: PlaceholderSegment): string => {
   if (needsQuotes(segment.role)) {
     return quoteLogsQLValue(value);
   }
-  if (isFieldNameRole(segment.role) && needsFieldNameQuotes(value)) {
-    return quoteLogsQLValue(value);
+  if (isFieldNameRole(segment.role)) {
+    return quoteLogsQLFieldName(value);
   }
   return value;
 };

--- a/src/components/QueryEditor/TemplateBuilder/templates/modifyTemplates.ts
+++ b/src/components/QueryEditor/TemplateBuilder/templates/modifyTemplates.ts
@@ -1,3 +1,4 @@
+import { capitalize } from '../../../../utils/string';
 import { getTabOrder, placeholder, text, uniqueId } from '../segmentHelpers';
 
 import { limitExtension, packExtensions, unpackExtensions } from './extensions';
@@ -5,7 +6,7 @@ import { TemplateConfig } from './types';
 
 const fieldPairTemplate = (keyword: string): TemplateConfig => ({
   type: keyword,
-  label: keyword.charAt(0).toUpperCase() + keyword.slice(1),
+  label: capitalize(keyword),
   stepCategory: 'modify',
   group: 'Fields',
   createSegments: () => [

--- a/src/configuration/LogLevelRules/const.test.ts
+++ b/src/configuration/LogLevelRules/const.test.ts
@@ -1,0 +1,66 @@
+import { LogLevel } from '@grafana/data';
+
+import { OperatorLabelsQueryBuilder } from './const';
+import { LogLevelRule, LogLevelRuleType } from './types';
+
+const makeRule = (operator: LogLevelRuleType, value: string | number, field = 'severity'): LogLevelRule => ({
+  field,
+  operator,
+  value,
+  level: LogLevel.error,
+  enabled: true,
+});
+
+describe('OperatorLabelsQueryBuilder', () => {
+  it('builds Equals as the exact filter `:=` (strict equality, like the client matcher)', () => {
+    expect(OperatorLabelsQueryBuilder[LogLevelRuleType.Equals](makeRule(LogLevelRuleType.Equals, 'api'))).toBe(
+      'severity:="api"'
+    );
+  });
+
+  it('builds NotEquals as the negated exact filter `:!=`', () => {
+    expect(OperatorLabelsQueryBuilder[LogLevelRuleType.NotEquals](makeRule(LogLevelRuleType.NotEquals, 'api'))).toBe(
+      'severity:!="api"'
+    );
+  });
+
+  it('builds CaseInsensitiveEquals as equals_common_case with a Title-Case value', () => {
+    const rule = makeRule(LogLevelRuleType.CaseInsensitiveEquals, 'info');
+    expect(OperatorLabelsQueryBuilder[LogLevelRuleType.CaseInsensitiveEquals](rule)).toBe(
+      'severity:equals_common_case("Info")'
+    );
+  });
+
+  it('builds WordFilter as the phrase filter', () => {
+    expect(OperatorLabelsQueryBuilder[LogLevelRuleType.WordFilter](makeRule(LogLevelRuleType.WordFilter, 'error'))).toBe(
+      'severity:"error"'
+    );
+  });
+
+  it('builds Regex, LessThan and GreaterThan with quoted values', () => {
+    expect(OperatorLabelsQueryBuilder[LogLevelRuleType.Regex](makeRule(LogLevelRuleType.Regex, 'env.*'))).toBe(
+      'severity:~"env.*"'
+    );
+    expect(OperatorLabelsQueryBuilder[LogLevelRuleType.LessThan](makeRule(LogLevelRuleType.LessThan, 9))).toBe(
+      'severity:<"9"'
+    );
+    expect(OperatorLabelsQueryBuilder[LogLevelRuleType.GreaterThan](makeRule(LogLevelRuleType.GreaterThan, 9))).toBe(
+      'severity:>"9"'
+    );
+  });
+
+  it('quotes field names containing characters that clash with the query syntax', () => {
+    const rule = makeRule(LogLevelRuleType.Equals, 'error', 'log:level');
+    expect(OperatorLabelsQueryBuilder[LogLevelRuleType.Equals](rule)).toBe('"log:level":="error"');
+  });
+
+  it('keeps plain field names with letters, digits, underscores and dots unquoted', () => {
+    const rule = makeRule(LogLevelRuleType.Equals, 'error', 'kubernetes.pod_name1');
+    expect(OperatorLabelsQueryBuilder[LogLevelRuleType.Equals](rule)).toBe('kubernetes.pod_name1:="error"');
+  });
+
+  it('escapes quotes and backslashes in values for every operator', () => {
+    const rule = makeRule(LogLevelRuleType.Equals, 'a"b\\c');
+    expect(OperatorLabelsQueryBuilder[LogLevelRuleType.Equals](rule)).toBe('severity:="a\\"b\\\\c"');
+  });
+});

--- a/src/configuration/LogLevelRules/const.test.ts
+++ b/src/configuration/LogLevelRules/const.test.ts
@@ -24,10 +24,10 @@ describe('OperatorLabelsQueryBuilder', () => {
     );
   });
 
-  it('builds CaseInsensitiveEquals as equals_common_case with a Title-Case value', () => {
+  it('builds CaseInsensitiveEquals as contains_common_case with a Title-Case value', () => {
     const rule = makeRule(LogLevelRuleType.CaseInsensitiveEquals, 'info');
     expect(OperatorLabelsQueryBuilder[LogLevelRuleType.CaseInsensitiveEquals](rule)).toBe(
-      'severity:equals_common_case("Info")'
+      'severity:contains_common_case("Info")'
     );
   });
 

--- a/src/configuration/LogLevelRules/const.ts
+++ b/src/configuration/LogLevelRules/const.ts
@@ -1,6 +1,8 @@
 import { LogLevel } from '@grafana/data';
 import { colors, ComboboxOption } from '@grafana/ui';
 
+import { quoteLogsQLValue } from '../../utils/query/logsqlEscape';
+
 import { LogLevelRule, LogLevelRuleType } from './types';
 
 export interface LogOperatorOption {
@@ -29,13 +31,13 @@ export const OperatorLabels: Record<LogLevelRuleType, string> = {
 };
 
 export const OperatorLabelsQueryBuilder: Record<LogLevelRuleType, (rule: LogLevelRule) => string> = {
-  [LogLevelRuleType.Equals]: (rule) => `${rule.field}:"${rule.value}"`,
-  [LogLevelRuleType.CaseInsensitiveEquals]: (rule) => `${rule.field}:contains_common_case("${rule.value}")`,
-  [LogLevelRuleType.NotEquals]: (rule) => `${rule.field}:!"${rule.value}"`,
-  [LogLevelRuleType.Regex]: (rule) => `${rule.field}:~"${rule.value}"`,
-  [LogLevelRuleType.LessThan]: (rule) => `${rule.field}:<"${rule.value}"`,
-  [LogLevelRuleType.GreaterThan]: (rule) => `${rule.field}:>"${rule.value}"`,
-  [LogLevelRuleType.WordFilter]: (rule) => `${rule.field}:"${rule.value}"`,
+  [LogLevelRuleType.Equals]: (rule) => `${rule.field}:${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.CaseInsensitiveEquals]: (rule) => `${rule.field}:contains_common_case(${quoteLogsQLValue(rule.value)})`,
+  [LogLevelRuleType.NotEquals]: (rule) => `${rule.field}:!${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.Regex]: (rule) => `${rule.field}:~${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.LessThan]: (rule) => `${rule.field}:<${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.GreaterThan]: (rule) => `${rule.field}:>${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.WordFilter]: (rule) => `${rule.field}:${quoteLogsQLValue(rule.value)}`,
 };
 
 export const LOG_LEVEL_OPTIONS: Array<ComboboxOption<LogLevel>> = Array.from(

--- a/src/configuration/LogLevelRules/const.ts
+++ b/src/configuration/LogLevelRules/const.ts
@@ -2,7 +2,6 @@ import { LogLevel } from '@grafana/data';
 import { colors, ComboboxOption } from '@grafana/ui';
 
 import { quoteLogsQLFieldName, quoteLogsQLValue } from '../../utils/query/logsqlEscape';
-import { capitalize } from '../../utils/string';
 
 import { LogLevelRule, LogLevelRuleType } from './types';
 
@@ -33,7 +32,7 @@ export const OperatorLabels: Record<LogLevelRuleType, string> = {
 
 export const OperatorLabelsQueryBuilder: Record<LogLevelRuleType, (rule: LogLevelRule) => string> = {
   [LogLevelRuleType.Equals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:=${quoteLogsQLValue(rule.value)}`,
-  [LogLevelRuleType.CaseInsensitiveEquals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:equals_common_case(${quoteLogsQLValue(capitalize(String(rule.value)))})`,
+  [LogLevelRuleType.CaseInsensitiveEquals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:i(${quoteLogsQLValue(rule.value)})`,
   [LogLevelRuleType.NotEquals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:!=${quoteLogsQLValue(rule.value)}`,
   [LogLevelRuleType.Regex]: (rule) => `${quoteLogsQLFieldName(rule.field)}:~${quoteLogsQLValue(rule.value)}`,
   [LogLevelRuleType.LessThan]: (rule) => `${quoteLogsQLFieldName(rule.field)}:<${quoteLogsQLValue(rule.value)}`,

--- a/src/configuration/LogLevelRules/const.ts
+++ b/src/configuration/LogLevelRules/const.ts
@@ -2,6 +2,7 @@ import { LogLevel } from '@grafana/data';
 import { colors, ComboboxOption } from '@grafana/ui';
 
 import { quoteLogsQLFieldName, quoteLogsQLValue } from '../../utils/query/logsqlEscape';
+import { capitalize } from '../../utils/string';
 
 import { LogLevelRule, LogLevelRuleType } from './types';
 
@@ -32,7 +33,7 @@ export const OperatorLabels: Record<LogLevelRuleType, string> = {
 
 export const OperatorLabelsQueryBuilder: Record<LogLevelRuleType, (rule: LogLevelRule) => string> = {
   [LogLevelRuleType.Equals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:=${quoteLogsQLValue(rule.value)}`,
-  [LogLevelRuleType.CaseInsensitiveEquals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:i(${quoteLogsQLValue(rule.value)})`,
+  [LogLevelRuleType.CaseInsensitiveEquals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:contains_common_case(${quoteLogsQLValue(capitalize(String(rule.value)))})`,
   [LogLevelRuleType.NotEquals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:!=${quoteLogsQLValue(rule.value)}`,
   [LogLevelRuleType.Regex]: (rule) => `${quoteLogsQLFieldName(rule.field)}:~${quoteLogsQLValue(rule.value)}`,
   [LogLevelRuleType.LessThan]: (rule) => `${quoteLogsQLFieldName(rule.field)}:<${quoteLogsQLValue(rule.value)}`,

--- a/src/configuration/LogLevelRules/const.ts
+++ b/src/configuration/LogLevelRules/const.ts
@@ -1,7 +1,8 @@
 import { LogLevel } from '@grafana/data';
 import { colors, ComboboxOption } from '@grafana/ui';
 
-import { quoteLogsQLValue } from '../../utils/query/logsqlEscape';
+import { quoteLogsQLFieldName, quoteLogsQLValue } from '../../utils/query/logsqlEscape';
+import { capitalize } from '../../utils/string';
 
 import { LogLevelRule, LogLevelRuleType } from './types';
 
@@ -31,13 +32,13 @@ export const OperatorLabels: Record<LogLevelRuleType, string> = {
 };
 
 export const OperatorLabelsQueryBuilder: Record<LogLevelRuleType, (rule: LogLevelRule) => string> = {
-  [LogLevelRuleType.Equals]: (rule) => `${rule.field}:${quoteLogsQLValue(rule.value)}`,
-  [LogLevelRuleType.CaseInsensitiveEquals]: (rule) => `${rule.field}:contains_common_case(${quoteLogsQLValue(rule.value)})`,
-  [LogLevelRuleType.NotEquals]: (rule) => `${rule.field}:!${quoteLogsQLValue(rule.value)}`,
-  [LogLevelRuleType.Regex]: (rule) => `${rule.field}:~${quoteLogsQLValue(rule.value)}`,
-  [LogLevelRuleType.LessThan]: (rule) => `${rule.field}:<${quoteLogsQLValue(rule.value)}`,
-  [LogLevelRuleType.GreaterThan]: (rule) => `${rule.field}:>${quoteLogsQLValue(rule.value)}`,
-  [LogLevelRuleType.WordFilter]: (rule) => `${rule.field}:${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.Equals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:=${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.CaseInsensitiveEquals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:equals_common_case(${quoteLogsQLValue(capitalize(String(rule.value)))})`,
+  [LogLevelRuleType.NotEquals]: (rule) => `${quoteLogsQLFieldName(rule.field)}:!=${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.Regex]: (rule) => `${quoteLogsQLFieldName(rule.field)}:~${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.LessThan]: (rule) => `${quoteLogsQLFieldName(rule.field)}:<${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.GreaterThan]: (rule) => `${quoteLogsQLFieldName(rule.field)}:>${quoteLogsQLValue(rule.value)}`,
+  [LogLevelRuleType.WordFilter]: (rule) => `${quoteLogsQLFieldName(rule.field)}:${quoteLogsQLValue(rule.value)}`,
 };
 
 export const LOG_LEVEL_OPTIONS: Array<ComboboxOption<LogLevel>> = Array.from(

--- a/src/configuration/LogLevelRules/utils.test.ts
+++ b/src/configuration/LogLevelRules/utils.test.ts
@@ -137,4 +137,12 @@ describe('resolveLogLevel — existing operators (regression)', () => {
     expect(resolve({ lvl: 'ERROR' }, rules)).toBe(LogLevel.error);
     expect(resolve({ lvl: 'warn' }, rules)).toBe(LogLevel.unknown);
   });
+
+  it('CaseInsensitiveEquals lowercases the rule value too (provisioned values like "INFO")', () => {
+    const rules = [
+      rule({ operator: LogLevelRuleType.CaseInsensitiveEquals, field: 'lvl', value: 'INFO', level: LogLevel.info }),
+    ];
+    expect(resolve({ lvl: 'info' }, rules)).toBe(LogLevel.info);
+    expect(resolve({ lvl: 'Info' }, rules)).toBe(LogLevel.info);
+  });
 });

--- a/src/configuration/LogLevelRules/utils.ts
+++ b/src/configuration/LogLevelRules/utils.ts
@@ -39,7 +39,7 @@ const ruleMatchers: Record<LogLevelRuleType, RuleMatcher> = {
   [LogLevelRuleType.LessThan]: (fieldValue, rule) => compareNumeric(fieldValue, rule.value, (a, b) => a < b),
   [LogLevelRuleType.Regex]: (fieldValue, rule) => matchesRegex(fieldValue, rule.value),
   [LogLevelRuleType.CaseInsensitiveEquals]: (fieldValue, rule) =>
-    typeof fieldValue === 'string' && fieldValue.toLowerCase() === rule.value,
+    typeof fieldValue === 'string' && fieldValue.toLowerCase() === String(rule.value).toLowerCase(),
   [LogLevelRuleType.WordFilter]: (fieldValue, rule) => matchesWordFilter(fieldValue, rule.value),
 };
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -22,6 +22,8 @@ import { OpenTelemetryPreset } from './configuration/OpenTelemetryPreset/types';
 import { LOGS_LIMIT_DEFAULT, LOGS_LIMIT_HARD_CAP, TEXT_FILTER_ALL_VALUE, VARIABLE_ALL_VALUE } from './constants';
 import { VictoriaLogsDatasource } from './datasource';
 import { AdHocFilter, AdHocFiltersMode, FilterActionType, Query, QueryType, SupportingQueryType, ToggleFilterAction } from './types';
+import { buildExactLevelExprMap } from './utils/query/levelExpansion';
+import { DERIVED_LEVEL_FIELD } from './utils/query/levelFormatPipes';
 
 const replaceMock = jest.fn().mockImplementation((a: string) => a);
 
@@ -458,7 +460,7 @@ describe('VictoriaLogsDatasource', () => {
         {},
       );
       expect(replacedQuery.expr).toBe('_time:5m');
-      expect(replacedQuery.extraFilters).toMatch(/^\(level:contains_common_case\(.+\)\)$/);
+      expect(replacedQuery.extraFilters).toBe(`(${buildExactLevelExprMap([])['error']})`);
     });
 
     it('expands a marked level chip into the root query in rootQuery mode', () => {
@@ -474,7 +476,7 @@ describe('VictoriaLogsDatasource', () => {
         { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.RootQuery, adHocFilters },
         {},
       );
-      expect(replacedQuery.expr).toMatch(/^\(level:contains_common_case\(.+\)\) \| _time:5m$/);
+      expect(replacedQuery.expr).toBe(`(${buildExactLevelExprMap([])['error']}) | _time:5m`);
       expect(replacedQuery.extraFilters).toBeUndefined();
     });
 
@@ -492,7 +494,7 @@ describe('VictoriaLogsDatasource', () => {
         {},
       );
       expect(replacedQuery.expr).toBe('_time:5m');
-      expect(replacedQuery.extraFilters).toMatch(/^\(level:contains_common_case\(.+\)\)$/);
+      expect(replacedQuery.extraFilters).toBe(`(${buildExactLevelExprMap([])['error']})`);
     });
 
     it('OR-combines two marked level chips into one parenthesised group', () => {
@@ -509,9 +511,8 @@ describe('VictoriaLogsDatasource', () => {
         { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.ExtraFilters, adHocFilters },
         {},
       );
-      expect(replacedQuery.extraFilters).toMatch(
-        /^\(level:contains_common_case\(.+\) OR level:contains_common_case\(.+\)\)$/,
-      );
+      const map = buildExactLevelExprMap([]);
+      expect(replacedQuery.extraFilters).toBe(`(${map['error']} OR ${map['warning']})`);
     });
 
     it('expands a marked unknown-level chip into a negation', () => {
@@ -527,8 +528,9 @@ describe('VictoriaLogsDatasource', () => {
         { expr: '_time:5m', refId: 'A', adHocFiltersMode: AdHocFiltersMode.ExtraFilters, adHocFilters },
         {},
       );
-      // unknown = !(<all known levels OR'd>), wrapped by expandLevelChips in parens
-      expect(replacedQuery.extraFilters).toMatch(/^\(!\(.+\)\)$/);
+      // unknown = exact per-level expression (guard against earlier-level aliases, plus the
+      // no-rule-matched negation), wrapped by expandLevelChips in parens.
+      expect(replacedQuery.extraFilters).toBe(`(${buildExactLevelExprMap([])['unknown']})`);
     });
 
   });
@@ -1384,6 +1386,70 @@ describe('VictoriaLogsDatasource preset merge', () => {
         expect(result).toBeUndefined();
       });
 
+      it('keeps the lightweight level grouping when no level rules are active', () => {
+        const result = ds.getSupplementaryQuery(opts, makeQuery(QueryType.Instant), makeRequest());
+        expect(result?.fields).toEqual(['level']);
+        expect(result?.expr).toBe('*');
+      });
+
+      it('derives the level server-side via format pipes when level rules are active', () => {
+        const dsWithRules = createDatasource(templateSrvStub, {
+          id: 1,
+          uid: 'u',
+          jsonData: {
+            logLevelRules: [
+              { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'error', level: LogLevel.error, enabled: true },
+            ],
+          },
+        });
+        const result = dsWithRules.getSupplementaryQuery(opts, makeQuery(QueryType.Instant), makeRequest());
+        expect(result?.fields).toEqual([DERIVED_LEVEL_FIELD]);
+        expect(result?.expr).toContain(`* | format "" as ${DERIVED_LEVEL_FIELD}`);
+        expect(result?.expr).toContain('_msg:"error"');
+      });
+
+      it('ignores disabled rules when deciding to add format pipes', () => {
+        const dsDisabled = createDatasource(templateSrvStub, {
+          id: 1,
+          uid: 'u',
+          jsonData: {
+            logLevelRules: [
+              { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'error', level: LogLevel.error, enabled: false },
+            ],
+          },
+        });
+        const result = dsDisabled.getSupplementaryQuery(opts, makeQuery(QueryType.Instant), makeRequest());
+        expect(result?.fields).toEqual(['level']);
+        expect(result?.expr).toBe('*');
+      });
+
+      it('strips the plugin-appended trailing sort pipe before adding format pipes', () => {
+        const dsWithRules = createDatasource(templateSrvStub, {
+          id: 1,
+          uid: 'u',
+          jsonData: {
+            logLevelRules: [
+              { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'error', level: LogLevel.error, enabled: true },
+            ],
+          },
+        });
+        const result = dsWithRules.getSupplementaryQuery(
+          opts,
+          makeQuery(QueryType.Instant, { expr: 'app:x | sort by (_time) desc' }),
+          makeRequest(),
+        );
+        expect(result?.expr).toContain(`app:x | format "" as ${DERIVED_LEVEL_FIELD}`);
+        expect(result?.expr).not.toContain('sort by');
+      });
+
+      it('keeps the trailing sort pipe untouched when no level rules are active', () => {
+        const result = ds.getSupplementaryQuery(
+          opts,
+          makeQuery(QueryType.Instant, { expr: 'app:x | sort by (_time) desc' }),
+          makeRequest(),
+        );
+        expect(result?.expr).toBe('app:x | sort by (_time) desc');
+      });
     });
 
     describe('LogsSample', () => {

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1450,6 +1450,27 @@ describe('VictoriaLogsDatasource preset merge', () => {
         );
         expect(result?.expr).toBe('app:x | sort by (_time) desc');
       });
+
+      it('does not append format pipes to an empty expression', () => {
+        const dsWithRules = createDatasource(templateSrvStub, {
+          id: 1,
+          uid: 'u',
+          jsonData: {
+            logLevelRules: [
+              { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'error', level: LogLevel.error, enabled: true },
+            ],
+          },
+        });
+        // A `| format ...` query without a filter part is unparsable; the empty-expr
+        // target must stay empty so query() drops it, as it did before format pipes
+        const result = dsWithRules.getSupplementaryQuery(
+          opts,
+          makeQuery(QueryType.Instant, { expr: '' }),
+          makeRequest(),
+        );
+        expect(result?.expr).toBe('');
+        expect(result?.fields).toEqual(['level']);
+      });
     });
 
     describe('LogsSample', () => {

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1423,7 +1423,7 @@ describe('VictoriaLogsDatasource preset merge', () => {
         expect(result?.expr).toBe('*');
       });
 
-      it('strips the plugin-appended trailing sort pipe before adding format pipes', () => {
+      it('inserts the format pipes before the trailing sort pipe', () => {
         const dsWithRules = createDatasource(templateSrvStub, {
           id: 1,
           uid: 'u',
@@ -1439,7 +1439,28 @@ describe('VictoriaLogsDatasource preset merge', () => {
           makeRequest(),
         );
         expect(result?.expr).toContain(`app:x | format "" as ${DERIVED_LEVEL_FIELD}`);
-        expect(result?.expr).not.toContain('sort by');
+        expect(result?.expr?.endsWith(' | sort by (_time) desc')).toBe(true);
+      });
+
+      it('inserts the format pipes before the first sort-class pipe, keeping later pipes intact', () => {
+        const dsWithRules = createDatasource(templateSrvStub, {
+          id: 1,
+          uid: 'u',
+          jsonData: {
+            logLevelRules: [
+              { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'error', level: LogLevel.error, enabled: true },
+            ],
+          },
+        });
+        // hits ignores sort-class pipes and loses fields created after them — the format
+        // pipes must land before `sort`, otherwise every bar collapses into `unknown`
+        const result = dsWithRules.getSupplementaryQuery(
+          opts,
+          makeQuery(QueryType.Instant, { expr: '* | sort by (_time) desc | limit 10 | pack_json' }),
+          makeRequest(),
+        );
+        expect(result?.expr).toContain(`* | format "" as ${DERIVED_LEVEL_FIELD}`);
+        expect(result?.expr?.endsWith(' | sort by (_time) desc | limit 10 | pack_json')).toBe(true);
       });
 
       it('keeps the trailing sort pipe untouched when no level rules are active', () => {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -50,7 +50,7 @@ import {
   addLabelToQuery,
   addSortPipeToQuery,
   getQueryFormat,
-  removeTrailingSortPipe,
+  insertPipesBeforeSortClassPipe,
 } from './modifyQuery';
 import { removeDoubleQuotesAroundVar } from './parsing';
 import { replaceOperatorWithIn, returnVariables } from './parsingUtils';
@@ -552,16 +552,16 @@ export class VictoriaLogsDatasource
         // With active level rules the level is derived server-side via `format` pipes,
         // grouping hits by the single derived field instead of every rule field
         // (a `_msg` rule would otherwise explode cardinality — issue #700).
-        // The plugin-appended trailing sort pipe is stripped: hits ignores ordering, and
-        // VictoriaLogs returns empty values for format-derived fields placed after a sort pipe.
-        // An empty base expression gets no pipes — a `| format ...` query without a filter
+        // The pipes are inserted before the first sort-class pipe (see
+        // insertPipesBeforeSortClassPipe): hits ignores those pipes and loses fields
+        // created after them, while rules may reference fields created by earlier pipes.
+        // An empty expression gets no pipes — a `| format ...` query without a filter
         // part is unparsable, and the empty-expr target is dropped later in query() anyway
-        const baseExpr = removeTrailingSortPipe(query.expr);
-        const levelPipes = baseExpr ? buildLevelFormatPipes(this.getActiveLevelRules()) : '';
+        const levelPipes = query.expr ? buildLevelFormatPipes(this.getActiveLevelRules()) : '';
 
         return {
           ...query,
-          expr: levelPipes ? `${baseExpr}${levelPipes}` : query.expr,
+          expr: levelPipes ? insertPipesBeforeSortClassPipe(query.expr, levelPipes) : query.expr,
           step: `${step}s`,
           fields: levelPipes ? [DERIVED_LEVEL_FIELD] : ['level'],
           queryType: QueryType.Hits,

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -553,12 +553,15 @@ export class VictoriaLogsDatasource
         // grouping hits by the single derived field instead of every rule field
         // (a `_msg` rule would otherwise explode cardinality — issue #700).
         // The plugin-appended trailing sort pipe is stripped: hits ignores ordering, and
-        // VictoriaLogs returns empty values for format-derived fields placed after a sort pipe
-        const levelPipes = buildLevelFormatPipes(this.getActiveLevelRules());
+        // VictoriaLogs returns empty values for format-derived fields placed after a sort pipe.
+        // An empty base expression gets no pipes — a `| format ...` query without a filter
+        // part is unparsable, and the empty-expr target is dropped later in query() anyway
+        const baseExpr = removeTrailingSortPipe(query.expr);
+        const levelPipes = baseExpr ? buildLevelFormatPipes(this.getActiveLevelRules()) : '';
 
         return {
           ...query,
-          expr: levelPipes ? `${removeTrailingSortPipe(query.expr)}${levelPipes}` : query.expr,
+          expr: levelPipes ? `${baseExpr}${levelPipes}` : query.expr,
           step: `${step}s`,
           fields: levelPipes ? [DERIVED_LEVEL_FIELD] : ['level'],
           queryType: QueryType.Hits,

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -50,6 +50,7 @@ import {
   addLabelToQuery,
   addSortPipeToQuery,
   getQueryFormat,
+  removeTrailingSortPipe,
 } from './modifyQuery';
 import { removeDoubleQuotesAroundVar } from './parsing';
 import { replaceOperatorWithIn, returnVariables } from './parsingUtils';
@@ -77,6 +78,7 @@ import {
   resolveAdHocFilters,
   serializeChipsForBackend,
 } from './utils/query/adHocFilters';
+import { buildLevelFormatPipes, DERIVED_LEVEL_FIELD } from './utils/query/levelFormatPipes';
 import { streamFiltersHaveValue, toggleStreamFilterValue } from './utils/query/streamFilterToggle';
 import { formatOffsetDuration, getMillisecondsFromDuration } from './utils/timeUtils';
 import { VariableSupport } from './variableSupport/VariableSupport';
@@ -547,13 +549,18 @@ export class VictoriaLogsDatasource
         const totalSeconds = request.range.to.diff(request.range.from, 'second');
         const step = Math.ceil(totalSeconds / LOGS_VOLUME_BARS) || '';
 
-        const fields = this.getActiveLevelRules().map(r => r.field).filter(Boolean);
-        const uniqFields = Array.from(new Set([...fields, 'level']));
+        // With active level rules the level is derived server-side via `format` pipes,
+        // grouping hits by the single derived field instead of every rule field
+        // (a `_msg` rule would otherwise explode cardinality — issue #700).
+        // The plugin-appended trailing sort pipe is stripped: hits ignores ordering, and
+        // VictoriaLogs returns empty values for format-derived fields placed after a sort pipe
+        const levelPipes = buildLevelFormatPipes(this.getActiveLevelRules());
 
         return {
           ...query,
+          expr: levelPipes ? `${removeTrailingSortPipe(query.expr)}${levelPipes}` : query.expr,
           step: `${step}s`,
-          fields: uniqFields,
+          fields: levelPipes ? [DERIVED_LEVEL_FIELD] : ['level'],
           queryType: QueryType.Hits,
           refId: `${REF_ID_STARTER_LOG_VOLUME}${query.refId}`,
           supportingQueryType: SupportingQueryType.LogsVolume,

--- a/src/logsVolumeLegacy.test.ts
+++ b/src/logsVolumeLegacy.test.ts
@@ -1,0 +1,34 @@
+import { FieldType, LogLevel, toDataFrame } from '@grafana/data';
+
+import { LogLevelRuleType } from './configuration/LogLevelRules/types';
+import { extractLevel } from './logsVolumeLegacy';
+import { DERIVED_LEVEL_FIELD } from './utils/query/levelFormatPipes';
+
+const makeFrame = (labels?: Record<string, string>) =>
+  toDataFrame({
+    fields: [
+      { name: 'Time', type: FieldType.time, values: [0] },
+      { name: 'Value', type: FieldType.number, values: [1], labels },
+    ],
+  });
+
+describe('extractLevel', () => {
+  it('maps the derived level label directly', () => {
+    expect(extractLevel(makeFrame({ [DERIVED_LEVEL_FIELD]: 'error' }), [])).toBe(LogLevel.error);
+  });
+
+  it('maps an empty derived level to unknown without applying rules', () => {
+    const rules = [
+      { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'error', level: LogLevel.error, enabled: true },
+    ];
+    expect(extractLevel(makeFrame({ [DERIVED_LEVEL_FIELD]: '' }), rules)).toBe(LogLevel.unknown);
+  });
+
+  it('falls back to label matching when the derived label is absent', () => {
+    expect(extractLevel(makeFrame({ level: 'error' }), [])).toBe(LogLevel.error);
+  });
+
+  it('returns unknown when the value field has no labels', () => {
+    expect(extractLevel(makeFrame(), [])).toBe(LogLevel.unknown);
+  });
+});

--- a/src/logsVolumeLegacy.ts
+++ b/src/logsVolumeLegacy.ts
@@ -19,6 +19,7 @@ import { LogLevelRule } from './configuration/LogLevelRules/types';
 import { extractLevelFromLabels } from './configuration/LogLevelRules/utils';
 import { VictoriaLogsDatasource } from './datasource';
 import { Query } from './types';
+import { DERIVED_LEVEL_FIELD, parseDerivedLevel } from './utils/query/levelFormatPipes';
 
 export const LOGS_VOLUME_BARS = 100;
 
@@ -180,11 +181,19 @@ function getLogVolumeFieldConfig(level: LogLevel) {
   };
 }
 
-const extractLevel = (frame: DataFrame, rules: LogLevelRule[]): LogLevel => {
+export const extractLevel = (frame: DataFrame, rules: LogLevelRule[]): LogLevel => {
   const valueField = frame.fields.find(f => f.name === 'Value');
 
   if (!valueField?.labels) {
     return LogLevel.unknown;
+  }
+
+  // The derived label is written by our own `format` pipes (see levelFormatPipes.ts),
+  // so its value is authoritative: empty means "no pipe matched" → unknown,
+  // and client-side rule matching must not run again
+  const derivedLevel = valueField.labels[DERIVED_LEVEL_FIELD];
+  if (derivedLevel !== undefined) {
+    return parseDerivedLevel(derivedLevel);
   }
 
   return extractLevelFromLabels(valueField.labels, rules);

--- a/src/modifyQuery.test.ts
+++ b/src/modifyQuery.test.ts
@@ -1,6 +1,6 @@
 import { CoreApp } from '@grafana/data';
 
-import { addLabelToQuery, addSortPipeToQuery, removeLabelFromQuery, removeTrailingSortPipe } from './modifyQuery';
+import { addLabelToQuery, addSortPipeToQuery, insertPipesBeforeSortClassPipe, removeLabelFromQuery } from './modifyQuery';
 import store from './store/store';
 import { Query, QueryType } from './types';
 
@@ -344,47 +344,69 @@ describe('modifyQuery', () => {
     });
   });
 
-  describe('removeTrailingSortPipe', () => {
-    it('removes the trailing desc sort pipe', () => {
-      expect(removeTrailingSortPipe('app:x | sort by (_time) desc')).toBe('app:x');
+  describe('insertPipesBeforeSortClassPipe', () => {
+    const PIPES = ' | format "" as lvl';
+
+    it('appends at the end when the expression has no pipes', () => {
+      expect(insertPipesBeforeSortClassPipe('app:x', PIPES)).toBe('app:x | format "" as lvl');
     });
 
-    it('removes the trailing asc sort pipe', () => {
-      expect(removeTrailingSortPipe('app:x | sort by (_time) asc')).toBe('app:x');
-    });
-
-    it('returns the expression unchanged when there is no trailing sort pipe', () => {
-      expect(removeTrailingSortPipe('app:x')).toBe('app:x');
-    });
-
-    it('keeps a sort pipe that is not the trailing pipe', () => {
-      expect(removeTrailingSortPipe('app:x | sort by (_time) desc | fields _msg')).toBe(
-        'app:x | sort by (_time) desc | fields _msg'
+    it('appends at the end when there are no sort-class pipes', () => {
+      expect(insertPipesBeforeSortClassPipe('app:x | unpack_json | fields _msg', PIPES)).toBe(
+        'app:x | unpack_json | fields _msg | format "" as lvl'
       );
     });
 
-    it('removes user-written trailing sorts with other fields, limit or offset', () => {
-      expect(removeTrailingSortPipe('app:x | sort by (level) desc')).toBe('app:x');
-      expect(removeTrailingSortPipe('app:x | sort by (_time) desc limit 10')).toBe('app:x');
-      expect(removeTrailingSortPipe('app:x | sort by (_time) desc offset 5')).toBe('app:x');
+    it('inserts before a trailing sort pipe', () => {
+      expect(insertPipesBeforeSortClassPipe('app:x | sort by (_time) desc', PIPES)).toBe(
+        'app:x | format "" as lvl | sort by (_time) desc'
+      );
     });
 
-    it('removes a trailing order by pipe regardless of keyword case', () => {
-      expect(removeTrailingSortPipe('app:x | order by (_time) desc')).toBe('app:x');
-      expect(removeTrailingSortPipe('app:x | SORT BY (_time) DESC')).toBe('app:x');
+    it('inserts before the first sort-class pipe, keeping the tail intact', () => {
+      expect(insertPipesBeforeSortClassPipe('app:x | sort by (_time) desc | limit 10 | pack_json', PIPES)).toBe(
+        'app:x | format "" as lvl | sort by (_time) desc | limit 10 | pack_json'
+      );
     });
 
-    it('does not strip pipes whose name merely starts with sort', () => {
-      expect(removeTrailingSortPipe('app:x | sort_values')).toBe('app:x | sort_values');
+    it('inserts after field-transforming pipes the level rules may reference', () => {
+      expect(insertPipesBeforeSortClassPipe('app:x | unpack_json | sort by (_time) desc', PIPES)).toBe(
+        'app:x | unpack_json | format "" as lvl | sort by (_time) desc'
+      );
     });
 
-    it('does not corrupt quoted values containing a pipe with sort', () => {
-      expect(removeTrailingSortPipe('_msg:"error | sort by (x)"')).toBe('_msg:"error | sort by (x)"');
-      expect(removeTrailingSortPipe('app:x | filter _msg:"a | order by"')).toBe('app:x | filter _msg:"a | order by"');
+    it.each(['limit 10', 'head 10', 'offset 5', 'skip 5', 'first 10 by (_time)', 'last 10 by (_time)', 'order by (_time) desc'])(
+      'treats `%s` as a sort-class pipe',
+      (pipe) => {
+        expect(insertPipesBeforeSortClassPipe(`app:x | ${pipe}`, PIPES)).toBe(`app:x | format "" as lvl | ${pipe}`);
+      }
+    );
+
+    it('matches sort-class pipe keywords case-insensitively', () => {
+      expect(insertPipesBeforeSortClassPipe('app:x | SORT BY (_time) DESC', PIPES)).toBe(
+        'app:x | format "" as lvl | SORT BY (_time) DESC'
+      );
     });
 
-    it('removes a trailing sort pipe after a quoted value containing a pipe', () => {
-      expect(removeTrailingSortPipe('_msg:"a|b" | sort by (_time) desc')).toBe('_msg:"a|b"');
+    it('does not treat pipes whose name merely starts with a keyword as sort-class', () => {
+      expect(insertPipesBeforeSortClassPipe('app:x | sort_values', PIPES)).toBe(
+        'app:x | sort_values | format "" as lvl'
+      );
+    });
+
+    it('ignores sort keywords inside quoted values', () => {
+      expect(insertPipesBeforeSortClassPipe('_msg:"error | sort by (x)"', PIPES)).toBe(
+        '_msg:"error | sort by (x)" | format "" as lvl'
+      );
+      expect(insertPipesBeforeSortClassPipe('app:x | filter _msg:"a | order by"', PIPES)).toBe(
+        'app:x | filter _msg:"a | order by" | format "" as lvl'
+      );
+    });
+
+    it('inserts before a sort pipe following a quoted value containing a pipe', () => {
+      expect(insertPipesBeforeSortClassPipe('_msg:"a|b" | sort by (_time) desc', PIPES)).toBe(
+        '_msg:"a|b" | format "" as lvl | sort by (_time) desc'
+      );
     });
   });
 });

--- a/src/modifyQuery.test.ts
+++ b/src/modifyQuery.test.ts
@@ -377,5 +377,14 @@ describe('modifyQuery', () => {
     it('does not strip pipes whose name merely starts with sort', () => {
       expect(removeTrailingSortPipe('app:x | sort_values')).toBe('app:x | sort_values');
     });
+
+    it('does not corrupt quoted values containing a pipe with sort', () => {
+      expect(removeTrailingSortPipe('_msg:"error | sort by (x)"')).toBe('_msg:"error | sort by (x)"');
+      expect(removeTrailingSortPipe('app:x | filter _msg:"a | order by"')).toBe('app:x | filter _msg:"a | order by"');
+    });
+
+    it('removes a trailing sort pipe after a quoted value containing a pipe', () => {
+      expect(removeTrailingSortPipe('_msg:"a|b" | sort by (_time) desc')).toBe('_msg:"a|b"');
+    });
   });
 });

--- a/src/modifyQuery.test.ts
+++ b/src/modifyQuery.test.ts
@@ -1,6 +1,6 @@
 import { CoreApp } from '@grafana/data';
 
-import { addLabelToQuery, addSortPipeToQuery, removeLabelFromQuery } from './modifyQuery';
+import { addLabelToQuery, addSortPipeToQuery, removeLabelFromQuery, removeTrailingSortPipe } from './modifyQuery';
 import store from './store/store';
 import { Query, QueryType } from './types';
 
@@ -341,6 +341,41 @@ describe('modifyQuery', () => {
         const result = addSortPipeToQuery(query, CoreApp.Dashboard);
         expect(result).toBe('foo: bar | sort by (level) asc');
       });
+    });
+  });
+
+  describe('removeTrailingSortPipe', () => {
+    it('removes the trailing desc sort pipe', () => {
+      expect(removeTrailingSortPipe('app:x | sort by (_time) desc')).toBe('app:x');
+    });
+
+    it('removes the trailing asc sort pipe', () => {
+      expect(removeTrailingSortPipe('app:x | sort by (_time) asc')).toBe('app:x');
+    });
+
+    it('returns the expression unchanged when there is no trailing sort pipe', () => {
+      expect(removeTrailingSortPipe('app:x')).toBe('app:x');
+    });
+
+    it('keeps a sort pipe that is not the trailing pipe', () => {
+      expect(removeTrailingSortPipe('app:x | sort by (_time) desc | fields _msg')).toBe(
+        'app:x | sort by (_time) desc | fields _msg'
+      );
+    });
+
+    it('removes user-written trailing sorts with other fields, limit or offset', () => {
+      expect(removeTrailingSortPipe('app:x | sort by (level) desc')).toBe('app:x');
+      expect(removeTrailingSortPipe('app:x | sort by (_time) desc limit 10')).toBe('app:x');
+      expect(removeTrailingSortPipe('app:x | sort by (_time) desc offset 5')).toBe('app:x');
+    });
+
+    it('removes a trailing order by pipe regardless of keyword case', () => {
+      expect(removeTrailingSortPipe('app:x | order by (_time) desc')).toBe('app:x');
+      expect(removeTrailingSortPipe('app:x | SORT BY (_time) DESC')).toBe('app:x');
+    });
+
+    it('does not strip pipes whose name merely starts with sort', () => {
+      expect(removeTrailingSortPipe('app:x | sort_values')).toBe('app:x | sort_values');
     });
   });
 });

--- a/src/modifyQuery.ts
+++ b/src/modifyQuery.ts
@@ -148,6 +148,19 @@ export const addSortPipeToQuery = ({ expr, queryType, direction }: Query, app: C
   return `${expr} | ${sortPipe}`;
 };
 
+// Matches any trailing `| sort ...` / `| order ...` pipe with all its options
+// (field list, asc/desc, limit/offset, ...). Only the LAST pipe is matched —
+// a sort feeding a later pipe is left intact.
+const TRAILING_SORT_PIPE_RE = /\s*\|\s*(?:sort|order)\b[^|]*$/i;
+
+/**
+ * Removes the trailing sort pipe — plugin-appended by addSortPipeToQuery or user-written.
+ * The logs volume hits query appends `format` pipes to the expression, and VictoriaLogs
+ * `/select/logsql/hits` returns empty values for fields created by pipes placed after
+ * a `sort` pipe — sorting is meaningless for hits aggregation anyway.
+ */
+export const removeTrailingSortPipe = (expr: string): string => expr.replace(TRAILING_SORT_PIPE_RE, '');
+
 
 export const getQueryFormat = (expr: string): Format | undefined => {
   if (isExprHasStatsPipeFunc(expr, 'histogram')) {

--- a/src/modifyQuery.ts
+++ b/src/modifyQuery.ts
@@ -149,26 +149,29 @@ export const addSortPipeToQuery = ({ expr, queryType, direction }: Query, app: C
   return `${expr} | ${sortPipe}`;
 };
 
-// Matches a pipe segment that is a `sort ...` / `order ...` pipe with any of
-// its options (field list, asc/desc, limit/offset, ...).
-const SORT_PIPE_RE = /^(?:sort|order)\b/i;
+// Matches a pipe segment that reorders or slices rows: `sort`/`order by`,
+// `limit`/`head`, `offset`/`skip` and the `first`/`last` sort+limit shorthands
+const SORT_CLASS_PIPE_RE = /^(?:sort|order|limit|head|offset|skip|first|last)\b/i;
 
 /**
- * Removes the trailing sort pipe — plugin-appended by addSortPipeToQuery or user-written.
- * Only the LAST top-level pipe is removed — a sort feeding a later pipe is left intact,
- * and `|` characters inside quoted values, parentheses or `{}` are ignored.
- * The logs volume hits query appends `format` pipes to the expression, and VictoriaLogs
- * `/select/logsql/hits` returns empty values for fields created by pipes placed after
- * a `sort` pipe — sorting is meaningless for hits aggregation anyway.
+ * Inserts a pipe suffix (starting with ` | `) before the first sort-class pipe,
+ * or appends it at the end when the expression has none. `|` characters inside
+ * quoted values, parentheses or `{}` are ignored when locating pipes.
+ * VictoriaLogs `/select/logsql/hits` ignores sort-class pipes and returns empty
+ * values for fields created by pipes placed after them, so the logs volume
+ * format pipes must land after the field-transforming pipes (whose fields the
+ * level rules may reference) but before the first sort-class pipe.
  */
-export const removeTrailingSortPipe = (expr: string): string => {
+export const insertPipesBeforeSortClassPipe = (expr: string, pipesSuffix: string): string => {
   const segments = splitByPipes(expr);
-  const lastPipe = segments[segments.length - 1];
-  // segments[0] is the filter part, so a single segment means there are no pipes
-  if (segments.length < 2 || !SORT_PIPE_RE.test(lastPipe)) {
-    return expr;
+  // segments[0] is the filter part, so only later segments are pipes
+  const sortClassIdx = segments.findIndex((segment, i) => i > 0 && SORT_CLASS_PIPE_RE.test(segment));
+  if (sortClassIdx === -1) {
+    return `${expr}${pipesSuffix}`;
   }
-  return segments.slice(0, -1).join(' | ');
+  const head = segments.slice(0, sortClassIdx).join(' | ');
+  const tail = segments.slice(sortClassIdx).join(' | ');
+  return `${head}${pipesSuffix} | ${tail}`;
 };
 
 

--- a/src/modifyQuery.ts
+++ b/src/modifyQuery.ts
@@ -1,5 +1,6 @@
 import { AdHocVariableFilter, CoreApp, LogsSortOrder } from '@grafana/data';
 
+import { splitByPipes } from './LogsQL/splitByPipes';
 import { isExprHasStatsPipeFunc } from './LogsQL/statsPipeFunctions';
 import { escapeLabelValueInExactSelector } from './languageUtils';
 import { storeKeys } from './store/constants';
@@ -148,18 +149,27 @@ export const addSortPipeToQuery = ({ expr, queryType, direction }: Query, app: C
   return `${expr} | ${sortPipe}`;
 };
 
-// Matches any trailing `| sort ...` / `| order ...` pipe with all its options
-// (field list, asc/desc, limit/offset, ...). Only the LAST pipe is matched —
-// a sort feeding a later pipe is left intact.
-const TRAILING_SORT_PIPE_RE = /\s*\|\s*(?:sort|order)\b[^|]*$/i;
+// Matches a pipe segment that is a `sort ...` / `order ...` pipe with any of
+// its options (field list, asc/desc, limit/offset, ...).
+const SORT_PIPE_RE = /^(?:sort|order)\b/i;
 
 /**
  * Removes the trailing sort pipe — plugin-appended by addSortPipeToQuery or user-written.
+ * Only the LAST top-level pipe is removed — a sort feeding a later pipe is left intact,
+ * and `|` characters inside quoted values, parentheses or `{}` are ignored.
  * The logs volume hits query appends `format` pipes to the expression, and VictoriaLogs
  * `/select/logsql/hits` returns empty values for fields created by pipes placed after
  * a `sort` pipe — sorting is meaningless for hits aggregation anyway.
  */
-export const removeTrailingSortPipe = (expr: string): string => expr.replace(TRAILING_SORT_PIPE_RE, '');
+export const removeTrailingSortPipe = (expr: string): string => {
+  const segments = splitByPipes(expr);
+  const lastPipe = segments[segments.length - 1];
+  // segments[0] is the filter part, so a single segment means there are no pipes
+  if (segments.length < 2 || !SORT_PIPE_RE.test(lastPipe)) {
+    return expr;
+  }
+  return segments.slice(0, -1).join(' | ');
+};
 
 
 export const getQueryFormat = (expr: string): Format | undefined => {

--- a/src/utils/query/adHocFilters.test.ts
+++ b/src/utils/query/adHocFilters.test.ts
@@ -1,5 +1,6 @@
-import { AdHocVariableFilter } from '@grafana/data';
+import { AdHocVariableFilter, LogLevel } from '@grafana/data';
 
+import { LogLevelRuleType } from '../../configuration/LogLevelRules/types';
 import { AdHocFilter, AdHocFiltersMode } from '../../types';
 
 import {
@@ -13,6 +14,7 @@ import {
   serializeAdHocFilters,
   serializeChipsForBackend,
 } from './adHocFilters';
+import { buildExactLevelExprMap } from './levelExpansion';
 
 describe('serializeAdHocFilters', () => {
   it('returns undefined for empty / missing input', () => {
@@ -354,8 +356,9 @@ describe('expandLevelChips', () => {
   it('expands a single marked level chip, wrapped in parens', () => {
     const chips: AdHocFilter[] = [{ key: 'level', operator: '=', value: 'error', fromLevelFilter: true }];
     const { levelExpr, rest } = expandLevelChips(chips, []);
+    const map = buildExactLevelExprMap([]);
     expect(rest).toEqual([]);
-    expect(levelExpr).toMatch(/^\(level:contains_common_case\(.+\)\)$/);
+    expect(levelExpr).toBe(`(${map['error']})`);
   });
 
   it('OR-combines multiple marked level chips inside one paren group', () => {
@@ -364,8 +367,9 @@ describe('expandLevelChips', () => {
       { key: 'level', operator: '=', value: 'warning', fromLevelFilter: true },
     ];
     const { levelExpr, rest } = expandLevelChips(chips, []);
+    const map = buildExactLevelExprMap([]);
     expect(rest).toEqual([]);
-    expect(levelExpr).toMatch(/^\(level:contains_common_case\(.+\) OR level:contains_common_case\(.+\)\)$/);
+    expect(levelExpr).toBe(`(${map['error']} OR ${map['warning']})`);
   });
 
   it('keeps non-level chips in rest', () => {
@@ -374,7 +378,8 @@ describe('expandLevelChips', () => {
       { key: 'service', operator: '=', value: 'api' },
     ];
     const { levelExpr, rest } = expandLevelChips(chips, []);
-    expect(levelExpr).toMatch(/^\(level:contains_common_case\(.+\)\)$/);
+    const map = buildExactLevelExprMap([]);
+    expect(levelExpr).toBe(`(${map['error']})`);
     expect(rest).toEqual([{ key: 'service', operator: '=', value: 'api' }]);
   });
 
@@ -383,6 +388,17 @@ describe('expandLevelChips', () => {
     const { levelExpr, rest } = expandLevelChips(chips, []);
     expect(levelExpr).toBeUndefined();
     expect(rest).toEqual([{ key: 'level', operator: '=', value: 'bogus', fromLevelFilter: true }]);
+  });
+
+  it('expands chips with the exact precedence-aware expressions', () => {
+    const rules = [
+      { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'Creating', level: LogLevel.warning, enabled: true },
+      { field: '_msg', operator: LogLevelRuleType.Regex, value: 'Creating', level: LogLevel.info, enabled: true },
+    ];
+    const chips = [{ key: 'level', value: 'info', operator: '=' as const, fromLevelFilter: true }];
+    const { levelExpr } = expandLevelChips(chips, rules);
+    expect(levelExpr).toBe(`(${buildExactLevelExprMap(rules)['info']})`);
+    expect(levelExpr).toContain('(_msg:~"Creating" and !(_msg:"Creating"))');
   });
 });
 
@@ -393,7 +409,8 @@ describe('serializeChipsForBackend with level rules', () => {
       { key: 'service', operator: '=', value: 'api' },
     ];
     const result = serializeChipsForBackend(chips, []);
-    expect(result).toMatch(/^\(level:contains_common_case\(.+\)\) AND service:="api"$/);
+    const map = buildExactLevelExprMap([]);
+    expect(result).toBe(`(${map['error']}) AND service:="api"`);
   });
 
   it('leaves unmarked level chips literal even when rules are passed', () => {

--- a/src/utils/query/adHocFilters.ts
+++ b/src/utils/query/adHocFilters.ts
@@ -6,7 +6,7 @@ import { addLabelToQuery } from '../../modifyQuery';
 import { returnVariables } from '../../parsingUtils';
 import { AdHocFilter, AdHocFilterOperator, AdHocFiltersMode, Query } from '../../types';
 
-import { buildLevelExprMap } from './levelExpansion';
+import { buildExactLevelExprMap } from './levelExpansion';
 
 export const serializeAdHocFilters = (filters: AdHocFilter[] | undefined): string | undefined => {
   if (!filters || filters.length === 0) {
@@ -71,15 +71,16 @@ export interface ExpandedLevelChips {
 }
 
 // Expands marked level chips (set by the level buttons) into a single parenthesised,
-// OR-combined LogsQL group. Other chips — including unmarked `level` chips from a
-// dashboard adhoc variable or Explore — are returned untouched in `rest`.
+// OR-combined group of EXACT per-level expressions (see buildExactLevelExprMap).
+// Other chips — including unmarked `level` chips from a dashboard adhoc variable or
+// Explore — are returned untouched in `rest`.
 export function expandLevelChips(chips: AdHocFilter[], rules: LogLevelRule[]): ExpandedLevelChips {
   const levelChips = chips.filter(isExpandableLevelChip);
   const rest = chips.filter((c) => !isExpandableLevelChip(c));
   if (!levelChips.length) {
     return { rest };
   }
-  const exprMap = buildLevelExprMap(rules);
+  const exprMap = buildExactLevelExprMap(rules);
   const exprs: string[] = [];
   levelChips.forEach((chip) => {
     const expr = exprMap[chip.value];

--- a/src/utils/query/levelExpansion.test.ts
+++ b/src/utils/query/levelExpansion.test.ts
@@ -2,7 +2,7 @@ import { LogLevel } from '@grafana/data';
 
 import { LogLevelRuleType } from '../../configuration/LogLevelRules/types';
 
-import { buildLevelExprMap, buildLevelExprs } from './levelExpansion';
+import { buildExactLevelExprMap, buildLevelAliasClause, buildLevelExprMap, buildLevelExprs, usableLevelRules } from './levelExpansion';
 
 describe('buildLevelExprs', () => {
   it('builds an expr per known level plus unknown last', () => {
@@ -48,5 +48,85 @@ describe('buildLevelExprs', () => {
       { field: 'message', operator: LogLevelRuleType.WordFilter, value: 'error', level: LogLevel.error, enabled: true },
     ];
     expect(buildLevelExprMap(rules)[LogLevel.error]).toContain(' OR message:"error"');
+  });
+
+  it('escapes quotes in rule values via the shared LogsQL quoting helper', () => {
+    const rules = [
+      { field: 'msg', operator: LogLevelRuleType.Equals, value: 'a"b', level: LogLevel.error, enabled: true },
+    ];
+    expect(buildLevelExprMap(rules)[LogLevel.error]).toContain('msg:"a\\"b"');
+  });
+
+  it('skips draft rules with an empty field', () => {
+    const rules = [
+      { field: '', operator: LogLevelRuleType.Equals, value: 'x', level: LogLevel.error, enabled: true },
+    ];
+    expect(buildLevelExprMap(rules)[LogLevel.error]).not.toContain(':"x"');
+  });
+});
+
+describe('shared level primitives', () => {
+  it('buildLevelAliasClause builds the contains_common_case clause for a level', () => {
+    expect(buildLevelAliasClause(LogLevel.error)).toMatch(/^level:contains_common_case\("err","eror","error"\)$/);
+  });
+
+  it('usableLevelRules drops draft rules with an empty field', () => {
+    const draft = { field: '', operator: LogLevelRuleType.Equals, value: 'x', level: LogLevel.error, enabled: true };
+    const real = { field: '_msg', operator: LogLevelRuleType.Equals, value: 'x', level: LogLevel.error, enabled: true };
+    expect(usableLevelRules([draft, real])).toEqual([real]);
+  });
+});
+
+describe('buildExactLevelExprMap', () => {
+  const loadedError = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'Loaded', level: LogLevel.error, enabled: true };
+  const creatingWarn = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'Creating', level: LogLevel.warning, enabled: true };
+  const creatingInfo = { field: '_msg', operator: LogLevelRuleType.Regex, value: 'Creating', level: LogLevel.info, enabled: true };
+
+  it('guards a rule with the negation of earlier rules of other levels (first-match-wins)', () => {
+    const map = buildExactLevelExprMap([creatingWarn, creatingInfo]);
+    expect(map[LogLevel.info]).toContain('(_msg:~"Creating" and !(_msg:"Creating"))');
+  });
+
+  it('does not guard against earlier rules of the same level', () => {
+    const deletedError = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'Deleted', level: LogLevel.error, enabled: true };
+    const map = buildExactLevelExprMap([loadedError, deletedError]);
+    expect(map[LogLevel.error]).toContain('_msg:"Deleted"');
+    expect(map[LogLevel.error]).not.toContain('_msg:"Deleted" and');
+  });
+
+  it('guards the alias clause with the negation of earlier levels in canonical order', () => {
+    const map = buildExactLevelExprMap([loadedError]);
+    expect(map[LogLevel.critical].startsWith('level:contains_common_case(')).toBe(true);
+    expect(map[LogLevel.error]).toContain('(level:contains_common_case("err","eror","error") and !(level:contains_common_case(');
+  });
+
+  it('guards the rules section with the negation of every alias clause', () => {
+    const map = buildExactLevelExprMap([loadedError]);
+    const rulesSection = map[LogLevel.error].split(' OR (!(')[1];
+    expect(rulesSection).toBeDefined();
+    expect(rulesSection).toContain('_msg:"Loaded"');
+    // all 7 alias groups are negated before any rule applies
+    expect((map[LogLevel.error].match(/contains_common_case/g) ?? []).length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('unknown covers the unknown alias, unknown-level rules, and rows matching no rule', () => {
+    const noiseUnknown = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'noise', level: LogLevel.unknown, enabled: true };
+    const map = buildExactLevelExprMap([loadedError, noiseUnknown]);
+    expect(map[LogLevel.unknown]).toContain('level:contains_common_case("unknown")');
+    expect(map[LogLevel.unknown]).toContain('(_msg:"noise" and !(_msg:"Loaded"))');
+    expect(map[LogLevel.unknown]).toContain('!(_msg:"Loaded" OR _msg:"noise")');
+  });
+
+  it('with no rules a known level is its guarded alias clause and unknown catches everything else', () => {
+    const map = buildExactLevelExprMap([]);
+    expect(map[LogLevel.critical]).toBe('level:contains_common_case("emerg","fatal","alert","crit","critical")');
+    expect(map[LogLevel.info]).not.toContain(' and (');
+    expect(map[LogLevel.unknown]).toMatch(/ OR !\(level:contains_common_case\(/);
+  });
+
+  it('skips draft rules with an empty field', () => {
+    const draft = { field: '', operator: LogLevelRuleType.Equals, value: 'x', level: LogLevel.error, enabled: true };
+    const map = buildExactLevelExprMap([draft]);
+    expect(map[LogLevel.error]).not.toContain(':"x"');
   });
 });

--- a/src/utils/query/levelExpansion.test.ts
+++ b/src/utils/query/levelExpansion.test.ts
@@ -26,14 +26,14 @@ describe('buildLevelExprs', () => {
     const rules = [
       { field: 'log.level', operator: LogLevelRuleType.Equals, value: 'err', level: LogLevel.error, enabled: true },
     ];
-    expect(buildLevelExprMap(rules)[LogLevel.error]).toContain(' OR log.level:"err"');
+    expect(buildLevelExprMap(rules)[LogLevel.error]).toContain(' OR log.level:="err"');
   });
 
   it('does not filter by enabled (caller pre-filters)', () => {
     const rules = [
       { field: 'log.level', operator: LogLevelRuleType.Equals, value: 'err', level: LogLevel.error, enabled: false },
     ];
-    expect(buildLevelExprMap(rules)[LogLevel.error]).toContain(' OR log.level:"err"');
+    expect(buildLevelExprMap(rules)[LogLevel.error]).toContain(' OR log.level:="err"');
   });
 
   it('emits field:"" for an empty WordFilter (matches empty/missing fields, mirrors LogsQL)', () => {
@@ -54,7 +54,7 @@ describe('buildLevelExprs', () => {
     const rules = [
       { field: 'msg', operator: LogLevelRuleType.Equals, value: 'a"b', level: LogLevel.error, enabled: true },
     ];
-    expect(buildLevelExprMap(rules)[LogLevel.error]).toContain('msg:"a\\"b"');
+    expect(buildLevelExprMap(rules)[LogLevel.error]).toContain('msg:="a\\"b"');
   });
 
   it('skips draft rules with an empty field', () => {
@@ -66,14 +66,23 @@ describe('buildLevelExprs', () => {
 });
 
 describe('shared level primitives', () => {
-  it('buildLevelAliasClause builds the contains_common_case clause for a level', () => {
-    expect(buildLevelAliasClause(LogLevel.error)).toMatch(/^level:contains_common_case\("err","eror","error"\)$/);
+  it('buildLevelAliasClause builds the contains_common_case clause with Title-Case aliases', () => {
+    // Title-Case arguments make contains_common_case match lowercase, UPPERCASE
+    // and Title-Case field values (e.g. `error`, `ERROR`, `Error`)
+    expect(buildLevelAliasClause(LogLevel.error)).toMatch(/^level:contains_common_case\("Err","Eror","Error"\)$/);
   });
 
   it('usableLevelRules drops draft rules with an empty field', () => {
     const draft = { field: '', operator: LogLevelRuleType.Equals, value: 'x', level: LogLevel.error, enabled: true };
     const real = { field: '_msg', operator: LogLevelRuleType.Equals, value: 'x', level: LogLevel.error, enabled: true };
     expect(usableLevelRules([draft, real])).toEqual([real]);
+  });
+
+  it('builds case-insensitive rules as equals_common_case with a Title-Case value', () => {
+    const rules = [
+      { field: 'severity_text', operator: LogLevelRuleType.CaseInsensitiveEquals, value: 'info', level: LogLevel.info, enabled: true },
+    ];
+    expect(buildLevelExprMap(rules)[LogLevel.info]).toContain('severity_text:equals_common_case("Info")');
   });
 });
 
@@ -97,7 +106,7 @@ describe('buildExactLevelExprMap', () => {
   it('guards the alias clause with the negation of earlier levels in canonical order', () => {
     const map = buildExactLevelExprMap([loadedError]);
     expect(map[LogLevel.critical].startsWith('level:contains_common_case(')).toBe(true);
-    expect(map[LogLevel.error]).toContain('(level:contains_common_case("err","eror","error") and !(level:contains_common_case(');
+    expect(map[LogLevel.error]).toContain('(level:contains_common_case("Err","Eror","Error") and !(level:contains_common_case(');
   });
 
   it('guards the rules section with the negation of every alias clause', () => {
@@ -112,14 +121,14 @@ describe('buildExactLevelExprMap', () => {
   it('unknown covers the unknown alias, unknown-level rules, and rows matching no rule', () => {
     const noiseUnknown = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'noise', level: LogLevel.unknown, enabled: true };
     const map = buildExactLevelExprMap([loadedError, noiseUnknown]);
-    expect(map[LogLevel.unknown]).toContain('level:contains_common_case("unknown")');
+    expect(map[LogLevel.unknown]).toContain('level:contains_common_case("Unknown")');
     expect(map[LogLevel.unknown]).toContain('(_msg:"noise" and !(_msg:"Loaded"))');
     expect(map[LogLevel.unknown]).toContain('!(_msg:"Loaded" OR _msg:"noise")');
   });
 
   it('with no rules a known level is its guarded alias clause and unknown catches everything else', () => {
     const map = buildExactLevelExprMap([]);
-    expect(map[LogLevel.critical]).toBe('level:contains_common_case("emerg","fatal","alert","crit","critical")');
+    expect(map[LogLevel.critical]).toBe('level:contains_common_case("Emerg","Fatal","Alert","Crit","Critical")');
     expect(map[LogLevel.info]).not.toContain(' and (');
     expect(map[LogLevel.unknown]).toMatch(/ OR !\(level:contains_common_case\(/);
   });

--- a/src/utils/query/levelExpansion.test.ts
+++ b/src/utils/query/levelExpansion.test.ts
@@ -129,4 +129,30 @@ describe('buildExactLevelExprMap', () => {
     const map = buildExactLevelExprMap([draft]);
     expect(map[LogLevel.error]).not.toContain(':"x"');
   });
+
+  it('shares one guard between same-level rules instead of inlining it per rule', () => {
+    const infoX = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'X', level: LogLevel.info, enabled: true };
+    const warnA = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'A', level: LogLevel.warning, enabled: true };
+    const warnB = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'B', level: LogLevel.warning, enabled: true };
+    const map = buildExactLevelExprMap([infoX, warnA, warnB]);
+    expect(map[LogLevel.warning]).toContain('((_msg:"A" OR _msg:"B") and !(_msg:"X"))');
+    // The guard is factored out once — the expression stays linear in the rule count
+    expect((map[LogLevel.warning].match(/_msg:"X"/g) ?? []).length).toBe(1);
+  });
+
+  it('nests guards when other-level rules interleave own rules', () => {
+    const warnA = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'A', level: LogLevel.warning, enabled: true };
+    const infoX = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'X', level: LogLevel.info, enabled: true };
+    const warnB = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'B', level: LogLevel.warning, enabled: true };
+    const map = buildExactLevelExprMap([warnA, infoX, warnB]);
+    expect(map[LogLevel.warning]).toContain('_msg:"A" OR (_msg:"B" and !(_msg:"X"))');
+  });
+
+  it('ignores other-level rules placed after the last own rule', () => {
+    const warnA = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'A', level: LogLevel.warning, enabled: true };
+    const infoX = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'X', level: LogLevel.info, enabled: true };
+    const map = buildExactLevelExprMap([warnA, infoX]);
+    expect(map[LogLevel.warning]).toContain('_msg:"A"');
+    expect(map[LogLevel.warning]).not.toContain('_msg:"A" and');
+  });
 });

--- a/src/utils/query/levelExpansion.test.ts
+++ b/src/utils/query/levelExpansion.test.ts
@@ -78,11 +78,11 @@ describe('shared level primitives', () => {
     expect(usableLevelRules([draft, real])).toEqual([real]);
   });
 
-  it('builds case-insensitive rules as equals_common_case with a Title-Case value', () => {
+  it('builds case-insensitive rules as contains_common_case with a Title-Case value', () => {
     const rules = [
       { field: 'severity_text', operator: LogLevelRuleType.CaseInsensitiveEquals, value: 'info', level: LogLevel.info, enabled: true },
     ];
-    expect(buildLevelExprMap(rules)[LogLevel.info]).toContain('severity_text:equals_common_case("Info")');
+    expect(buildLevelExprMap(rules)[LogLevel.info]).toContain('severity_text:contains_common_case("Info")');
   });
 });
 

--- a/src/utils/query/levelExpansion.test.ts
+++ b/src/utils/query/levelExpansion.test.ts
@@ -153,6 +153,6 @@ describe('buildExactLevelExprMap', () => {
     const infoX = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'X', level: LogLevel.info, enabled: true };
     const map = buildExactLevelExprMap([warnA, infoX]);
     expect(map[LogLevel.warning]).toContain('_msg:"A"');
-    expect(map[LogLevel.warning]).not.toContain('_msg:"A" and');
+    expect(map[LogLevel.warning]).not.toContain('_msg:"X"');
   });
 });

--- a/src/utils/query/levelExpansion.ts
+++ b/src/utils/query/levelExpansion.ts
@@ -16,13 +16,32 @@ export interface LevelExpr {
 }
 
 /**
+ * Builds the `level:contains_common_case(...)` clause matching the canonical
+ * alias values of the given level (shared by filter expansion and format pipes)
+ */
+export function buildLevelAliasClause(level: UniqLogLevelKeys): string {
+  const values = possibleLogValueByLevelType[level].map((value) => `"${value}"`).join(',');
+  return `level:contains_common_case(${values})`;
+}
+
+/**
+ * Drops draft rules with an empty field — they would produce an unparsable
+ * `:"value"` condition (shared by filter expansion and format pipes)
+ */
+export function usableLevelRules(rules: LogLevelRule[]): LogLevelRule[] {
+  return rules.filter((rule) => rule.field);
+}
+
+const buildRuleExpr = (rule: LogLevelRule): string => OperatorLabelsQueryBuilder[rule.operator](rule);
+
+/**
  * Builds the LogsQL expression for each log level from the given rules.
  * Pure (no React). Callers pass already-filtered (active) rules.
  * Known levels: `level:contains_common_case(<values>) OR <rule exprs>`.
  * The last entry is `unknown` = `!(<all known levels OR'd>)`.
  */
 export function buildLevelExprs(rules: LogLevelRule[]): LevelExpr[] {
-  const groupedByLevelRules = groupBy(rules, 'level');
+  const groupedByLevelRules = groupBy(usableLevelRules(rules), 'level');
   const levelFilters = Object.values(UNIQ_LOG_LEVEL)
     // `unknown` is handled separately below as the negation of all known levels and has no `possibleLogValueByLevelType` expansion of its own.
     .filter((val) => val !== LogLevel.unknown)
@@ -31,13 +50,10 @@ export function buildLevelExprs(rules: LogLevelRule[]): LevelExpr[] {
       return acc;
     }, {} as Record<UniqLogLevelKeys, LogLevelRule[]>);
 
-  const buildRuleExpr = (rule: LogLevelRule) => OperatorLabelsQueryBuilder[rule.operator](rule);
-
   const result: LevelExpr[] = Object.entries(levelFilters).map(([ruleLevel, levelRules]) => {
     const levelKey = ruleLevel as UniqLogLevelKeys;
     const ruleExprs = levelRules.map(buildRuleExpr);
-    const possibleLevelValues = possibleLogValueByLevelType[levelKey].map((value) => `"${value}"`).join(',');
-    const levelExpr = `level:contains_common_case(${possibleLevelValues})`;
+    const levelExpr = buildLevelAliasClause(levelKey);
     return { level: levelKey, expr: [levelExpr, ...ruleExprs].join(' OR ') };
   });
 
@@ -52,6 +68,61 @@ export function buildLevelExprs(rules: LogLevelRule[]): LevelExpr[] {
 export function buildLevelExprMap(rules: LogLevelRule[]): Record<string, string> {
   return buildLevelExprs(rules).reduce<Record<string, string>>((acc, { level, expr }) => {
     acc[level] = expr;
+    return acc;
+  }, {});
+}
+
+// Canonical level order — must match the format-pipe emission order in levelFormatPipes.ts
+const LEVEL_ORDER = Object.values(UNIQ_LOG_LEVEL);
+
+/**
+ * Builds an EXACT per-level LogsQL expression reproducing the classifier's
+ * first-match-wins semantics (extractLevelFromLabels / buildLevelFormatPipes):
+ * a valid `level` field value claims the row first (in canonical level order),
+ * then rules apply in list order — a rule claims a row only when no earlier
+ * rule of a DIFFERENT level matches it (earlier same-level rules yield the
+ * same level, so they need no guard). Rows matching nothing are `unknown`.
+ * The per-level sets are disjoint, so entries can be OR-combined safely.
+ */
+export function buildExactLevelExprMap(rules: LogLevelRule[]): Record<string, string> {
+  const usable = usableLevelRules(rules);
+  const ruleExprs = usable.map(buildRuleExpr);
+  const anyAlias = LEVEL_ORDER.map(buildLevelAliasClause).join(' OR ');
+
+  return LEVEL_ORDER.reduce<Record<string, string>>((acc, level, levelIdx) => {
+    const parts: string[] = [];
+
+    const earlierAliases = LEVEL_ORDER.slice(0, levelIdx).map(buildLevelAliasClause);
+    parts.push(
+      earlierAliases.length
+        ? `(${buildLevelAliasClause(level)} and !(${earlierAliases.join(' OR ')}))`
+        : buildLevelAliasClause(level)
+    );
+
+    const ruleParts = usable
+      .map((rule, index) => ({ rule, index }))
+      .filter(({ rule }) => rule.level === level)
+      .map(({ rule, index }) => {
+        const earlierOtherLevel = usable
+          .slice(0, index)
+          .filter((earlier) => earlier.level !== level)
+          .map(buildRuleExpr);
+        const own = buildRuleExpr(rule);
+        return earlierOtherLevel.length ? `(${own} and !(${earlierOtherLevel.join(' OR ')}))` : own;
+      });
+
+    if (level === LogLevel.unknown && usable.length) {
+      // Rows matching no rule at all also classify as unknown
+      ruleParts.push(`!(${ruleExprs.join(' OR ')})`);
+    }
+
+    if (level === LogLevel.unknown && !usable.length) {
+      parts.push(`!(${anyAlias})`);
+    } else if (ruleParts.length) {
+      parts.push(`(!(${anyAlias}) and (${ruleParts.join(' OR ')}))`);
+    }
+
+    acc[level] = parts.join(' OR ');
     return acc;
   }, {});
 }

--- a/src/utils/query/levelExpansion.ts
+++ b/src/utils/query/levelExpansion.ts
@@ -9,6 +9,7 @@ import {
   UniqLogLevelKeys,
 } from '../../configuration/LogLevelRules/const';
 import { LogLevelRule } from '../../configuration/LogLevelRules/types';
+import { capitalize } from '../string';
 
 export interface LevelExpr {
   level: UniqLogLevelKeys;
@@ -17,10 +18,13 @@ export interface LevelExpr {
 
 /**
  * Builds the `level:contains_common_case(...)` clause matching the canonical
- * alias values of the given level (shared by filter expansion and format pipes)
+ * alias values of the given level (shared by filter expansion and format pipes).
+ * Arguments are Title-Cased so lowercase, UPPERCASE and Title-Case field values
+ * all match — the client-side matcher lowercases the field value and would
+ * otherwise disagree with the server on values like `Error`
  */
 export function buildLevelAliasClause(level: UniqLogLevelKeys): string {
-  const values = possibleLogValueByLevelType[level].map((value) => `"${value}"`).join(',');
+  const values = possibleLogValueByLevelType[level].map((value) => `"${capitalize(value)}"`).join(',');
   return `level:contains_common_case(${values})`;
 }
 

--- a/src/utils/query/levelExpansion.ts
+++ b/src/utils/query/levelExpansion.ts
@@ -76,6 +76,51 @@ export function buildLevelExprMap(rules: LogLevelRule[]): Record<string, string>
 const LEVEL_ORDER = Object.values(UNIQ_LOG_LEVEL);
 
 /**
+ * Builds the expression claiming rows for `level` via its rules, guarded by the
+ * first-match-wins semantics: a rule claims a row only when no EARLIER rule of a
+ * different level matches it. Instead of inlining the full guard per rule (which
+ * grows quadratically with the rule count), guards are factored into a nested
+ * chain — `own1 OR (own2 and !(earlier others))` — built back-to-front, so every
+ * rule expression appears exactly once and the result stays linear in size.
+ * Returns null when the level has no rules.
+ */
+const buildGuardedRuleChain = (rules: LogLevelRule[], level: UniqLogLevelKeys): string | null => {
+  let chain: string | null = null;
+  // `and` binds tighter than `OR` in LogsQL — an OR chain must be parenthesized before guarding
+  let chainHasTopLevelOr = false;
+  // Other-level rules seen between the current position and the next own rule
+  let pendingGuards: string[] = [];
+
+  const guardChain = () => {
+    if (chain !== null && pendingGuards.length) {
+      const guarded = chainHasTopLevelOr ? `(${chain})` : chain;
+      chain = `(${guarded} and !(${pendingGuards.join(' OR ')}))`;
+      chainHasTopLevelOr = false;
+    }
+  };
+
+  for (let i = rules.length - 1; i >= 0; i--) {
+    const rule = rules[i];
+    if (rule.level !== level) {
+      pendingGuards.unshift(buildRuleExpr(rule));
+      continue;
+    }
+    guardChain();
+    // Rules after the LAST own rule guard nothing for this level — drop them
+    pendingGuards = [];
+    if (chain === null) {
+      chain = buildRuleExpr(rule);
+    } else {
+      chain = `${buildRuleExpr(rule)} OR ${chain}`;
+      chainHasTopLevelOr = true;
+    }
+  }
+
+  guardChain();
+  return chain;
+};
+
+/**
  * Builds an EXACT per-level LogsQL expression reproducing the classifier's
  * first-match-wins semantics (extractLevelFromLabels / buildLevelFormatPipes):
  * a valid `level` field value claims the row first (in canonical level order),
@@ -99,17 +144,8 @@ export function buildExactLevelExprMap(rules: LogLevelRule[]): Record<string, st
         : buildLevelAliasClause(level)
     );
 
-    const ruleParts = usable
-      .map((rule, index) => ({ rule, index }))
-      .filter(({ rule }) => rule.level === level)
-      .map(({ rule, index }) => {
-        const earlierOtherLevel = usable
-          .slice(0, index)
-          .filter((earlier) => earlier.level !== level)
-          .map(buildRuleExpr);
-        const own = buildRuleExpr(rule);
-        return earlierOtherLevel.length ? `(${own} and !(${earlierOtherLevel.join(' OR ')}))` : own;
-      });
+    const ruleChain = buildGuardedRuleChain(usable, level);
+    const ruleParts = ruleChain === null ? [] : [ruleChain];
 
     if (level === LogLevel.unknown && usable.length) {
       // Rows matching no rule at all also classify as unknown

--- a/src/utils/query/levelFormatPipes.test.ts
+++ b/src/utils/query/levelFormatPipes.test.ts
@@ -1,0 +1,79 @@
+import { LogLevel } from '@grafana/data';
+
+import { LogLevelRuleType } from '../../configuration/LogLevelRules/types';
+
+import { buildLevelFormatPipes, DERIVED_LEVEL_FIELD, parseDerivedLevel } from './levelFormatPipes';
+
+const errorRule = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'error', level: LogLevel.error, enabled: true };
+const warnRule = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'warn', level: LogLevel.warning, enabled: true };
+
+describe('buildLevelFormatPipes', () => {
+  it('returns an empty string when there are no rules', () => {
+    expect(buildLevelFormatPipes([])).toBe('');
+  });
+
+  it('starts with the unconditional reset pipe', () => {
+    expect(buildLevelFormatPipes([errorRule]).startsWith(` | format "" as ${DERIVED_LEVEL_FIELD}`)).toBe(true);
+  });
+
+  it('guards every conditional pipe with an empty check on the derived field', () => {
+    const pipes = buildLevelFormatPipes([errorRule, warnRule]);
+    const conditional = pipes.split(' | ').filter((p) => p.startsWith('format if'));
+    expect(conditional.length).toBeGreaterThan(0);
+    conditional.forEach((p) => expect(p).toContain(`and ${DERIVED_LEVEL_FIELD}:""`));
+  });
+
+  it('emits level-field pipes (including unknown) before rule pipes', () => {
+    const pipes = buildLevelFormatPipes([errorRule]);
+    const levelPipeIdx = pipes.indexOf('level:contains_common_case');
+    const rulePipeIdx = pipes.indexOf('_msg:"error"');
+    expect(levelPipeIdx).toBeGreaterThan(-1);
+    expect(rulePipeIdx).toBeGreaterThan(levelPipeIdx);
+    expect(pipes).toContain(`"unknown" as ${DERIVED_LEVEL_FIELD}`);
+  });
+
+  it('keeps rule pipes in rule-list order (first-match-wins)', () => {
+    const pipes = buildLevelFormatPipes([warnRule, errorRule]);
+    expect(pipes.indexOf('_msg:"warn"')).toBeLessThan(pipes.indexOf('_msg:"error"'));
+  });
+
+  it('emits pipes for rules targeting the unknown level', () => {
+    const unknownRule = { field: '_msg', operator: LogLevelRuleType.WordFilter, value: 'noise', level: LogLevel.unknown, enabled: true };
+    const pipes = buildLevelFormatPipes([unknownRule]);
+    expect(pipes).toContain(`if ((_msg:"noise") and ${DERIVED_LEVEL_FIELD}:"") "unknown"`);
+  });
+
+  it('escapes quotes and backslashes in rule values', () => {
+    const trickyRule = { field: '_msg', operator: LogLevelRuleType.Equals, value: 'a"b\\c', level: LogLevel.error, enabled: true };
+    expect(buildLevelFormatPipes([trickyRule])).toContain('_msg:"a\\"b\\\\c"');
+  });
+
+  it('skips rules with an empty field (draft rows from the rule editor)', () => {
+    const draftRule = { field: '', operator: LogLevelRuleType.Equals, value: 'x', level: LogLevel.error, enabled: true };
+    const pipes = buildLevelFormatPipes([draftRule, errorRule]);
+    expect(pipes).not.toContain(':"x"');
+    expect(pipes).toContain('_msg:"error"');
+  });
+
+  it('returns an empty string when all rules have an empty field', () => {
+    const draftRule = { field: '', operator: LogLevelRuleType.Equals, value: 'x', level: LogLevel.error, enabled: true };
+    expect(buildLevelFormatPipes([draftRule])).toBe('');
+  });
+});
+
+describe('parseDerivedLevel', () => {
+  it.each(['critical', 'error', 'warning', 'info', 'debug', 'trace', 'unknown'])(
+    'maps canonical value %s to itself',
+    (value) => {
+      expect(parseDerivedLevel(value)).toBe(value);
+    }
+  );
+
+  it('maps an empty string to unknown (no pipe matched)', () => {
+    expect(parseDerivedLevel('')).toBe(LogLevel.unknown);
+  });
+
+  it('maps a foreign value to unknown', () => {
+    expect(parseDerivedLevel('sev1')).toBe(LogLevel.unknown);
+  });
+});

--- a/src/utils/query/levelFormatPipes.test.ts
+++ b/src/utils/query/levelFormatPipes.test.ts
@@ -45,7 +45,7 @@ describe('buildLevelFormatPipes', () => {
 
   it('escapes quotes and backslashes in rule values', () => {
     const trickyRule = { field: '_msg', operator: LogLevelRuleType.Equals, value: 'a"b\\c', level: LogLevel.error, enabled: true };
-    expect(buildLevelFormatPipes([trickyRule])).toContain('_msg:"a\\"b\\\\c"');
+    expect(buildLevelFormatPipes([trickyRule])).toContain('_msg:="a\\"b\\\\c"');
   });
 
   it('skips rules with an empty field (draft rows from the rule editor)', () => {

--- a/src/utils/query/levelFormatPipes.ts
+++ b/src/utils/query/levelFormatPipes.ts
@@ -1,0 +1,49 @@
+import { LogLevel } from '@grafana/data';
+
+import { OperatorLabelsQueryBuilder, UNIQ_LOG_LEVEL } from '../../configuration/LogLevelRules/const';
+import { LogLevelRule } from '../../configuration/LogLevelRules/types';
+
+import { buildLevelAliasClause, usableLevelRules } from './levelExpansion';
+
+/**
+ * Field name derived by the generated `format` pipes; unique enough to avoid
+ * clashing with real ingested fields or user pipes
+ */
+export const DERIVED_LEVEL_FIELD = '__vl_ds_level';
+
+const derivedLevelValues = new Set<string>(Object.values(UNIQ_LOG_LEVEL));
+
+const guardedFormatPipe = (condition: string, level: string): string =>
+  `format if ((${condition}) and ${DERIVED_LEVEL_FIELD}:"") "${level}" as ${DERIVED_LEVEL_FIELD}`;
+
+/**
+ * Builds conditional `format` pipes that derive the log level server-side.
+ * Pipe order mirrors the client matcher (`extractLevelFromLabels`): a valid
+ * `level` field value wins first, then rules apply in list order. Each pipe is
+ * guarded with `and __vl_ds_level:""` to keep first-match-wins semantics under
+ * last-write-wins `format` pipes. Returns an empty string when no rules exist,
+ * so callers keep the lightweight `field=level` request.
+ */
+export function buildLevelFormatPipes(rules: LogLevelRule[]): string {
+  const usableRules = usableLevelRules(rules);
+  if (!usableRules.length) {
+    return '';
+  }
+
+  const resetPipe = `format "" as ${DERIVED_LEVEL_FIELD}`;
+
+  const levelFieldPipes = Object.values(UNIQ_LOG_LEVEL).map((level) =>
+    guardedFormatPipe(buildLevelAliasClause(level), level)
+  );
+
+  const rulePipes = usableRules.map((rule) => guardedFormatPipe(OperatorLabelsQueryBuilder[rule.operator](rule), rule.level));
+
+  return [resetPipe, ...levelFieldPipes, ...rulePipes].map((pipe) => ` | ${pipe}`).join('');
+}
+
+/**
+ * Maps a derived level label value back to a LogLevel; empty or foreign values become unknown
+ */
+export function parseDerivedLevel(value: string): LogLevel {
+  return derivedLevelValues.has(value) ? (value as LogLevel) : LogLevel.unknown;
+}

--- a/src/utils/query/logsqlEscape.test.ts
+++ b/src/utils/query/logsqlEscape.test.ts
@@ -8,6 +8,10 @@ describe('escapeLogsQLQuotedValue', () => {
   it('returns plain values unchanged', () => {
     expect(escapeLogsQLQuotedValue('nginx')).toBe('nginx');
   });
+
+  it('escapes newlines so the literal stays valid Go-style syntax', () => {
+    expect(escapeLogsQLQuotedValue('a\nb')).toBe('a\\nb');
+  });
 });
 
 describe('quoteLogsQLValue', () => {

--- a/src/utils/query/logsqlEscape.test.ts
+++ b/src/utils/query/logsqlEscape.test.ts
@@ -12,6 +12,10 @@ describe('escapeLogsQLQuotedValue', () => {
   it('escapes newlines so the literal stays valid Go-style syntax', () => {
     expect(escapeLogsQLQuotedValue('a\nb')).toBe('a\\nb');
   });
+
+  it('converts numbers to strings', () => {
+    expect(escapeLogsQLQuotedValue(42)).toBe('42');
+  });
 });
 
 describe('quoteLogsQLValue', () => {

--- a/src/utils/query/logsqlEscape.test.ts
+++ b/src/utils/query/logsqlEscape.test.ts
@@ -1,4 +1,4 @@
-import { escapeLogsQLQuotedValue, quoteLogsQLValue } from './logsqlEscape';
+import { escapeLogsQLQuotedValue, quoteLogsQLFieldName, quoteLogsQLValue } from './logsqlEscape';
 
 describe('escapeLogsQLQuotedValue', () => {
   it('escapes backslashes, newlines and double quotes', () => {
@@ -21,5 +21,20 @@ describe('escapeLogsQLQuotedValue', () => {
 describe('quoteLogsQLValue', () => {
   it('wraps the escaped value in double quotes', () => {
     expect(quoteLogsQLValue('a"b')).toBe('"a\\"b"');
+  });
+});
+
+describe('quoteLogsQLFieldName', () => {
+  it('returns plain field names unchanged', () => {
+    expect(quoteLogsQLFieldName('kubernetes.pod_name1')).toBe('kubernetes.pod_name1');
+  });
+
+  it('quotes field names with special characters', () => {
+    expect(quoteLogsQLFieldName('log:level')).toBe('"log:level"');
+    expect(quoteLogsQLFieldName('field name')).toBe('"field name"');
+  });
+
+  it('quotes an empty field name', () => {
+    expect(quoteLogsQLFieldName('')).toBe('""');
   });
 });

--- a/src/utils/query/logsqlEscape.ts
+++ b/src/utils/query/logsqlEscape.ts
@@ -4,11 +4,11 @@
  * string literal cannot contain a raw line break, and VictoriaLogs rejects
  * the whole query on one
  */
-export function escapeLogsQLQuotedValue(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"');
+export function escapeLogsQLQuotedValue(value: string | number): string {
+  return String(value).replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"');
 }
 
 /** Wraps a raw value in double quotes, escaping it for LogsQL */
-export function quoteLogsQLValue(value: string): string {
+export function quoteLogsQLValue(value: string | number): string {
   return `"${escapeLogsQLQuotedValue(value)}"`;
 }

--- a/src/utils/query/logsqlEscape.ts
+++ b/src/utils/query/logsqlEscape.ts
@@ -12,3 +12,12 @@ export function escapeLogsQLQuotedValue(value: string | number): string {
 export function quoteLogsQLValue(value: string | number): string {
   return `"${escapeLogsQLQuotedValue(value)}"`;
 }
+
+/**
+ * Quotes a LogsQL field name when it contains characters that would clash with
+ * the query syntax (e.g. `log:level` would otherwise parse as field `log`).
+ * Plain names of letters, digits, `_` and `.` are returned as-is
+ */
+export function quoteLogsQLFieldName(field: string): string {
+  return /^[a-zA-Z0-9_.]+$/.test(field) ? field : quoteLogsQLValue(field);
+}

--- a/src/utils/string/capitalize/capitalize.test.ts
+++ b/src/utils/string/capitalize/capitalize.test.ts
@@ -1,0 +1,17 @@
+import { capitalize } from './capitalize';
+
+describe('capitalize', () => {
+  it('capitalizes the first letter of a lowercase string', () => {
+    expect(capitalize('info')).toBe('Info');
+  });
+
+  it('keeps already-capitalized and non-letter strings unchanged', () => {
+    expect(capitalize('INFO')).toBe('INFO');
+    expect(capitalize('42')).toBe('42');
+    expect(capitalize('')).toBe('');
+  });
+
+  it('does not touch letters after the first one', () => {
+    expect(capitalize('vICTORIA')).toBe('VICTORIA');
+  });
+});

--- a/src/utils/string/capitalize/capitalize.ts
+++ b/src/utils/string/capitalize/capitalize.ts
@@ -1,0 +1,4 @@
+/** Capitalizes the first letter of a string, leaving the rest unchanged */
+export function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -1,2 +1,3 @@
+export { capitalize } from './capitalize/capitalize';
 export { hashString } from './hashString/hashString';
 export { skipBalanced } from './skipBalanced/skipBalanced';


### PR DESCRIPTION
Related issue: #700 

### Describe Your Changes

- Build conditional `format if` pipes from log level rules so /select/logsql/hits groups by a single derived field instead of every rule field — a `_msg` rule no longer produces a series per unique message value (#700)
- Strip any trailing sort pipe from the hits expression: VictoriaLogs hits returns empty values for fields created by pipes placed after `sort`, which would collapse the histogram into `unknown`
- Expand level chips with exact first-match-wins expressions (buildExactLevelExprMap) so chip filters select exactly the rows the histogram counted into each level
- Escape `"` and `\` in rule values interpolated into LogsQL (logsqlEscape), shared by filters and format pipes

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
