### PR TITLE
fix(logs): deduplicate log row ids to stop lines overlapping (#706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * BUGFIX: interpolate dashboard variables into the query builder state and stream filter values when jumping from a dashboard panel to Explore. Previously, the raw variable names (e.g., `$app`) leaked back into the query on the first editor interaction, and the query returned no results.
 * BUGFIX: pass the panel time range to the `Instant` (stats) query type via the `start`/`end` query parameters instead of prepending a `_time:[...]` filter to the query text. The prepended filter was not parenthesized, so a top-level `OR` (e.g. `level:error OR level:warn | stats count()`) left part of the query outside the time range, making VictoriaLogs scan the full retention and the panel time out. Thanks to @github-vincent-miszczak for contributing.
 * BUGFIX: increase the default line limit for log queries from 50 to 1000. If your logs are large or expensive to render, set a lower limit in the datasource settings or via provisioning - see [Line limits](https://docs.victoriametrics.com/victorialogs/integrations/grafana/#line-limits).
+* BUGFIX: fix log lines overlapping each other in the logs panel after re-running a query, which happened in Grafana Explore when the results contained identical log lines. See [#706](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/706).
 
 ## v0.30.1
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -363,7 +363,7 @@ func (di *DatasourceInstance) streamQuery(ctx context.Context, request *backend.
 		}
 	}()
 
-	return parseStreamResponse(r, livestream)
+	return parseStreamResponse(newLogReader(r), livestream)
 }
 
 // getQueryFromRaw parses the query json from the raw message.
@@ -471,7 +471,7 @@ func (di *DatasourceInstance) query(ctx context.Context, q *Query) backend.DataR
 	case QueryTypeHits:
 		return parseHitsResponse(r)
 	default:
-		return parseInstantResponse(r)
+		return parseInstantResponse(newLogReader(r))
 	}
 }
 

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -194,13 +194,15 @@ func TestDatasourceQueryRequest(t *testing.T) {
 		}
 		timeFd.Append(ts)
 
-		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`))
+		lblRaw := `{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`
+		labelsField.Append(json.RawMessage(lblRaw))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
 			[]byte(tsRaw),
 			[]byte(lineRaw),
 			nil,
+			[]byte(lblRaw),
 		))
 		streamsField, streamIdField := newHiddenStreamFields(
 			[]string{""},
@@ -284,13 +286,15 @@ func TestDatasourceQueryRequest(t *testing.T) {
 		lineRaw := "123"
 		lineField.Append(lineRaw)
 
-		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`))
+		lblRaw := `{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`
+		labelsField.Append(json.RawMessage(lblRaw))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
 			[]byte(tsRaw),
 			[]byte(lineRaw),
 			nil,
