### PR TITLE
fix: send an explicit end bound in the datasource health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## tip
 
-* BUGFIX: send an explicit `end` bound in the datasource health check. Without it, VictoriaLogs defaulted the upper bound to the maximum int64 nanosecond timestamp (year 2262), so instances running with `-search.maxQueryTimeRange` failed "Save & test" with `too big time range selected`. See [#712](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/712).
+* BUGFIX: send an explicit `end` bound in the datasource health check. Without it, VictoriaLogs defaulted the upper bound to the maximum int64 nanosecond timestamp (year 2262), so instances running with `-search.maxQueryTimeRange` failed "Save & test" with `too big time range selected`. See [#712](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/712). Thanks to @dberkerdem for contributing.
 
 ## v0.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: send an explicit `end` bound in the datasource health check. Without it, VictoriaLogs defaulted the upper bound to the maximum int64 nanosecond timestamp (year 2262), so instances running with `-search.maxQueryTimeRange` failed "Save & test" with `too big time range selected`. See [#712](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/712).
+
 ## v0.31.0
 
 * FEATURE: `Filter for value` / `Filter out value` in log details now adds the value to the `Stream filters` when the clicked field is a stream field. Stream filters are resolved via the stream index, so such filters run noticeably faster on large volumes. See [#691](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/691).

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -840,6 +840,10 @@ func checkHealthWithInstance(ctx context.Context, di *DatasourceInstance) (*back
 	values.Set("query", "*")
 	values.Set("limit", "1")
 	values.Set("start", "-5m")
+	// An explicit upper bound is required: without `end`, VictoriaLogs defaults
+	// it to the maximum int64 nanosecond timestamp (year 2262), so instances
+	// running with -search.maxQueryTimeRange reject the health check with 400.
+	values.Set("end", "now")
 	u.RawQuery = values.Encode()
 
 	method := di.grafanaSettings.HTTPMethod


### PR DESCRIPTION
Fixes #712.

## Problem

`checkHealthWithInstance` builds the health-check request with a `start` but no
`end`:

```go
values.Set("query", "*")
values.Set("limit", "1")
values.Set("start", "-5m")
```

With no `end`, VictoriaLogs defaults the upper bound to the maximum int64
nanosecond timestamp — `2262-04-11T23:47:16.854775807Z` — so the effective range
is `now-5m … year 2262`. Any instance running with `-search.maxQueryTimeRange`
therefore rejects the health check:

```
got response code 400: too big time range selected:
[2026-08-05T23:51:28.749548662Z, 2262-04-11T23:47:16.854775807Z];
it cannot exceed -search.maxQueryTimeRange=720h0m0s
```

The datasource works fine once saved — only "Save & test" fails — but it is
alarming, and it makes Grafana's `/api/datasources/uid/<uid>/health` endpoint
report the datasource as broken.

This has been present since #599 moved the health check onto the `query`
endpoint.

## Fix

Set an explicit upper bound:

```go
values.Set("start", "-5m")
values.Set("end", "now")
```

Every other query path already sends both bounds — `queryLogsURL`,
`statsQueryRangeURL` and `hitsQueryURL` all `Set("start", …)` and
`Set("end", …)` — so the health check was the only caller relying on the
server-side default.

## Verification

Against an instance started with `-search.maxQueryTimeRange=720h`:

```console
# before - what the plugin sends today
$ curl -s -o /dev/null -w '%{http_code}\n' \
    'http://vlselect:9428/select/logsql/query?query=*&limit=1&start=-5m'
400

# after - with the explicit end bound
$ curl -s -o /dev/null -w '%{http_code}\n' \
    'http://vlselect:9428/select/logsql/query?query=*&limit=1&start=-5m&end=now'
200
```

`gofmt` reports no changes.

## Note for reviewers

`end=now` keeps the health check's relative style, matching the existing
`start=-5m`. An absolute unix timestamp would work equally well if you prefer
consistency with the query paths, which format both bounds with
`strconv.FormatInt(...Unix(), 10)`.
