### PR TITLE
add group hits by field option to the explore page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: add a `Group hits by` option to `Raw Logs` queries in Explore: the logs volume histogram can be grouped by any log field instead of the default `level`. See [#689](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/689).
+
 * BUGFIX: send an explicit `end` bound in the datasource health check. Without it, VictoriaLogs defaulted the upper bound to the maximum int64 nanosecond timestamp (year 2262), so instances running with `-search.maxQueryTimeRange` failed "Save & test" with `too big time range selected`. See [#712](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/712). Thanks to @dberkerdem for contributing.
 * BUGFIX: keep the selected fields in the Explore logs panel after a query returns no results. Previously, an empty result reset the field selection. See [#714](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/714).
 

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -54,6 +54,7 @@ type Query struct {
 	MaxLines           int       `json:"maxLines"`
 	Step               string    `json:"step"`
 	Fields             []string  `json:"fields"`
+	FieldsLimit        int       `json:"fieldsLimit"`
 	QueryType          QueryType `json:"queryType"`
 	ExtraFilters       string    `json:"extraFilters"`
 	ExtraStreamFilters string    `json:"extraStreamFilters"`
@@ -279,6 +280,9 @@ func (q *Query) hitsQueryURL(queryParams url.Values, minInterval time.Duration) 
 	}
 	for _, f := range q.Fields {
 		values.Add("field", f)
+	}
+	if q.FieldsLimit > 0 {
+		values.Set("fields_limit", strconv.Itoa(q.FieldsLimit))
 	}
 
 	q.url.RawQuery = values.Encode()

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -16,6 +16,8 @@ func TestQuery_getQueryURL(t *testing.T) {
 		QueryType      QueryType
 		ExtraFilters   string
 		TimezoneOffset string
+		Fields         []string
+		FieldsLimit    int
 		rawURL         string
 		queryParams    string
 		want           string
@@ -34,6 +36,8 @@ func TestQuery_getQueryURL(t *testing.T) {
 			QueryType:      opts.QueryType,
 			ExtraFilters:   opts.ExtraFilters,
 			TimezoneOffset: opts.TimezoneOffset,
+			Fields:         opts.Fields,
+			FieldsLimit:    opts.FieldsLimit,
 		}
 		got, err := q.getQueryURL(opts.rawURL, opts.queryParams)
 		if (err != nil) != opts.wantErr {
@@ -256,6 +260,21 @@ func TestQuery_getQueryURL(t *testing.T) {
 		QueryType: QueryTypeHits,
 		rawURL:    "http://127.0.0.1:9429",
 		want:      "http://127.0.0.1:9429/select/logsql/hits?end=1609462800000000000&query=&start=1609459200000000000&step=15s",
+	}
+	f(o)
+
+	// hits grouped by a field with a limit on the number of groups
+	o = opts{
+		RefID: "1",
+		TimeRange: backend.TimeRange{
+			From: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2021, 1, 1, 1, 0, 0, 0, time.UTC),
+		},
+		QueryType:   QueryTypeHits,
+		Fields:      []string{"container_name"},
+		FieldsLimit: 20,
+		rawURL:      "http://127.0.0.1:9429",
+		want:        "http://127.0.0.1:9429/select/logsql/hits?end=1609462800000000000&field=container_name&fields_limit=20&query=&start=1609459200000000000&step=15s",
 	}
 	f(o)
 

--- a/src/components/QueryEditor/GroupByFieldSelect.tsx
+++ b/src/components/QueryEditor/GroupByFieldSelect.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback } from 'react';
+
+import { TimeRange } from '@grafana/data';
+import { ComboboxOption } from '@grafana/ui';
+
+import { VictoriaLogsDatasource } from '../../datasource';
+import { CompatibleCombobox } from '../CompatibleCombobox';
+
+import { useFieldFetch } from './shared/useFieldFetch';
+
+interface Props {
+  datasource: VictoriaLogsDatasource;
+  timeRange?: TimeRange;
+  queryContext?: string;
+  value?: string;
+  onChange: (field?: string) => void;
+}
+
+/** Single log field selector used to group hits query results by the field value */
+export const GroupByFieldSelect = ({ datasource, timeRange, queryContext, value, onChange }: Props) => {
+  const { loadFieldNames } = useFieldFetch({ datasource, timeRange, queryContext });
+
+  const handleChange = useCallback(
+    (option: ComboboxOption<string> | null) => {
+      onChange(option?.value || undefined);
+    },
+    [onChange]
+  );
+
+  return (
+    <CompatibleCombobox
+      placeholder='none'
+      isClearable
+      width={20}
+      value={value ?? null}
+      options={loadFieldNames}
+      onChange={handleChange}
+    />
+  );
+};

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -180,6 +180,8 @@ const QueryEditor = React.memo<VictoriaLogsQueryEditorProps>((props) => {
               onRunQuery={onRunQuery}
               app={app}
               maxLines={datasource.maxLines}
+              datasource={datasource}
+              timeRange={timeRange}
             />
           </div>
         </div>

--- a/src/components/QueryEditor/QueryEditorOptions.tsx
+++ b/src/components/QueryEditor/QueryEditorOptions.tsx
@@ -1,17 +1,19 @@
 import React, { useMemo } from 'react';
 
-import { CoreApp, isValidGrafanaDuration, SelectableValue } from '@grafana/data';
+import { CoreApp, isValidGrafanaDuration, SelectableValue, TimeRange } from '@grafana/data';
 import { AutoSizeInput, Input, RadioButtonGroup, Switch, TextLink } from '@grafana/ui';
 
 import { VICTORIA_LOGS_DOCS_HOST } from '../../conf';
 import { LOGS_LIMIT_HARD_CAP, LOGS_LIMIT_WARNING_THRESHOLD } from '../../constants';
-import { resolveAdHocFiltersMode } from '../../datasource';
+import { resolveAdHocFiltersMode, VictoriaLogsDatasource } from '../../datasource';
+import { LOGS_VOLUME_DEFAULT_GROUP_BY } from '../../logsVolumeLegacy';
 import { AdHocFiltersMode, Query, QueryType } from '../../types';
 import { isVariable } from '../../utils/isVariable';
 import { useMaxLinesWarning } from '../shared/shared/useMaxLinesWarning';
 
 import EditorField from './EditorField';
 import { EditorRow } from './EditorRow';
+import { GroupByFieldSelect } from './GroupByFieldSelect';
 import QueryEditorOptionsGroup from './QueryEditorOptionsGroup';
 
 export interface Props {
@@ -20,6 +22,8 @@ export interface Props {
   onRunQuery: () => void;
   maxLines: number;
   app?: CoreApp;
+  datasource: VictoriaLogsDatasource;
+  timeRange?: TimeRange;
 }
 
 export const queryTypeOptions: Array<SelectableValue<QueryType>> = [
@@ -47,7 +51,7 @@ const adHocFiltersModeOptions: Array<SelectableValue<AdHocFiltersMode>> = [
   { value: AdHocFiltersMode.Off, label: 'Off' },
 ];
 
-export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onChange, onRunQuery }) => {
+export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onChange, onRunQuery, datasource, timeRange }) => {
   const filteredOptions = queryTypeOptions.filter(option => option.filter?.({ app }) ?? true);
   const queryType = query.queryType;
 
@@ -111,6 +115,13 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
     onRunQuery();
   };
 
+  const onGroupByFieldChange = (field?: string) => {
+    // The default level grouping is stored as undefined so queries don't carry the default around
+    const groupBy = field && field !== LOGS_VOLUME_DEFAULT_GROUP_BY ? field : undefined;
+    onChange({ ...query, groupBy });
+    onRunQuery();
+  };
+
   return (
     <EditorRow>
       {maxLinesWarningModal}
@@ -143,6 +154,20 @@ export const QueryEditorOptions = React.memo<Props>(({ app, query, maxLines, onC
             Learn more about querying logs
           </TextLink>
         </div>
+        {queryType === QueryType.Instant && (
+          <EditorField
+            label='Group hits by'
+            tooltip='Groups the logs volume histogram by the selected field value. Each field value gets its own series. The default `level` grouping colors the histogram by log level.'
+          >
+            <GroupByFieldSelect
+              datasource={datasource}
+              timeRange={timeRange}
+              queryContext={query.expr}
+              value={query.groupBy ?? LOGS_VOLUME_DEFAULT_GROUP_BY}
+              onChange={onGroupByFieldChange}
+            />
+          </EditorField>
+        )}
         {queryType === QueryType.Instant && (
           <EditorField
             label='Line limit'
@@ -228,6 +253,10 @@ function getCollapsedInfo({ app, query, queryType, maxLines, isValidStep }: Coll
 
   if (queryType === QueryType.StatsRange && query.step) {
     items.push(`Step: ${isValidStep ? query.step : 'Invalid value'}`);
+  }
+
+  if (queryType === QueryType.Instant) {
+    items.push(`Group hits by: ${query.groupBy || LOGS_VOLUME_DEFAULT_GROUP_BY}`);
   }
 
   if (queryType === QueryType.Instant && maxLines) {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -45,7 +45,7 @@ import { LOGS_LIMIT_DEFAULT, LOGS_LIMIT_HARD_CAP, TEXT_FILTER_ALL_VALUE, VARIABL
 import LogsQlLanguageProvider from './language_provider';
 import { LiveChannelPathProvider } from './live/LiveChannelPathProvider';
 import { LogContextProvider } from './logContext/LogContextProvider';
-import { LOGS_VOLUME_BARS, queryLogsVolume } from './logsVolumeLegacy';
+import { LOGS_VOLUME_BARS, LOGS_VOLUME_DEFAULT_GROUP_BY, LOGS_VOLUME_GROUPS_LIMIT, queryLogsVolume } from './logsVolumeLegacy';
 import {
   addLabelToQuery,
   addSortPipeToQuery,
@@ -548,6 +548,22 @@ export class VictoriaLogsDatasource
         const totalSeconds = request.range.to.diff(request.range.from, 'second');
         const step = Math.ceil(totalSeconds / LOGS_VOLUME_BARS) || '';
 
+        const volumeQuery = {
+          ...query,
+          step: `${step}s`,
+          queryType: QueryType.Hits,
+          refId: `${REF_ID_STARTER_LOG_VOLUME}${query.refId}`,
+          supportingQueryType: SupportingQueryType.LogsVolume,
+          timezoneOffset: formatOffsetDuration(request.timezone, request.range.from.utcOffset()),
+        };
+
+        // Custom grouping: one series per field value, level derivation is not involved.
+        // The groups limit keeps high-cardinality fields from exploding the histogram
+        const customGroupBy = query.groupBy && query.groupBy !== LOGS_VOLUME_DEFAULT_GROUP_BY ? query.groupBy : undefined;
+        if (customGroupBy) {
+          return { ...volumeQuery, fields: [customGroupBy], fieldsLimit: LOGS_VOLUME_GROUPS_LIMIT };
+        }
+
         // With active level rules the level is derived server-side via `format` pipes,
         // grouping hits by the single derived field instead of every rule field
         // (a `_msg` rule would otherwise explode cardinality — issue #700).
@@ -559,14 +575,9 @@ export class VictoriaLogsDatasource
         const levelPipes = query.expr ? buildLevelFormatPipes(this.getActiveLevelRules()) : '';
 
         return {
-          ...query,
+          ...volumeQuery,
           expr: levelPipes ? insertPipesBeforeSortClassPipe(query.expr, levelPipes) : query.expr,
-          step: `${step}s`,
           fields: levelPipes ? [DERIVED_LEVEL_FIELD] : ['level'],
-          queryType: QueryType.Hits,
-          refId: `${REF_ID_STARTER_LOG_VOLUME}${query.refId}`,
-          supportingQueryType: SupportingQueryType.LogsVolume,
-          timezoneOffset: formatOffsetDuration(request.timezone, request.range.from.utcOffset()),
         };
       }
       case SupplementaryQueryType.LogsSample:

--- a/src/logsVolumeLegacy.test.ts
+++ b/src/logsVolumeLegacy.test.ts
@@ -1,13 +1,14 @@
-import { DataQueryRequest, dateTime, FieldType, LogLevel, toDataFrame } from '@grafana/data';
+import { DataQueryRequest, dateTime, FieldColorModeId, FieldType, LogLevel, toDataFrame } from '@grafana/data';
 
 import { LOG_LEVEL_COLOR } from './configuration/LogLevelRules/const';
 import { LogLevelRuleType } from './configuration/LogLevelRules/types';
-import { aggregateRawLogsVolume, extractLevel } from './logsVolumeLegacy';
+import { aggregateRawLogsVolume, aggregateVolumeFrames, extractLevel } from './logsVolumeLegacy';
 import { Query } from './types';
 import { DERIVED_LEVEL_FIELD } from './utils/query/levelFormatPipes';
 
-const makeFrame = (labels?: Record<string, string>) =>
+const makeFrame = (labels?: Record<string, string>, refId?: string) =>
   toDataFrame({
+    refId,
     fields: [
       { name: 'Time', type: FieldType.time, values: [0] },
       { name: 'Value', type: FieldType.number, values: [1], labels },
@@ -59,5 +60,66 @@ describe('aggregateRawLogsVolume level styling', () => {
     const frames = aggregateRawLogsVolume([makeFrame()], () => LogLevel.unspecified, request, []);
     expect(valueConfig(frames)?.displayNameFromDS).toBe(LogLevel.unknown);
     expect(valueConfig(frames)?.color?.fixedColor).toBe(LOG_LEVEL_COLOR[LogLevel.unknown]);
+  });
+});
+
+describe('aggregateVolumeFrames custom grouping', () => {
+  const request = {
+    range: {
+      from: dateTime('2026-07-06T00:00:00Z'),
+      to: dateTime('2026-07-06T01:00:00Z'),
+      raw: { from: 'now-1h', to: 'now' },
+    },
+  } as DataQueryRequest<Query>;
+
+  const makeTarget = (overrides: Partial<Query>): Query => ({
+    refId: 'log-volume-A',
+    expr: '*',
+    ...overrides,
+  });
+
+  const configOf = (frame: ReturnType<typeof aggregateVolumeFrames>[number]) =>
+    frame.fields.find((f) => f.name === 'Value')?.config;
+
+  it('renders one palette-colored series per group value', () => {
+    const targets = [makeTarget({ groupBy: 'container_name' })];
+    const frames = aggregateVolumeFrames(
+      [
+        makeFrame({ container_name: 'app-1' }, 'log-volume-A'),
+        makeFrame({ container_name: 'app-2' }, 'log-volume-A'),
+      ],
+      targets,
+      request,
+      []
+    );
+
+    expect(frames).toHaveLength(2);
+    expect(frames.map((f) => configOf(f)?.displayNameFromDS)).toEqual(['app-1', 'app-2']);
+    expect(configOf(frames[0])?.color?.mode).toBe(FieldColorModeId.PaletteClassic);
+  });
+
+  it('labels an empty group value as (empty) and the merged tail bucket as other', () => {
+    const targets = [makeTarget({ groupBy: 'container_name' })];
+    const frames = aggregateVolumeFrames(
+      [
+        makeFrame({ container_name: '' }, 'log-volume-A'),
+        // the fields_limit tail bucket comes back without the group field at all
+        makeFrame({}, 'log-volume-A'),
+      ],
+      targets,
+      request,
+      []
+    );
+
+    expect(frames.map((f) => configOf(f)?.displayNameFromDS)).toEqual(['(empty)', 'other']);
+  });
+
+  it('keeps the level aggregation for targets without a custom groupBy', () => {
+    const targets = [makeTarget({ groupBy: 'level' })];
+    const frames = aggregateVolumeFrames([makeFrame({ level: 'error' }, 'log-volume-A')], targets, request, []);
+
+    expect(frames).toHaveLength(1);
+    expect(configOf(frames[0])?.displayNameFromDS).toBe(LogLevel.error);
+    expect(configOf(frames[0])?.color?.fixedColor).toBe(LOG_LEVEL_COLOR[LogLevel.error]);
   });
 });

--- a/src/logsVolumeLegacy.ts
+++ b/src/logsVolumeLegacy.ts
@@ -85,10 +85,23 @@ export const queryLogsVolume = (datasource: VictoriaLogsDatasource, request: Dat
   });
 };
 
-/** Name for the group of logs that don't have the grouping field (empty value in VictoriaLogs) */
-const EMPTY_GROUP_NAME = '(empty)';
-/** Name for the tail bucket VictoriaLogs merges the groups beyond fields_limit into (it comes back with no fields at all) */
-const OTHER_GROUP_NAME = 'other';
+/** Label for the group of logs that don't have the grouping field (empty value in VictoriaLogs) */
+const EMPTY_GROUP_LABEL = '(empty)';
+/** Label for the tail bucket VictoriaLogs merges the groups beyond fields_limit into (it comes back with no fields at all) */
+const OTHER_GROUP_LABEL = 'other';
+
+/** Separator for composite group keys; never occurs in field names or values */
+const GROUP_KEY_SEPARATOR = '\u0000';
+
+/** Bucket types in the group key — they keep a literal `other` / `(empty)` field value from colliding with the synthetic buckets */
+const GROUP_TYPE_VALUE = 'value';
+const GROUP_TYPE_EMPTY = 'empty';
+const GROUP_TYPE_OTHER = 'other';
+
+interface GroupBucket {
+  label: string;
+  frames: DataFrame[];
+}
 
 /**
  * Aggregate raw hits frames into logs volume series.
@@ -109,7 +122,7 @@ export function aggregateVolumeFrames(
   });
 
   const levelFrames: DataFrame[] = [];
-  const customGroups = new Map<string, DataFrame[]>();
+  const customGroups = new Map<string, GroupBucket>();
 
   rawLogsVolume.forEach((frame) => {
     const groupField = frame.refId ? groupFieldByRefId.get(frame.refId) : undefined;
@@ -119,14 +132,21 @@ export function aggregateVolumeFrames(
     }
     const labels = frame.fields.find((f) => f.name === 'Value')?.labels;
     const value = labels?.[groupField];
-    const name = value === undefined ? OTHER_GROUP_NAME : value || EMPTY_GROUP_NAME;
-    customGroups.set(name, [...(customGroups.get(name) ?? []), frame]);
+    const groupType = value === undefined ? GROUP_TYPE_OTHER : value === '' ? GROUP_TYPE_EMPTY : GROUP_TYPE_VALUE;
+    const label = value === undefined ? OTHER_GROUP_LABEL : value || EMPTY_GROUP_LABEL;
+    // The key includes the grouping field, so equal values of different fields stay
+    // separate series, while the same field from several targets merges — mirroring
+    // the cross-target aggregation of the level path
+    const key = [groupField, groupType, value ?? ''].join(GROUP_KEY_SEPARATOR);
+    const bucket = customGroups.get(key) ?? { label, frames: [] };
+    bucket.frames.push(frame);
+    customGroups.set(key, bucket);
   });
 
   return [
     ...aggregateRawLogsVolume(levelFrames, extractLevel, request, rules),
-    ...Array.from(customGroups, ([name, frames]) =>
-      aggregateFields(frames, getGroupVolumeFieldConfig(name), request)
+    ...Array.from(customGroups.values(), ({ label, frames }) =>
+      aggregateFields(frames, getGroupVolumeFieldConfig(label), request)
     ),
   ];
 }

--- a/src/logsVolumeLegacy.ts
+++ b/src/logsVolumeLegacy.ts
@@ -22,6 +22,10 @@ import { Query } from './types';
 import { DERIVED_LEVEL_FIELD, parseDerivedLevel } from './utils/query/levelFormatPipes';
 
 export const LOGS_VOLUME_BARS = 100;
+/** Cap on the number of series when the volume is grouped by a custom field — VictoriaLogs merges the tail into one bucket */
+export const LOGS_VOLUME_GROUPS_LIMIT = 20;
+/** Default logs volume grouping — level-based aggregation with level colors */
+export const LOGS_VOLUME_DEFAULT_GROUP_BY = 'level';
 
 export const queryLogsVolume = (datasource: VictoriaLogsDatasource, request: DataQueryRequest<Query>): Observable<DataQueryResponse> | undefined => {
   return new Observable((observer) => {
@@ -37,7 +41,7 @@ export const queryLogsVolume = (datasource: VictoriaLogsDatasource, request: Dat
 
     const subscription = queryObservable.subscribe({
       complete: () => {
-        const aggregatedLogsVolume = aggregateRawLogsVolume(rawLogsVolume, extractLevel, request, datasource.logLevelRules);
+        const aggregatedLogsVolume = aggregateVolumeFrames(rawLogsVolume, request.targets, request, datasource.logLevelRules);
         if (aggregatedLogsVolume[0]) {
           aggregatedLogsVolume[0].meta = {
             custom: {
@@ -80,6 +84,52 @@ export const queryLogsVolume = (datasource: VictoriaLogsDatasource, request: Dat
     };
   });
 };
+
+/** Name for the group of logs that don't have the grouping field (empty value in VictoriaLogs) */
+const EMPTY_GROUP_NAME = '(empty)';
+/** Name for the tail bucket VictoriaLogs merges the groups beyond fields_limit into (it comes back with no fields at all) */
+const OTHER_GROUP_NAME = 'other';
+
+/**
+ * Aggregate raw hits frames into logs volume series.
+ * Frames whose target is grouped by a custom field become one palette-colored series
+ * per field value; the rest go through the level-based aggregation
+ */
+export function aggregateVolumeFrames(
+  rawLogsVolume: DataFrame[],
+  targets: Query[],
+  request: DataQueryRequest<Query>,
+  rules: LogLevelRule[]
+): DataFrame[] {
+  const groupFieldByRefId = new Map<string, string>();
+  targets.forEach((target) => {
+    if (target.groupBy && target.groupBy !== LOGS_VOLUME_DEFAULT_GROUP_BY) {
+      groupFieldByRefId.set(target.refId, target.groupBy);
+    }
+  });
+
+  const levelFrames: DataFrame[] = [];
+  const customGroups = new Map<string, DataFrame[]>();
+
+  rawLogsVolume.forEach((frame) => {
+    const groupField = frame.refId ? groupFieldByRefId.get(frame.refId) : undefined;
+    if (!groupField) {
+      levelFrames.push(frame);
+      return;
+    }
+    const labels = frame.fields.find((f) => f.name === 'Value')?.labels;
+    const value = labels?.[groupField];
+    const name = value === undefined ? OTHER_GROUP_NAME : value || EMPTY_GROUP_NAME;
+    customGroups.set(name, [...(customGroups.get(name) ?? []), frame]);
+  });
+
+  return [
+    ...aggregateRawLogsVolume(levelFrames, extractLevel, request, rules),
+    ...Array.from(customGroups, ([name, frames]) =>
+      aggregateFields(frames, getGroupVolumeFieldConfig(name), request)
+    ),
+  ];
+}
 
 /**
  * Take multiple data frames, sum up values and group by level.
@@ -171,6 +221,28 @@ function getLogVolumeFieldConfig(level: LogLevel) {
       lineColor: color,
       pointColor: color,
       fillColor: color,
+      lineWidth: 1,
+      fillOpacity: 100,
+      stacking: {
+        mode: StackingMode.Normal,
+        group: 'A',
+      },
+    },
+  };
+}
+
+/**
+ * Returns field configuration for a series of the volume grouped by a custom field
+ */
+function getGroupVolumeFieldConfig(name: string): FieldConfig {
+  return {
+    displayNameFromDS: name,
+    color: {
+      mode: FieldColorModeId.PaletteClassic,
+    },
+    custom: {
+      drawStyle: GraphDrawStyle.Bars,
+      barAlignment: BarAlignment.Center,
       lineWidth: 1,
       fillOpacity: 100,
       stacking: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,10 @@ export interface Query extends DataQuery {
   interval?: string;
   /** groups the results by the specified field value for /select/logsql/hits */
   fields?: string[];
+  /** limits the number of groups returned by /select/logsql/hits; the tail is merged into one bucket */
+  fieldsLimit?: number;
+  /** log field the logs volume histogram is grouped by; defaults to the level-based grouping */
+  groupBy?: string;
   /** timezone offset for bucket alignment in stats_query_range and hits endpoints (e.g. "2h", "-5h30m") */
   timezoneOffset?: string;
   /** @deprecated Use adHocFiltersMode instead */


### PR DESCRIPTION
Related issue: #689 

### Describe Your Changes

Added a `Group hits by` option to `Raw Logs` queries in Explore: the logs volume histogram can be grouped by any log field instead of the default `level`.
<img width="1455" height="601" alt="image" src="https://github.com/user-attachments/assets/552320d1-822f-4c61-bca9-e7e1f23e2b3f" />


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