+			[]byte(lblRaw),
 		))
 		streamsField, streamIdField := newHiddenStreamFields(
 			[]string{""},
@@ -589,13 +593,15 @@ func TestDatasourceStreamQueryRequest(t *testing.T) {
 		lineRaw := "123"
 		lineField.Append(lineRaw)
 
-		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`))
+		lblRaw := `{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`
+		labelsField.Append(json.RawMessage(lblRaw))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
 			[]byte(tsRaw),
 			[]byte(lineRaw),
 			nil,
+			[]byte(lblRaw),
 		))
 		streamsField, streamIdField := newHiddenStreamFields(
 			[]string{""},
@@ -652,13 +658,15 @@ func TestDatasourceStreamQueryRequest(t *testing.T) {
 		lineRaw := "123"
 		lineField.Append(lineRaw)
 
-		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`))
+		lblRaw := `{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`
+		labelsField.Append(json.RawMessage(lblRaw))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
 			[]byte(tsRaw),
 			[]byte(lineRaw),
 			nil,
+			[]byte(lblRaw),
 		))
 		streamsField, streamIdField := newHiddenStreamFields(
 			[]string{""},
@@ -990,13 +998,15 @@ func TestDatasourceStreamRequestWithRetry(t *testing.T) {
 		lineRaw := "123"
 		lineField.Append(lineRaw)
 
-		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`))
+		lblRaw := `{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`
+		labelsField.Append(json.RawMessage(lblRaw))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
 			[]byte(tsRaw),
 			[]byte(lineRaw),
 			nil,
+			[]byte(lblRaw),
 		))
 		streamsField, streamIdField := newHiddenStreamFields(
 			[]string{""},
@@ -1053,13 +1063,15 @@ func TestDatasourceStreamRequestWithRetry(t *testing.T) {
 		lineRaw := "123"
 		lineField.Append(lineRaw)
 
-		labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`))
+		lblRaw := `{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`
+		labelsField.Append(json.RawMessage(lblRaw))
 		idField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 		idField.Name = gIDField
 		idField.Append(buildLogID(
 			[]byte(tsRaw),
 			[]byte(lineRaw),
 			nil,
+			[]byte(lblRaw),
 		))
 		streamsField, streamIdField := newHiddenStreamFields(
 			[]string{""},

--- a/pkg/plugin/log_reader.go
+++ b/pkg/plugin/log_reader.go
@@ -31,7 +31,7 @@ func newLogReader(reader io.Reader) *logReader {
 	}
 }
 
-func (lr *logReader) ReadRow() (logRow, error) {
+func (lr *logReader) readRow() (logRow, error) {
 	for {
 		b, err := lr.readLine()
 		if errors.Is(err, errLineTooLong) {

--- a/pkg/plugin/log_reader.go
+++ b/pkg/plugin/log_reader.go
@@ -1,0 +1,155 @@
+package plugin
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/VictoriaMetrics/victorialogs-datasource/pkg/utils"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/valyala/fastjson"
+)
+
+var errLineTooLong = errors.New("line too long")
+
+type logReader struct {
+	parser       fastjson.Parser
+	idb          *idBuilder
+	bufferReader *bufio.Reader
+	lineNum      int64
+}
+
+func newLogReader(reader io.Reader) *logReader {
+	bufferReader := bufio.NewReaderSize(reader, 64*1024)
+	return &logReader{
+		idb:          newIDBuilder(),
+		bufferReader: bufferReader,
+	}
+}
+
+func (lr *logReader) ReadRow() (logRow, error) {
+	for {
+		b, err := lr.readLine()
+		if errors.Is(err, errLineTooLong) {
+			backend.Logger.Debug("skipping line: line too long", "lineNumber", lr.lineNum)
+			continue
+		}
+		if err != nil {
+			return logRow{}, err
+		}
+		if len(bytes.TrimSpace(b)) == 0 {
+			continue
+		}
+		return lr.parseRow(b)
+	}
+}
+
+func (lr *logReader) readLine() ([]byte, error) {
+	lr.lineNum++
+	b, err := lr.bufferReader.ReadBytes('\n')
+	switch {
+	case err == nil:
+		return b, nil
+	case errors.Is(err, bufio.ErrBufferFull):
+		for errors.Is(err, bufio.ErrBufferFull) {
+			_, err = lr.bufferReader.ReadBytes('\n')
+		}
+		if err != nil && !errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("cannot read line in response: %w", err)
+		}
+		return nil, errLineTooLong
+	case errors.Is(err, io.EOF):
+		if len(b) > 0 {
+			return b, nil
+		}
+		return nil, io.EOF
+	default:
+		return nil, fmt.Errorf("cannot read line in response: %w", err)
+	}
+}
+
+// parseJsonLine trims, decodes and validates that the line is a JSON object.
+func (lr *logReader) parseJsonLine(b []byte) (*fastjson.Value, error) {
+	b = bytes.Trim(b, "\n")
+	value, err := lr.parser.ParseBytes(b)
+	if err != nil {
+		return nil, fmt.Errorf("error decode response: %s", err)
+	}
+	if value.Type() != fastjson.TypeObject {
+		return nil, fmt.Errorf("error get object from decoded response: value doesn't contain object; it contains %s", value.Type())
+	}
+	return value, nil
+}
+
+// getLogRow processes one parsed log object
+func (lr *logReader) getLogRow(value *fastjson.Value) (logRow, error) {
+	// Time field
+	var ts time.Time
+	rawTime := value.GetStringBytes(timeField)
+	if rawTime != nil {
+		t, err := utils.GetTime(string(rawTime))
+		if err != nil {
+			return logRow{}, fmt.Errorf("error parse time from _time field: %s", err)
+		}
+		ts = t
+	} else {
+		// No `_time` in the row: fall back to the zero time on purpose. Do NOT substitute
+		// nowFunc()/time.Now() here — a current timestamp looks plausible and would silently
+		// mislead the user into trusting a fabricated time. The zero time is an obvious signal
+		// that the timestamp is missing. In practice `_time` is always present for log queries.
+		ts = time.Time{}
+	}
+
+	rawStreamID := value.GetStringBytes(streamIdField)
+
+	// custom.metadata stream field
+	// parse `_stream` into a per-row label map for the log context UI and
+	var streamMap map[string]string
+	if value.Exists(streamField) {
+		rawStream := string(value.GetStringBytes(streamField))
+		stf, err := utils.ParseStreamFields(rawStream)
+		if err != nil {
+			return logRow{}, fmt.Errorf("error parse _stream field: %s", err)
+		}
+		streamMap = streamFieldsToMap(stf)
+	}
+
+	value.Del(timeField)
+
+	// Line field
+	rawMsg := value.GetStringBytes(messageField)
+	line := string(rawMsg)
+	value.Del(messageField)
+
+	// Labels field
+	labels := json.RawMessage(value.MarshalTo(nil))
+	// ID field
+	id := lr.idb.buildUniqLogID(rawTime, rawMsg, rawStreamID, labels)
+
+	return logRow{
+		Time:     ts,
+		Line:     line,
+		Labels:   labels,
+		StreamID: string(rawStreamID),
+		Stream:   streamMap,
+		ID:       id,
+	}, nil
+}
+
+func (lr *logReader) parseRow(data []byte) (logRow, error) {
+	value, err := lr.parseJsonLine(data)
+	if err != nil {
+		return logRow{}, err
+	}
+
+	row, err := lr.getLogRow(value)
+	if err != nil {
+		return logRow{}, err
+	}
+
+	return row, nil
+}

--- a/pkg/plugin/log_reader_test.go
+++ b/pkg/plugin/log_reader_test.go
@@ -1,0 +1,114 @@
+package plugin
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/VictoriaMetrics/victorialogs-datasource/pkg/utils"
+)
+
+func Test_logReader_parseRow(t *testing.T) {
+	lr := newLogReader(strings.NewReader(""))
+
+	line := `{"_time":"2024-02-20T14:04:27Z","_msg":"hello","_stream_id":"sid1","_stream":"{app=\"test\"}","foo":"bar"}`
+	row, err := lr.parseRow([]byte(line))
+	if err != nil {
+		t.Fatalf("parseRow() unexpected error: %s", err)
+	}
+
+	wantTime, err := utils.GetTime("2024-02-20T14:04:27Z")
+	if err != nil {
+		t.Fatalf("error parse expected time: %s", err)
+	}
+	if !row.Time.Equal(wantTime) {
+		t.Errorf("Time = %s, want %s", row.Time, wantTime)
+	}
+	if row.Line != "hello" {
+		t.Errorf("Line = %q, want %q", row.Line, "hello")
+	}
+	if row.StreamID != "sid1" {
+		t.Errorf("StreamID = %q, want %q", row.StreamID, "sid1")
+	}
+	if want := map[string]string{"app": "test"}; !reflect.DeepEqual(row.Stream, want) {
+		t.Errorf("Stream = %#v, want %#v", row.Stream, want)
+	}
+
+	// labels keep everything except the extracted _time/_msg fields
+	var labels map[string]string
+	if err := json.Unmarshal(row.Labels, &labels); err != nil {
+		t.Fatalf("error unmarshal labels: %s", err)
+	}
+	wantLabels := map[string]string{
+		"_stream_id": "sid1",
+		"_stream":    `{app="test"}`,
+		"foo":        "bar",
+	}
+	if !reflect.DeepEqual(labels, wantLabels) {
+		t.Errorf("Labels = %#v, want %#v", labels, wantLabels)
+	}
+
+	if want := buildLogID([]byte("2024-02-20T14:04:27Z"), []byte("hello"), []byte("sid1"), row.Labels); row.ID != want {
+		t.Errorf("ID = %s, want %s", row.ID, want)
+	}
+
+	// missing _time falls back to the zero time on purpose
+	row, err = lr.parseRow([]byte(`{"_msg":"no time"}`))
+	if err != nil {
+		t.Fatalf("parseRow() unexpected error: %s", err)
+	}
+	if !row.Time.IsZero() {
+		t.Errorf("Time = %s, want zero time for a row without _time", row.Time)
+	}
+}
+
+func Test_logReader_parseRow_errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		line    string
+		wantErr string
+	}{
+		{"invalid json", `abcd`, "error decode response"},
+		{"json is not an object", `[1,2]`, "value doesn't contain object"},
+		{"invalid _time", `{"_time":"acdf"}`, "error parse time from _time field"},
+		{"invalid _stream", `{"_time":"2024-02-20T14:04:27Z","_stream":"{hostname=}"}`, "error parse _stream field"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := newLogReader(strings.NewReader("")).parseRow([]byte(c.line))
+			if err == nil {
+				t.Fatalf("parseRow(%q) expected error, got nil", c.line)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("parseRow(%q) error = %q, want it to contain %q", c.line, err, c.wantErr)
+			}
+		})
+	}
+}
+
+func Test_logReader_parseRow_deduplicatesIDs(t *testing.T) {
+	line := []byte(`{"_time":"2024-02-20T14:04:27Z","_msg":"dup","_stream_id":"sid1"}`)
+
+	lr := newLogReader(strings.NewReader(""))
+	first, err := lr.parseRow(line)
+	if err != nil {
+		t.Fatalf("parseRow() unexpected error: %s", err)
+	}
+	second, err := lr.parseRow(line)
+	if err != nil {
+		t.Fatalf("parseRow() unexpected error: %s", err)
+	}
+	if want := first.ID + "_1"; second.ID != want {
+		t.Errorf("second identical row ID = %s, want %s", second.ID, want)
+	}
+
+	// the seen-id state is scoped to one reader: a fresh reader starts over
+	fresh, err := newLogReader(strings.NewReader("")).parseRow(line)
+	if err != nil {
+		t.Fatalf("parseRow() unexpected error: %s", err)
+	}
+	if fresh.ID != first.ID {
+		t.Errorf("fresh reader ID = %s, want %s", fresh.ID, first.ID)
+	}
+}

