### PR TITLE
fix: raise default line limit from 50 to 1000 to reduce load-more loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * BUGFIX: keep the selected values of multi-value ad-hoc filter operators (`one of`, `not one of`) when serializing the query. Previously, such dashboard filters produced an empty `in()` filter, and the panel showed no results.
 * BUGFIX: interpolate dashboard variables into the query builder state and stream filter values when jumping from a dashboard panel to Explore. Previously, the raw variable names (e.g., `$app`) leaked back into the query on the first editor interaction, and the query returned no results.
 * BUGFIX: pass the panel time range to the `Instant` (stats) query type via the `start`/`end` query parameters instead of prepending a `_time:[...]` filter to the query text. The prepended filter was not parenthesized, so a top-level `OR` (e.g. `level:error OR level:warn | stats count()`) left part of the query outside the time range, making VictoriaLogs scan the full retention and the panel time out. Thanks to @github-vincent-miszczak for contributing.
+* BUGFIX: increase the default line limit for log queries from 50 to 1000. If your logs are large or expensive to render, set a lower limit in the datasource settings or via provisioning - see [Line limits](https://docs.victoriametrics.com/victorialogs/integrations/grafana/#line-limits).
 
 ## v0.30.1
 

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -13,8 +13,8 @@ datasources:
     url: http://victorialogs:9428
     jsonData:
       # Default maximum number of log lines returned per query.
-      # Defaults to 50, maximum allowed value is 10000.
-      #maxLines: 50
+      # Defaults to 1000, maximum allowed value is 10000.
+      #maxLines: 1000
 
       # Multitenancy settings, see https://docs.victoriametrics.com/victorialogs/#multitenancy
       # to use the multitenancy uncomment lines below: AccountID and ProjectID

--- a/src/README.md
+++ b/src/README.md
@@ -275,7 +275,7 @@ reduces the rendering load on the browser and prevents the page from freezing wh
 There are two levels of control:
 
 - **Maximum lines** — the datasource-wide default, configured in the datasource settings. It applies to every query
-  that does not set its own limit. The default value is `50` and the maximum allowed value is `10000`.
+  that does not set its own limit. The default value is `1000` and the maximum allowed value is `10000`.
 - **Line limit** — a per-query override available in the query editor options. When set, it takes precedence over the
   datasource-wide **Maximum lines** for that query. It is also capped at `10000`.
 
@@ -297,8 +297,8 @@ datasources:
     url: http://victorialogs:9428
     jsonData:
       # Default maximum number of log lines returned per query.
-      # Defaults to 50, maximum allowed value is 10000.
-      maxLines: 50
+      # Defaults to 1000, maximum allowed value is 10000.
+      maxLines: 1000
 ```
 
 ## Correlations

--- a/src/configuration/QuerySettings.test.tsx
+++ b/src/configuration/QuerySettings.test.tsx
@@ -2,7 +2,9 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import '@testing-library/jest-dom';
 import React from 'react';
 
+import { LOGS_LIMIT_DEFAULT } from '../constants';
 import store from '../store/store';
+
 
 import { QuerySettings } from './QuerySettings';
 
@@ -27,7 +29,7 @@ describe('QuerySettings — Maximum lines protection', () => {
 
     render(<QuerySettings maxLines='' onMaxLinedChange={onMaxLinedChange} />);
 
-    fireEvent.change(screen.getByPlaceholderText('50'), { target: { value: '500' } });
+    fireEvent.change(screen.getByPlaceholderText(String(LOGS_LIMIT_DEFAULT)), { target: { value: '500' } });
 
     expect(onMaxLinedChange).toHaveBeenCalledWith('500');
     expect(screen.queryByText('Large line limit')).not.toBeInTheDocument();
@@ -36,7 +38,7 @@ describe('QuerySettings — Maximum lines protection', () => {
   it('does not open the modal on blur when the stored value is within the safe range', () => {
     render(<QuerySettings maxLines='500' onMaxLinedChange={jest.fn()} />);
 
-    fireEvent.blur(screen.getByPlaceholderText('50'));
+    fireEvent.blur(screen.getByPlaceholderText(String(LOGS_LIMIT_DEFAULT)));
 
     expect(screen.queryByText('Large line limit')).not.toBeInTheDocument();
   });
@@ -46,7 +48,7 @@ describe('QuerySettings — Maximum lines protection', () => {
 
     render(<QuerySettings maxLines='5000' onMaxLinedChange={onMaxLinedChange} />);
 
-    fireEvent.blur(screen.getByPlaceholderText('50'));
+    fireEvent.blur(screen.getByPlaceholderText(String(LOGS_LIMIT_DEFAULT)));
 
     const modal = screen.getByText('Large line limit').closest('[role="dialog"]') as HTMLElement;
     expect(modal).toBeInTheDocument();
@@ -63,7 +65,7 @@ describe('QuerySettings — Maximum lines protection', () => {
 
     render(<QuerySettings maxLines='' onMaxLinedChange={onMaxLinedChange} />);
 
-    fireEvent.change(screen.getByPlaceholderText('50'), { target: { value: '50000' } });
+    fireEvent.change(screen.getByPlaceholderText(String(LOGS_LIMIT_DEFAULT)), { target: { value: '50000' } });
 
     expect(onMaxLinedChange).toHaveBeenCalledWith('10000');
   });
@@ -73,7 +75,7 @@ describe('QuerySettings — Maximum lines protection', () => {
 
     render(<QuerySettings maxLines='500' onMaxLinedChange={onMaxLinedChange} />);
 
-    fireEvent.change(screen.getByPlaceholderText('50'), { target: { value: '-5' } });
+    fireEvent.change(screen.getByPlaceholderText(String(LOGS_LIMIT_DEFAULT)), { target: { value: '-5' } });
 
     expect(onMaxLinedChange).toHaveBeenCalledWith('');
   });
@@ -89,7 +91,7 @@ describe('QuerySettings — Maximum lines protection', () => {
 
     render(<QuerySettings maxLines='500' onMaxLinedChange={onMaxLinedChange} />);
 
-    fireEvent.change(screen.getByPlaceholderText('50'), { target: { value: '' } });
+    fireEvent.change(screen.getByPlaceholderText(String(LOGS_LIMIT_DEFAULT)), { target: { value: '' } });
     expect(onMaxLinedChange).toHaveBeenCalledWith('');
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@ export const VARIABLE_ALL_VALUE = '$__all';
 export const TEXT_FILTER_ALL_VALUE = '*';
 export const PLUGIN_ID = 'victoriametrics-logs-datasource';
 
-export const LOGS_LIMIT_DEFAULT = 50;
+export const LOGS_LIMIT_DEFAULT = 1000;
 export const LOGS_LIMIT_HARD_CAP = 10000;
 export const LOGS_LIMIT_WARNING_THRESHOLD = 1000;
 export const NOT_SHOW_AGAIN_LOGS_LIMIT_WARNING_LOCAL_STORAGE_KEY = `${PLUGIN_ID}:notShowAgainLogsLimitWarning`;


### PR DESCRIPTION
### Describe Your Changes

Why: with infinite scroll ("load more"), rows sharing the boundary timestamp can be silently lost at every chunk junction. Grafana narrows the next chunk's `to` to the oldest loaded row's timestamp truncated to milliseconds (the wire format is ms), and VictoriaLogs treats `end` as exclusive ([start, end)), so boundary-millisecond rows that did not fit into the previous chunk under the line limit can never be fetched by any later chunk. Reproduced deterministically: 120 rows on one millisecond with limit 50 lose 70 rows with no indication; the reference Loki datasource on Grafana 13.1 loses exactly the same rows, so the defect is systemic (panel ms-boundary + exclusive end + line limit), not specific to this plugin.

Raising the default limit from 50 to 1000 makes chunks 20x larger: there are far fewer load-more junctions, and each junction is far less likely to land inside a dense same-millisecond group, shrinking the expected loss (up to 1ms of logs per junction). This is mitigation, not a complete fix — the proper fix (aligning the range edge, e.g. end+1ms, or an upstream ns-precision range) is tracked separately.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
