### PR TITLE
fix(logs): keep selected fields after a query returns an empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: send an explicit `end` bound in the datasource health check. Without it, VictoriaLogs defaulted the upper bound to the maximum int64 nanosecond timestamp (year 2262), so instances running with `-search.maxQueryTimeRange` failed "Save & test" with `too big time range selected`. See [#712](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/712). Thanks to @dberkerdem for contributing.
+* BUGFIX: keep the selected fields in the Explore logs panel after a query returns no results. Previously, an empty result reset the field selection. See [#714](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/714).
 
 ## v0.31.0
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -453,8 +453,15 @@ func (di *DatasourceInstance) query(ctx context.Context, q *Query) backend.DataR
 	}
 
 	if r == nil {
-		// VictoriaLogs returned no data
-		return backend.DataResponse{Frames: data.Frames{}}
+		// VictoriaLogs returned an empty response body. For log queries return
+		// an empty logs frame instead of zero frames so Grafana keeps the logs
+		// panel mounted and preserves its state
+		switch q.QueryType {
+		case QueryTypeStats, QueryTypeStatsRange, QueryTypeHits:
+			return backend.DataResponse{Frames: data.Frames{}}
+		default:
+			return parseInstantResponse(newLogReader(strings.NewReader("")))
+		}
 	}
 
 	defer func() {

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -92,6 +92,9 @@ func TestDatasourceQueryRequest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error write response: %s", err)
 			}
+		case 6:
+			// VictoriaLogs returns an empty body when the query matches no logs
+			w.WriteHeader(http.StatusOK)
 		}
 	})
 
@@ -326,6 +329,43 @@ func TestDatasourceQueryRequest(t *testing.T) {
 
 		if !bytes.Equal(d, exd) {
 			t.Fatalf("unexpected metric %s want %s", d, exd)
+		}
+	}
+
+	// 6: empty response body must produce a single empty logs frame,
+	// not zero frames, so Grafana keeps the logs panel mounted
+	rsp, gotErr = d.QueryData(ctx, &backend.QueryDataRequest{
+		PluginContext: pluginCtx,
+		Queries: []backend.DataQuery{
+			{
+				RefID:     "A",
+				QueryType: instantQueryPath,
+				JSON:      queryJSON,
+			},
+		},
+	})
+	if gotErr != nil {
+		t.Fatalf("unexpected %s", gotErr)
+	}
+
+	response = rsp.Responses["A"]
+	if len(response.Frames) != 1 {
+		t.Fatalf("expected 1 frame got %d in %+v", len(response.Frames), response.Frames)
+	}
+
+	expected = backend.DataResponse{Frames: data.Frames{newLogFrame().dataFrame}}
+	for i, frame := range response.Frames {
+		d, err := frame.MarshalJSON()
+		if err != nil {
+			t.Fatalf("error marshal response frames %s", err)
+		}
+		exd, err := expected.Frames[i].MarshalJSON()
+		if err != nil {
+			t.Fatalf("error marshal expected frames %s", err)
+		}
+
+		if !bytes.Equal(d, exd) {
+			t.Fatalf("unexpected frame %s want %s", d, exd)
 		}
 	}
 }


### PR DESCRIPTION
Related issue: #714

### Describe Your Changes

Return a single empty logs frame instead of zero frames when VictoriaLogs responds with an empty body for a log query. With zero frames, Grafana unmounts the Explore logs panel and wipes its panel state (selected fields, columns, sort order); an empty frame keeps the panel mounted

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