--- a/pkg/plugin/logid.go
+++ b/pkg/plugin/logid.go
@@ -1,0 +1,66 @@
+package plugin
+
+import (
+	"hash/fnv"
+	"strconv"
+)
+
+const (
+	idDeduperMaxSize = 100_000
+)
+
+// idBuilder builds unique log row ids: repeats of the same base id within one
+// response or stream session get an incrementing `_1`, `_2`, ... suffix.
+// Duplicate base ids are expected for identical rows (same time, message,
+// stream and fields), and Grafana's LogList breaks on duplicate row uids
+// (rows render on top of each other), so every emitted id must be unique.
+type idBuilder struct {
+	seen    map[string]int
+	maxSize int
+}
+
+func newIDBuilder() *idBuilder {
+	return &idBuilder{
+		seen:    make(map[string]int),
+		maxSize: idDeduperMaxSize,
+	}
+}
+
+// unique returns id for its first occurrence and id_N for the N-th repeat.
+// Suffixed ids cannot collide with base ids: base ids are hex digests and
+// never contain `_`. When a new id would grow the set beyond maxSize, the
+// set is reset first to keep memory bounded in long live-tail sessions.
+func (b *idBuilder) unique(id string) string {
+	n, ok := b.seen[id]
+	if !ok && len(b.seen) >= b.maxSize {
+		b.seen = make(map[string]int)
+	}
+	b.seen[id] = n + 1
+	if n == 0 {
+		return id
+	}
+	return id + "_" + strconv.Itoa(n)
+}
+
+// buildUniqLogID hashes the row fields into its base id and returns it
+// uniquified within this builder's session
+func (b *idBuilder) buildUniqLogID(ts, msg, streamId, labels []byte) string {
+	logID := buildLogID(ts, msg, streamId, labels)
+	return b.unique(logID)
+}
+
+// idSeparator delimits the fields hashed into a log id so that values can't
+// run together across field boundaries (e.g. "ab"+"cd" vs "a"+"bcd").
+var idSeparator = []byte{0}
+
+func buildLogID(ts, msg, streamId, labels []byte) string {
+	h := fnv.New64a()
+	_, _ = h.Write(ts)
+	_, _ = h.Write(idSeparator)
+	_, _ = h.Write(msg)
+	_, _ = h.Write(idSeparator)
+	_, _ = h.Write(streamId)
+	_, _ = h.Write(idSeparator)
+	_, _ = h.Write(labels)
+	return strconv.FormatUint(h.Sum64(), 16)
+}

--- a/pkg/plugin/logid_test.go
+++ b/pkg/plugin/logid_test.go
@@ -1,0 +1,84 @@
+package plugin
+
+import (
+	"testing"
+)
+
+func Test_buildLogID(t *testing.T) {
+	ts := []byte("2024-02-20T14:04:27Z")
+	labels := []byte(`{"foo":"bar"}`)
+
+	// stability: same input produces same id
+	id1 := buildLogID(ts, []byte("hello"), []byte(`{a="1"}`), labels)
+	id2 := buildLogID(ts, []byte("hello"), []byte(`{a="1"}`), labels)
+	if id1 != id2 {
+		t.Errorf("buildLogID is not stable: %s != %s", id1, id2)
+	}
+
+	// uniqueness: differing inputs produce different ids
+	cases := []struct {
+		name   string
+		ts     string
+		msg    string
+		stm    string
+		labels string
+	}{
+		{"baseline", "2024-02-20T14:04:27Z", "hello", `{a="1"}`, `{"foo":"bar"}`},
+		{"different time", "2024-02-20T14:04:27.000000001Z", "hello", `{a="1"}`, `{"foo":"bar"}`},
+		{"different msg", "2024-02-20T14:04:27Z", "hello!", `{a="1"}`, `{"foo":"bar"}`},
+		{"different stream", "2024-02-20T14:04:27Z", "hello", `{a="2"}`, `{"foo":"bar"}`},
+		{"different labels", "2024-02-20T14:04:27Z", "hello", `{a="1"}`, `{"foo":"baz"}`},
+	}
+	seen := make(map[string]string, len(cases))
+	for _, c := range cases {
+		id := buildLogID([]byte(c.ts), []byte(c.msg), []byte(c.stm), []byte(c.labels))
+		if prev, ok := seen[id]; ok {
+			t.Errorf("buildLogID collision between %q and %q -> %s", prev, c.name, id)
+		}
+		seen[id] = c.name
+	}
+
+	// boundary safety: prefix-shifted adjacent fields must not collide
+	a := buildLogID(ts, []byte("ab"), []byte("cd"), labels)
+	b := buildLogID(ts, []byte("a"), []byte("bcd"), labels)
+	if a == b {
+		t.Errorf("buildLogID collides across msg/stream boundary: %s", a)
+	}
+	a = buildLogID(ts, []byte("msg"), []byte("ab"), []byte("cd"))
+	b = buildLogID(ts, []byte("msg"), []byte("a"), []byte("bcd"))
+	if a == b {
+		t.Errorf("buildLogID collides across stream/labels boundary: %s", a)
+	}
+}
+
+func Test_idBuilder(t *testing.T) {
+	// repeats of the same base id get incrementing suffixes
+	b := newIDBuilder()
+	for i, want := range []string{"aaaa", "aaaa_1", "aaaa_2"} {
+		if got := b.unique("aaaa"); got != want {
+			t.Errorf("unique() call %d = %s, want %s", i+1, got, want)
+		}
+	}
+
+	// a different id keeps its own independent count
+	if got := b.unique("bbbb"); got != "bbbb" {
+		t.Errorf("unique(bbbb) = %s, want bbbb", got)
+	}
+
+	// separate builders do not share state
+	if got := newIDBuilder().unique("aaaa"); got != "aaaa" {
+		t.Errorf("fresh builder unique(aaaa) = %s, want aaaa", got)
+	}
+
+	// when a new id would grow the set beyond maxSize, the set resets first
+	// to keep memory bounded; counts collected so far are dropped by design
+	small := &idBuilder{seen: make(map[string]int), maxSize: 2}
+	small.unique("a")
+	small.unique("b")
+	if got := small.unique("c"); got != "c" {
+		t.Errorf("unique(c) after reset = %s, want c", got)
+	}
+	if got := small.unique("a"); got != "a" {
+		t.Errorf("unique(a) after reset = %s, want a (count dropped by reset)", got)
+	}
+}

--- a/pkg/plugin/response_logs.go
+++ b/pkg/plugin/response_logs.go
@@ -1,38 +1,15 @@
 package plugin
 
 import (
-	"bufio"
-	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"hash/fnv"
 	"io"
-	"strconv"
 	"time"
 
+	"github.com/VictoriaMetrics/victorialogs-datasource/pkg/utils"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/valyala/fastjson"
-
-	"github.com/VictoriaMetrics/victorialogs-datasource/pkg/utils"
 )
-
-// idSeparator delimits the fields hashed into a log id so that values can't
-// run together across field boundaries (e.g. "ab"+"cd" vs "a"+"bcd").
-var idSeparator = []byte{0}
-
-// buildLogID returns a stable identifier for a log row, used by Grafana's
-// Logs panel to enable per-row permalinks ("Copy shortlink").
-func buildLogID(ts, msg, streamId []byte) string {
-	h := fnv.New64a()
-	_, _ = h.Write(ts)
-	_, _ = h.Write(idSeparator)
-	_, _ = h.Write(msg)
-	_, _ = h.Write(idSeparator)
-	_, _ = h.Write(streamId)
-	return strconv.FormatUint(h.Sum64(), 16)
-}
 
 // streamFieldsToMap turns the parsed `_stream` fields into a label->value map
 // for the hidden `streams` field, consumed by the "Show context" stream label
@@ -43,6 +20,12 @@ func streamFieldsToMap(stf []utils.StreamField) map[string]string {
 		m[f.Label] = f.Value
 	}
 	return m
+}
+
+// hiddenFieldConfig hides a technical field from the log details, table and
+// other Grafana visualizations
+func hiddenFieldConfig() *data.FieldConfig {
+	return &data.FieldConfig{Custom: map[string]any{"hidden": true}}
 }
 
 type logRow struct {
@@ -56,28 +39,6 @@ type logRow struct {
 
 type logFrame struct {
 	dataFrame *data.Frame
-}
-
-// append adds a row to the frame
-func (b *logFrame) append(r logRow) {
-	// order of fields must match the order of fields in the frame
-	b.dataFrame.AppendRow(r.Time, r.Line, r.ID, r.Labels, streamToJSON(r.Stream), r.StreamID)
-}
-
-// streamToJSON encodes the per-row stream label map for the hidden `streams`
-// field; a row without a `_stream` field is kept as null
-func streamToJSON(stream map[string]string) *json.RawMessage {
-	if stream == nil {
-		return nil
-	}
-	b, _ := json.Marshal(stream)
-	return new(json.RawMessage(b))
-}
-
-// hiddenFieldConfig hides a technical field from the log details, table and
-// other Grafana visualizations
-func hiddenFieldConfig() *data.FieldConfig {
-	return &data.FieldConfig{Custom: map[string]any{"hidden": true}}
 }
 
 // newLogFrame creates a new frame with the necessary fields
@@ -102,124 +63,48 @@ func newLogFrame() *logFrame {
 	streamIdField.Name = gStreamIdField
 	streamIdField.Config = hiddenFieldConfig()
 
+	frame := data.NewFrame("", timeFd, lineField, idField, labelsField, streamsField, streamIdField)
+	frame.Meta = &data.FrameMeta{
+		PreferredVisualization: logsVisualisation,
+	}
+
 	return &logFrame{
-		dataFrame: data.NewFrame("", timeFd, lineField, idField, labelsField, streamsField, streamIdField),
+		dataFrame: frame,
 	}
 }
 
-// parseJsonLine trims, decodes and validates that the line is a JSON object.
-func parseJsonLine(parser *fastjson.Parser, b []byte) (*fastjson.Value, error) {
-	b = bytes.Trim(b, "\n")
-	value, err := parser.ParseBytes(b)
-	if err != nil {
-		return nil, fmt.Errorf("error decode response: %s", err)
-	}
-	if value.Type() != fastjson.TypeObject {
-		return nil, fmt.Errorf("error get object from decoded response: value doesn't contain object; it contains %s", value.Type())
-	}
-	return value, nil
+// append adds a row to the frame
+func (b *logFrame) append(r logRow) {
+	// order of fields must match the order of fields in the frame
+	b.dataFrame.AppendRow(r.Time, r.Line, r.ID, r.Labels, streamToJSON(r.Stream), r.StreamID)
 }
 
-// getLogRow processes one parsed log object
-func getLogRow(value *fastjson.Value) (logRow, error) {
-	// Time field
-	var ts time.Time
-	rawTime := value.GetStringBytes(timeField)
-	if rawTime != nil {
-		t, err := utils.GetTime(string(rawTime))
-		if err != nil {
-			return logRow{}, fmt.Errorf("error parse time from _time field: %s", err)
-		}
-		ts = t
-	} else {
-		// No `_time` in the row: fall back to the zero time on purpose. Do NOT substitute
-		// nowFunc()/time.Now() here — a current timestamp looks plausible and would silently
-		// mislead the user into trusting a fabricated time. The zero time is an obvious signal
-		// that the timestamp is missing. In practice `_time` is always present for log queries.
-		ts = time.Time{}
+// streamToJSON encodes the per-row stream label map for the hidden `streams`
+// field; a row without a `_stream` field is kept as null
+func streamToJSON(stream map[string]string) *json.RawMessage {
+	if stream == nil {
+		return nil
 	}
-
-	rawStreamID := value.GetStringBytes(streamIdField)
-
-	// custom.metadata stream field
-	// parse `_stream` into a per-row label map for the log context UI and
-	var streamMap map[string]string
-	if value.Exists(streamField) {
-		rawStream := string(value.GetStringBytes(streamField))
-		stf, err := utils.ParseStreamFields(rawStream)
-		if err != nil {
-			return logRow{}, fmt.Errorf("error parse _stream field: %s", err)
-		}
-		streamMap = streamFieldsToMap(stf)
-	}
-
-	value.Del(timeField)
-
-	// Line field
-	rawMsg := value.GetStringBytes(messageField)
-	line := string(rawMsg)
-	value.Del(messageField)
-
-	// Labels field
-	labels := json.RawMessage(value.MarshalTo(nil))
-	// ID field
-	id := buildLogID(rawTime, rawMsg, rawStreamID)
-
-	return logRow{
-		Time:     ts,
-		Line:     line,
-		Labels:   labels,
-		StreamID: string(rawStreamID),
-		Stream:   streamMap,
-		ID:       id,
-	}, nil
+	b, _ := json.Marshal(stream)
+	return new(json.RawMessage(b))
 }
 
 // parseInstantResponse reads data from the reader and collects
 // fields and frame with necessary information
-func parseInstantResponse(reader io.Reader) backend.DataResponse {
+func parseInstantResponse(lr *logReader) backend.DataResponse {
 	frame := newLogFrame()
-	br := bufio.NewReaderSize(reader, 64*1024)
-	var parser fastjson.Parser
-	var finishedReading bool
-	for n := 0; !finishedReading; n++ {
-		b, err := br.ReadBytes('\n')
-		if err != nil {
-			if errors.Is(err, bufio.ErrBufferFull) {
-				backend.Logger.Debug("skipping line number: line too long", "lineNumber", n)
-				continue
-			}
-			if errors.Is(err, io.EOF) {
-				// b can be != nil when EOF is returned, so we need to process it
-				finishedReading = true
-			} else {
-				return newResponseError(fmt.Errorf("cannot read line in response: %s", err), backend.StatusInternal)
-			}
+	for {
+		row, err := lr.ReadRow()
+		if errors.Is(err, io.EOF) {
+			break
 		}
-
-		if len(b) == 0 {
-			continue
-		}
-
-		value, err := parseJsonLine(&parser, b)
 		if err != nil {
 			return newResponseError(err, backend.StatusInternal)
 		}
-
-		row, err := getLogRow(value)
-		if err != nil {
-			return newResponseError(err, backend.StatusInternal)
-		}
-
 		frame.append(row)
 	}
-
 	rsp := backend.DataResponse{}
-	frame.dataFrame.Meta = &data.FrameMeta{
-		PreferredVisualization: logsVisualisation,
-	}
 	rsp.Frames = append(rsp.Frames, frame.dataFrame)
-
 	return rsp
 }
 
@@ -227,49 +112,17 @@ func parseInstantResponse(reader io.Reader) backend.DataResponse {
 // fields and frame with necessary information
 // it looks like the parseInstantResponse function, but it reads data and continuously
 // parse the lines from the reader and we need to collect only one data.Frame
-func parseStreamResponse(reader io.Reader, ch chan *data.Frame) error {
-	br := bufio.NewReaderSize(reader, 64*1024)
-	var parser fastjson.Parser
-	var finishedReading bool
-	for n := 0; !finishedReading; n++ {
+func parseStreamResponse(lr *logReader, ch chan *data.Frame) error {
+	for {
+		row, err := lr.ReadRow()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
 		frame := newLogFrame()
-
-		b, err := br.ReadBytes('\n')
-		if err != nil {
-			if errors.Is(err, bufio.ErrBufferFull) {
-				backend.Logger.Debug("skipping line number: line too long", "lineNumber", n)
-				continue
-			}
-			if errors.Is(err, io.EOF) {
-				// b can be != nil when EOF is returned, so we need to process it
-				finishedReading = true
-			} else {
-				return fmt.Errorf("cannot read line in response: %s", err)
-			}
-		}
-
-		if len(b) == 0 {
-			continue
-		}
-
-		value, err := parseJsonLine(&parser, b)
-		if err != nil {
-			return err
-		}
-
-		row, err := getLogRow(value)
-		if err != nil {
-			return err
-		}
-
 		frame.append(row)
-		// this is necessary information because the logs visualization is preferred
-		frame.dataFrame.Meta = &data.FrameMeta{
-			PreferredVisualization: logsVisualisation,
-		}
-
 		ch <- frame.dataFrame
 	}
-
-	return nil
 }

--- a/pkg/plugin/response_logs.go
+++ b/pkg/plugin/response_logs.go
@@ -94,7 +94,7 @@ func streamToJSON(stream map[string]string) *json.RawMessage {
 func parseInstantResponse(lr *logReader) backend.DataResponse {
 	frame := newLogFrame()
 	for {
-		row, err := lr.ReadRow()
+		row, err := lr.readRow()
 		if errors.Is(err, io.EOF) {
 			break
 		}
@@ -114,7 +114,7 @@ func parseInstantResponse(lr *logReader) backend.DataResponse {
 // parse the lines from the reader and we need to collect only one data.Frame
 func parseStreamResponse(lr *logReader, ch chan *data.Frame) error {
 	for {
-		row, err := lr.ReadRow()
+		row, err := lr.readRow()
 		if errors.Is(err, io.EOF) {
 			return nil
 		}

--- a/pkg/plugin/response_logs_test.go
+++ b/pkg/plugin/response_logs_test.go
@@ -22,6 +22,7 @@ type row = struct {
 	ts       string
 	msg      string
 	streamID string
+	labels   string
 }
 
 // newIDField creates an id field pre-populated for the provided rows.
@@ -29,48 +30,9 @@ func newIDField(rows ...row) *data.Field {
 	f := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 	f.Name = gIDField
 	for _, r := range rows {
-		f.Append(buildLogID([]byte(r.ts), []byte(r.msg), []byte(r.streamID)))
+		f.Append(buildLogID([]byte(r.ts), []byte(r.msg), []byte(r.streamID), []byte(r.labels)))
 	}
 	return f
-}
-
-func Test_buildLogID(t *testing.T) {
-	ts := []byte("2024-02-20T14:04:27Z")
-
-	// stability: same input produces same id
-	id1 := buildLogID(ts, []byte("hello"), []byte(`{a="1"}`))
-	id2 := buildLogID(ts, []byte("hello"), []byte(`{a="1"}`))
-	if id1 != id2 {
-		t.Errorf("buildLogID is not stable: %s != %s", id1, id2)
-	}
-
-	// uniqueness: differing inputs produce different ids
-	cases := []struct {
-		name string
-		ts   string
-		msg  string
-		stm  string
-	}{
-		{"baseline", "2024-02-20T14:04:27Z", "hello", `{a="1"}`},
-		{"different time", "2024-02-20T14:04:27.000000001Z", "hello", `{a="1"}`},
-		{"different msg", "2024-02-20T14:04:27Z", "hello!", `{a="1"}`},
-		{"different stream", "2024-02-20T14:04:27Z", "hello", `{a="2"}`},
-	}
-	seen := make(map[string]string, len(cases))
-	for _, c := range cases {
-		id := buildLogID([]byte(c.ts), []byte(c.msg), []byte(c.stm))
-		if prev, ok := seen[id]; ok {
-			t.Errorf("buildLogID collision between %q and %q -> %s", prev, c.name, id)
-		}
-		seen[id] = c.name
-	}
-
-	// boundary safety: prefix-shifted msg/stream must not collide
-	a := buildLogID(ts, []byte("ab"), []byte("cd"))
-	b := buildLogID(ts, []byte("a"), []byte("bcd"))
-	if a == b {
-		t.Errorf("buildLogID collides across msg/stream boundary: %s", a)
-	}
 }
 
 // newHiddenStreamFields builds the hidden per-row `streams`/`streamId` fields
@@ -127,7 +89,7 @@ func Test_parseInstantResponse(t *testing.T) {
 
 		r := io.NopCloser(bytes.NewBuffer(file))
 		w := opts.want()
-		resp := parseInstantResponse(r)
+		resp := parseInstantResponse(newLogReader(r))
 
 		if w.Error != nil {
 			if !reflect.DeepEqual(w, resp) {
@@ -219,9 +181,10 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			msgRaw := ""
 			lineField.Append(msgRaw)
-			labelsField.Append(json.RawMessage(`{"_stream":"{}"}`))
+			lblRaw := `{"_stream":"{}"}`
+			labelsField.Append(json.RawMessage(lblRaw))
 
-			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msgRaw, ""}), labelsField, []string{""}, []map[string]string{{}})
+			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msgRaw, "", lblRaw}), labelsField, []string{""}, []map[string]string{{}})
 		},
 	}
 	f(o)
@@ -239,9 +202,10 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			msgRaw := "123"
 			lineField.Append(msgRaw)
-			labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`))
+			lblRaw := `{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}"}`
+			labelsField.Append(json.RawMessage(lblRaw))
 
-			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msgRaw, ""}), labelsField, []string{""}, []map[string]string{{"application": "logs-benchmark-Apache.log-1708437847", "hostname": "e28a622d7792"}})
+			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msgRaw, "", lblRaw}), labelsField, []string{""}, []map[string]string{{"application": "logs-benchmark-Apache.log-1708437847", "hostname": "e28a622d7792"}})
 		},
 	}
 	f(o)
@@ -259,9 +223,10 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			msgRaw := "123"
 			lineField.Append(msgRaw)
-			labelsField.Append(json.RawMessage(`{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`))
+			lblRaw := `{"_stream":"{application=\"logs-benchmark-Apache.log-1708437847\",hostname=\"e28a622d7792\"}","job":"vlogs"}`
+			labelsField.Append(json.RawMessage(lblRaw))
 
-			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msgRaw, ""}), labelsField, []string{""}, []map[string]string{{"application": "logs-benchmark-Apache.log-1708437847", "hostname": "e28a622d7792"}})
+			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msgRaw, "", lblRaw}), labelsField, []string{""}, []map[string]string{{"application": "logs-benchmark-Apache.log-1708437847", "hostname": "e28a622d7792"}})
 		},
 	}
 	f(o)
@@ -278,11 +243,13 @@ func Test_parseInstantResponse(t *testing.T) {
 			timeFd.Append(time.Time{})
 			lineField.Append("")
 			lineField.Append("")
-			labelsField.Append(json.RawMessage(`{"stream":"stderr","count(*)":"394"}`))
-			labelsField.Append(json.RawMessage(`{"stream":"stdout","count(*)":"21"}`))
+			lbl1 := `{"stream":"stderr","count(*)":"394"}`
+			lbl2 := `{"stream":"stdout","count(*)":"21"}`
+			labelsField.Append(json.RawMessage(lbl1))
+			labelsField.Append(json.RawMessage(lbl2))
 			idField := newIDField(
-				row{"", "", ""},
-				row{"", "", ""},
+				row{"", "", "", lbl1},
+				row{"", "", "", lbl2},
 			)
 
 			return newFrame(timeFd, lineField, idField, labelsField, []string{"", ""}, []map[string]string{nil, nil})
@@ -300,9 +267,10 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			timeFd.Append(time.Time{})
 			lineField.Append("")
-			labelsField.Append(json.RawMessage(`{"level":""}`))
+			lblRaw := `{"level":""}`
+			labelsField.Append(json.RawMessage(lblRaw))
 
-			return newFrame(timeFd, lineField, newIDField(row{"", "", ""}), labelsField, []string{""}, []map[string]string{nil})
+			return newFrame(timeFd, lineField, newIDField(row{"", "", "", lblRaw}), labelsField, []string{""}, []map[string]string{nil})
 		},
 	}
 	f(o)
@@ -321,10 +289,12 @@ func Test_parseInstantResponse(t *testing.T) {
 			timeFd.Append(getTimeType(ts2))
 			lineField.Append("")
 			lineField.Append("")
-			labelsField.Append(json.RawMessage(`{"logs":"1400"}`))
-			labelsField.Append(json.RawMessage(`{"logs":"374"}`))
+			lbl1 := `{"logs":"1400"}`
+			lbl2 := `{"logs":"374"}`
+			labelsField.Append(json.RawMessage(lbl1))
+			labelsField.Append(json.RawMessage(lbl2))
 
-			return newFrame(timeFd, lineField, newIDField(row{ts1, "", ""}, row{ts2, "", ""}), labelsField, []string{"", ""}, []map[string]string{nil, nil})
+			return newFrame(timeFd, lineField, newIDField(row{ts1, "", "", lbl1}, row{ts2, "", "", lbl2}), labelsField, []string{"", ""}, []map[string]string{nil, nil})
 		},
 	}
 	f(o)
@@ -343,9 +313,10 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			timeFd.Append(getTimeType(tsRaw))
 			lineField.Append(msg)
-			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000009eaf29866f70976a098adc735393deb1","_stream":"{compose_project=\"app\",compose_service=\"gateway\"}","compose_project":"app","compose_service":"gateway"}`))
+			lblRaw := `{"_stream_id":"00000000000000009eaf29866f70976a098adc735393deb1","_stream":"{compose_project=\"app\",compose_service=\"gateway\"}","compose_project":"app","compose_service":"gateway"}`
+			labelsField.Append(json.RawMessage(lblRaw))
 
-			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msg, streamID}), labelsField, []string{streamID}, []map[string]string{{"compose_project": "app", "compose_service": "gateway"}})
+			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msg, streamID, lblRaw}), labelsField, []string{streamID}, []map[string]string{{"compose_project": "app", "compose_service": "gateway"}})
 		},
 	}
 	f(o)
@@ -368,9 +339,10 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			timeFd.Append(getTimeType(tsRaw))
 			lineField.Append(msg)
-			labelsField.Append(json.RawMessage(`{"_stream":"{compose_project=\"app\",compose_service=\"gateway\"}","compose_project":"app","compose_service":"gateway"}`))
+			lblRaw := `{"_stream":"{compose_project=\"app\",compose_service=\"gateway\"}","compose_project":"app","compose_service":"gateway"}`
+			labelsField.Append(json.RawMessage(lblRaw))
 
-			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msg, ""}), labelsField, []string{""}, []map[string]string{{"compose_project": "app", "compose_service": "gateway"}})
+			return newFrame(timeFd, lineField, newIDField(row{tsRaw, msg, "", lblRaw}), labelsField, []string{""}, []map[string]string{{"compose_project": "app", "compose_service": "gateway"}})
 		},
 	}
 	f(o)
@@ -385,9 +357,10 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			timeFd.Append(time.Time{})
 			lineField.Append("507")
-			labelsField.Append(json.RawMessage(`{"count":"507"}`))
+			lblRaw := `{"count":"507"}`
+			labelsField.Append(json.RawMessage(lblRaw))
 
-			return newFrame(timeFd, lineField, newIDField(row{"", "507", ""}), labelsField, []string{""}, []map[string]string{nil})
+			return newFrame(timeFd, lineField, newIDField(row{"", "507", "", lblRaw}), labelsField, []string{""}, []map[string]string{nil})
 		},
 	}
 	f(o)
@@ -405,15 +378,16 @@ func Test_parseInstantResponse(t *testing.T) {
 			timeFd.Append(time.Time{})
 			lineField.Append("123")
 			lineField.Append("456")
-			labelsField.Append(json.RawMessage(`{"_stream":"{app=\"test\"}"}`))
-			labelsField.Append(json.RawMessage(`{"_stream":"{app=\"test\"}"}`))
+			lblRaw := `{"_stream":"{app=\"test\"}"}`
+			labelsField.Append(json.RawMessage(lblRaw))
+			labelsField.Append(json.RawMessage(lblRaw))
 
 			return newFrame(
 				timeFd,
 				lineField,
 				newIDField(
-					row{tsRaw, "123", ""},
-					row{"", "456", ""},
+					row{tsRaw, "123", "", lblRaw},
+					row{"", "456", "", lblRaw},
 				),
 				labelsField,
 				[]string{"", ""},
@@ -446,15 +420,18 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField.Append("1")
 			lineField.Append("2")
 			lineField.Append("3")
-			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000002e3bd2bdc376279a6418761ca20c417c","_stream":"{path=\"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log\",stream=\"stderr\"}","path":"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log","stream":"stderr","time":"2024-09-10T12:24:38.124811792Z"}`))
-			labelsField.Append(json.RawMessage(`{"_stream_id":"0000000000000000356bfe9e3c71128c750d94c15df6b908","_stream":"{stream=\"stream1\"}","date":"0","stream":"stream1","log.level":"info"}`))
-			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000002e3bd2bdc376279a6418761ca20c417c","_stream":"{path=\"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log\",stream=\"stderr\"}","path":"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log","stream":"stderr","time":"2024-09-10T13:06:56.451470093Z"}`))
+			lbl1 := `{"_stream_id":"00000000000000002e3bd2bdc376279a6418761ca20c417c","_stream":"{path=\"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log\",stream=\"stderr\"}","path":"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log","stream":"stderr","time":"2024-09-10T12:24:38.124811792Z"}`
+			lbl2 := `{"_stream_id":"0000000000000000356bfe9e3c71128c750d94c15df6b908","_stream":"{stream=\"stream1\"}","date":"0","stream":"stream1","log.level":"info"}`
+			lbl3 := `{"_stream_id":"00000000000000002e3bd2bdc376279a6418761ca20c417c","_stream":"{path=\"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log\",stream=\"stderr\"}","path":"/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log","stream":"stderr","time":"2024-09-10T13:06:56.451470093Z"}`
+			labelsField.Append(json.RawMessage(lbl1))
+			labelsField.Append(json.RawMessage(lbl2))
+			labelsField.Append(json.RawMessage(lbl3))
 
 			pathValue := "/var/lib/docker/containers/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89/c01cbe414773fa6b3e4e0976fb27c3583b1a5cd4b7007662477df66987f97f89-json.log"
 			return newFrame(timeFd, lineField, newIDField(
-				row{ts1, "1", sid13},
-				row{ts2, "2", sid2},
-				row{ts3, "3", sid13},
+				row{ts1, "1", sid13, lbl1},
+				row{ts2, "2", sid2, lbl2},
+				row{ts3, "3", sid13, lbl3},
 			), labelsField, []string{sid13, sid2, sid13}, []map[string]string{
 				{"path": pathValue, "stream": "stderr"},
 				{"stream": "stream1"},
@@ -479,9 +456,10 @@ func Test_parseInstantResponse(t *testing.T) {
 
 			timeFd.Append(getTimeType(tsRaw))
 			lineField.Append(str)
-			labelsField.Append(json.RawMessage(`{"_stream_id":"0000000000000000356bfe9e3c71128c750d94c15df6b908","_stream":"{stream=\"stream1\"}","date":"0","stream":"stream1","log.level":"info"}`))
+			lblRaw := `{"_stream_id":"0000000000000000356bfe9e3c71128c750d94c15df6b908","_stream":"{stream=\"stream1\"}","date":"0","stream":"stream1","log.level":"info"}`
+			labelsField.Append(json.RawMessage(lblRaw))
 
-			return newFrame(timeFd, lineField, newIDField(row{tsRaw, str, streamID}), labelsField, []string{streamID}, []map[string]string{{"stream": "stream1"}})
+			return newFrame(timeFd, lineField, newIDField(row{tsRaw, str, streamID, lblRaw}), labelsField, []string{streamID}, []map[string]string{{"stream": "stream1"}})
 		},
 	}
 	f(o)
@@ -497,9 +475,10 @@ func Test_parseInstantResponse(t *testing.T) {
 			tsRaw := "2024-02-20T14:04:27Z"
 			timeFd.Append(getTimeType(tsRaw))
 			lineField.Append("123")
-			labelsField.Append(json.RawMessage(`{"_stream":"{Dino Species=\"Stegosaurus\",kubernetes.labels.app.kubernetes.io/instance=\"123\",kubernetes.labels.app.kubernetes.io/name=\"vmagent\",kubernetes.namespace_name=\"monitoring\"}"}`))
+			lblRaw := `{"_stream":"{Dino Species=\"Stegosaurus\",kubernetes.labels.app.kubernetes.io/instance=\"123\",kubernetes.labels.app.kubernetes.io/name=\"vmagent\",kubernetes.namespace_name=\"monitoring\"}"}`
+			labelsField.Append(json.RawMessage(lblRaw))
 
-			return newFrame(timeFd, lineField, newIDField(row{tsRaw, "123", ""}), labelsField, []string{""}, []map[string]string{{
+			return newFrame(timeFd, lineField, newIDField(row{tsRaw, "123", "", lblRaw}), labelsField, []string{""}, []map[string]string{{
 				"Dino Species": "Stegosaurus",
 				"kubernetes.labels.app.kubernetes.io/instance": "123",
 				"kubernetes.labels.app.kubernetes.io/name":     "vmagent",
@@ -520,9 +499,10 @@ func Test_parseInstantResponse(t *testing.T) {
 			tsRaw := "2024-02-20T14:04:27Z"
 			timeFd.Append(getTimeType(tsRaw))
 			lineField.Append("123")
-			labelsField.Append(json.RawMessage(`{"_stream":"{kubernetes.host=\"host1\",kubernetes.labels.app.kubernetes.io/instance=\"123\",kubernetes.labels.app.kubernetes.io/name=\"vmagent\",kubernetes.namespace_name=\"monitoring\"}"}`))
+			lblRaw := `{"_stream":"{kubernetes.host=\"host1\",kubernetes.labels.app.kubernetes.io/instance=\"123\",kubernetes.labels.app.kubernetes.io/name=\"vmagent\",kubernetes.namespace_name=\"monitoring\"}"}`
+			labelsField.Append(json.RawMessage(lblRaw))
 
-			return newFrame(timeFd, lineField, newIDField(row{tsRaw, "123", ""}), labelsField, []string{""}, []map[string]string{{
+			return newFrame(timeFd, lineField, newIDField(row{tsRaw, "123", "", lblRaw}), labelsField, []string{""}, []map[string]string{{
 				"kubernetes.host": "host1",
 				"kubernetes.labels.app.kubernetes.io/instance": "123",
 				"kubernetes.labels.app.kubernetes.io/name":     "vmagent",
@@ -546,12 +526,14 @@ func Test_parseInstantResponse(t *testing.T) {
 			timeFd.Append(getTimeType(ts2))
 			lineField.Append("some new message")
 			lineField.Append("")
-			labelsField.Append(json.RawMessage(`{"_stream_id":"1","_stream":"{container.id=\"1\",container.name=\"1\"}","container.id":"1","container.name":"1","fluent.tag":"2fa06040a011","severity":"Unspecified","source":"stdout"}`))
-			labelsField.Append(json.RawMessage(`{"_stream_id":"2","_stream":"{container.id=\"2\",container.name=\"2\"}","container.id":"2","container.name":"2","fluent.tag":"2fa06040a011","severity":"Unspecified","source":"stdout"}`))
+			lbl1 := `{"_stream_id":"1","_stream":"{container.id=\"1\",container.name=\"1\"}","container.id":"1","container.name":"1","fluent.tag":"2fa06040a011","severity":"Unspecified","source":"stdout"}`
+			lbl2 := `{"_stream_id":"2","_stream":"{container.id=\"2\",container.name=\"2\"}","container.id":"2","container.name":"2","fluent.tag":"2fa06040a011","severity":"Unspecified","source":"stdout"}`
+			labelsField.Append(json.RawMessage(lbl1))
+			labelsField.Append(json.RawMessage(lbl2))
 
 			return newFrame(timeFd, lineField, newIDField(
-				row{ts1, "some new message", "1"},
-				row{ts2, "", "2"},
+				row{ts1, "some new message", "1", lbl1},
+				row{ts2, "", "2", lbl2},
 			), labelsField, []string{"1", "2"}, []map[string]string{
 				{"container.id": "1", "container.name": "1"},
 				{"container.id": "2", "container.name": "2"},
@@ -573,14 +555,17 @@ func Test_parseInstantResponse(t *testing.T) {
 			lineField.Append("")
 			lineField.Append("")
 			lineField.Append("")
-			labelsField.Append(json.RawMessage(`{"logs":"69275","_stream":"{az_id=\"use1-az2\",source=\"vector\",vpc_id=\"vpc\"}"}`))
-			labelsField.Append(json.RawMessage(`{"logs":"5022","_stream":"{namespace=\"ops-monitoring-ns\"}"}`))
-			labelsField.Append(json.RawMessage(`{"logs":"194","_stream":"{}"}`))
+			lbl1 := `{"logs":"69275","_stream":"{az_id=\"use1-az2\",source=\"vector\",vpc_id=\"vpc\"}"}`
+			lbl2 := `{"logs":"5022","_stream":"{namespace=\"ops-monitoring-ns\"}"}`
+			lbl3 := `{"logs":"194","_stream":"{}"}`
+			labelsField.Append(json.RawMessage(lbl1))
+			labelsField.Append(json.RawMessage(lbl2))
+			labelsField.Append(json.RawMessage(lbl3))
 
 			return newFrame(timeFd, lineField, newIDField(
-				row{"", "", ""},
-				row{"", "", ""},
-				row{"", "", ""},
+				row{"", "", "", lbl1},
+				row{"", "", "", lbl2},
+				row{"", "", "", lbl3},
 			), labelsField, []string{"", "", ""}, []map[string]string{
 				{"az_id": "use1-az2", "source": "vector", "vpc_id": "vpc"},
 				{"namespace": "ops-monitoring-ns"},
@@ -606,12 +591,14 @@ func Test_parseInstantResponse(t *testing.T) {
 			timeFd.Append(getTimeType(ts))
 			lineField.Append("hello")
 			lineField.Append("world")
-			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000009eaf29866f70976a098adc735393deb1"}`))
-			labelsField.Append(json.RawMessage(`{"foo":"bar"}`))
+			lbl1 := `{"_stream_id":"00000000000000009eaf29866f70976a098adc735393deb1"}`
+			lbl2 := `{"foo":"bar"}`
+			labelsField.Append(json.RawMessage(lbl1))
+			labelsField.Append(json.RawMessage(lbl2))
 
 			return newFrame(timeFd, lineField, newIDField(
-				row{ts, "hello", streamID},
-				row{ts, "world", ""},
+				row{ts, "hello", streamID, lbl1},
+				row{ts, "world", "", lbl2},
 			), labelsField, []string{streamID, ""}, []map[string]string{nil, nil})
 		},
 	}
@@ -631,12 +618,14 @@ func Test_parseInstantResponse(t *testing.T) {
 			timeFd.Append(getTimeType(ts2))
 			lineField.Append(msg)
 			lineField.Append("")
-			labelsField.Append(json.RawMessage(`{"_stream_id":"00000000000000000899b9a9578ea0f11a8a45c1b4cc8e34","_stream":"{kubernetes.container_name=\"frigate\",stream=\"stdout\"}","stream":"stdout"}`))
-			labelsField.Append(json.RawMessage(`{"_stream_id":"0000000000000000e934a84adb05276890d7f7bfcadabe92","_stream":"{}"}`))
+			lbl1 := `{"_stream_id":"00000000000000000899b9a9578ea0f11a8a45c1b4cc8e34","_stream":"{kubernetes.container_name=\"frigate\",stream=\"stdout\"}","stream":"stdout"}`
+			lbl2 := `{"_stream_id":"0000000000000000e934a84adb05276890d7f7bfcadabe92","_stream":"{}"}`
+			labelsField.Append(json.RawMessage(lbl1))
+			labelsField.Append(json.RawMessage(lbl2))
 
 			return newFrame(timeFd, lineField, newIDField(
-				row{ts1, msg, "00000000000000000899b9a9578ea0f11a8a45c1b4cc8e34"},
-				row{ts2, "", "0000000000000000e934a84adb05276890d7f7bfcadabe92"},
+				row{ts1, msg, "00000000000000000899b9a9578ea0f11a8a45c1b4cc8e34", lbl1},
+				row{ts2, "", "0000000000000000e934a84adb05276890d7f7bfcadabe92", lbl2},
 			), labelsField, []string{"00000000000000000899b9a9578ea0f11a8a45c1b4cc8e34", "0000000000000000e934a84adb05276890d7f7bfcadabe92"}, []map[string]string{
 				{"kubernetes.container_name": "frigate", "stream": "stdout"},
 				{},


### PR DESCRIPTION
Related issue: #706 

### Description

The problem was in the same LogID for the logs with the same time, stream_id, and _msg. To fix it:
- Include row labels in the log ID hash, so rows that differ only in their fields (e.g., trace_id) no longer share one ID
- Add idBuilder that suffixes repeated ids with _1, _2, ... within one response or live-tail session; the seen-set is size-capped, so long tail sessions don't grow memory unboundedly.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
