### PR TITLE
725 log panel improperly highlights commas when logsql function takes a comma delim argument list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## tip
 
+* BUGFIX: stop highlighting commas in the logs panel when the query uses a LogsQL filter with a comma-separated argument list, such as `seq("foo", "bar")` or `contains_common_case("foo", "bar")`. See [#725](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/725).
+* BUGFIX: fix a browser tab freeze when the query contains a pipe inside parentheses, for example a subquery filter like `_msg:in(* | fields _msg)`.
+
 ## v0.32.0
 
 * FEATURE: add a `Group hits by` option to `Raw Logs` queries in Explore: the logs volume histogram can be grouped by any log field instead of the default `level`. See [#689](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/689).

--- a/src/LogsQL/extractMsgSearchWords.test.ts
+++ b/src/LogsQL/extractMsgSearchWords.test.ts
@@ -98,6 +98,35 @@ describe('extractMsgSearchWords', () => {
     });
   });
 
+  describe('comma-delimited function arguments', () => {
+    it('does not highlight the comma between quoted arguments', () => {
+      expect(extractMsgSearchWords('contains_common_case("foo", "bar")')).toEqual(['foo', 'bar']);
+      expect(extractMsgSearchWords('seq("foo", "bar")')).toEqual(['foo', 'bar']);
+    });
+    it('splits quoted arguments without a space after the comma', () => {
+      expect(extractMsgSearchWords('contains_common_case("foo","bar")')).toEqual(['foo', 'bar']);
+    });
+    it('splits bare-word arguments on the comma', () => {
+      expect(extractMsgSearchWords('in(foo, bar)')).toEqual(['foo', 'bar']);
+      expect(extractMsgSearchWords('_msg:in(foo,bar)')).toEqual(['foo', 'bar']);
+    });
+    it('keeps a comma inside a quoted phrase or a regexp', () => {
+      expect(extractMsgSearchWords('"a, b"')).toEqual(['a, b']);
+      expect(extractMsgSearchWords('~"a,b"')).toEqual(['a,b']);
+    });
+  });
+
+  describe('termination on stray separators', () => {
+    it('terminates on a pipe inside a parenthesized group', () => {
+      expect(extractMsgSearchWords('(foo | bar)')).toEqual(['foo', 'bar']);
+      expect(Array.isArray(extractMsgSearchWords('_msg:in(_time:5m | fields x)'))).toBe(true);
+    });
+    it('terminates on an unmatched closing brace', () => {
+      expect(extractMsgSearchWords('}')).toEqual([]);
+      expect(extractMsgSearchWords('error } warn')).toEqual(['error', 'warn']);
+    });
+  });
+
   describe('grouped values after a field', () => {
     it('skips a grouped value of a non-_msg field', () => {
       expect(extractMsgSearchWords('app:(buggy_app OR foobar)')).toEqual([]);

--- a/src/LogsQL/extractMsgSearchWords.test.ts
+++ b/src/LogsQL/extractMsgSearchWords.test.ts
@@ -117,11 +117,26 @@ describe('extractMsgSearchWords', () => {
   });
 
   describe('termination on stray separators', () => {
-    it('terminates on a pipe inside a parenthesized group', () => {
-      expect(extractMsgSearchWords('(foo | bar)')).toEqual(['foo', 'bar']);
-      // TODO: the body of a subquery is still scanned as default _msg context,
-      // so its pipe-stage tokens leak into the terms. Tracked separately.
-      expect(extractMsgSearchWords('_msg:in(_time:5m | fields x)')).toEqual(['fields', 'x']);
+    it('skips a group holding a pipe instead of scanning its stages as _msg terms', () => {
+      expect(extractMsgSearchWords('_msg:in(* | fields _msg)')).toEqual([]);
+      expect(extractMsgSearchWords('_msg:in(_time:5m | fields x)')).toEqual([]);
+      expect(extractMsgSearchWords('in(_time:5m | fields x)')).toEqual([]);
+      expect(extractMsgSearchWords('(foo | bar)')).toEqual([]);
+    });
+    it('still scans a group holding no pipe', () => {
+      expect(extractMsgSearchWords('(foo OR bar)')).toEqual(['foo', 'bar']);
+      expect(extractMsgSearchWords('error _msg:in(a, b)')).toEqual(['error', 'a', 'b']);
+    });
+    it('keeps highlighting terms around a skipped subquery', () => {
+      expect(extractMsgSearchWords('error _msg:in(* | fields _msg) warn')).toEqual(['error', 'warn']);
+    });
+    it('skips only the subquery when it is nested in a boolean group', () => {
+      expect(extractMsgSearchWords('(error OR _msg:in(* | fields x))')).toEqual(['error']);
+      expect(extractMsgSearchWords('(_msg:error OR _msg:in(* | fields _msg))')).toEqual(['error']);
+      expect(extractMsgSearchWords('(error OR (warn AND _msg:in(* | fields x)))')).toEqual(['error', 'warn']);
+    });
+    it('keeps a quoted pipe as part of the term', () => {
+      expect(extractMsgSearchWords('_msg:in("a|b", c)')).toEqual(['a\\|b', 'c']);
     });
     it('keeps a colon bound to its field instead of consuming it as a stray separator', () => {
       expect(extractMsgSearchWords('_time:2023-04-25T22:45:59Z')).toEqual([]);

--- a/src/LogsQL/extractMsgSearchWords.test.ts
+++ b/src/LogsQL/extractMsgSearchWords.test.ts
@@ -119,7 +119,19 @@ describe('extractMsgSearchWords', () => {
   describe('termination on stray separators', () => {
     it('terminates on a pipe inside a parenthesized group', () => {
       expect(extractMsgSearchWords('(foo | bar)')).toEqual(['foo', 'bar']);
-      expect(Array.isArray(extractMsgSearchWords('_msg:in(_time:5m | fields x)'))).toBe(true);
+      // TODO: the body of a subquery is still scanned as default _msg context,
+      // so its pipe-stage tokens leak into the terms. Tracked separately.
+      expect(extractMsgSearchWords('_msg:in(_time:5m | fields x)')).toEqual(['fields', 'x']);
+    });
+    it('keeps a colon bound to its field instead of consuming it as a stray separator', () => {
+      expect(extractMsgSearchWords('_time:2023-04-25T22:45:59Z')).toEqual([]);
+      expect(extractMsgSearchWords('error _time:2023-04-25T22:45:59Z')).toEqual(['error']);
+      expect(extractMsgSearchWords('url:"http://example.com" error')).toEqual(['error']);
+    });
+    it('skips a bracketed range value of a field', () => {
+      expect(extractMsgSearchWords('_time:[2023-04-25T22:45:59Z, 2023-04-26T22:45:59Z]')).toEqual([]);
+      expect(extractMsgSearchWords('_time:[2023-04-25T22:45:59Z, 2023-04-26T22:45:59Z] error')).toEqual(['error']);
+      expect(extractMsgSearchWords('response_size:[1KB, 10MB]')).toEqual([]);
     });
     it('terminates on an unmatched closing brace', () => {
       expect(extractMsgSearchWords('}')).toEqual([]);

--- a/src/LogsQL/extractMsgSearchWords.ts
+++ b/src/LogsQL/extractMsgSearchWords.ts
@@ -5,8 +5,8 @@ import { skipBalanced } from '../utils';
 import { splitByPipes } from './splitByPipes';
 import { stripComments } from './stripComments';
 
-// Tabs/newlines are normalized to spaces in extractMsgSearchWords, so a plain space is enough here
-const TERM_SEPARATORS = [' ', ':', '|', '(', ')', '{', '}'];
+// Tabs/newlines are normalized to spaces in extractMsgSearchWords, so a plain space is enough here.
+const TERM_SEPARATORS = [' ', ',', ':', '|', '(', ')', '{', '}'];
 
 /**
  * Reads a quoted string starting at `openIdx` (quote char at that index)
@@ -190,6 +190,13 @@ function scanFilterSegment(segment: string): string[] {
       i++;
     }
     let word = segment.slice(start, i);
+
+    // An empty word means `ch` is a separator with no dedicated branch above
+    // (an argument-list comma, a stray `|` or `}`). Consume it so the scan always advances.
+    if (word === '') {
+      i++;
+      continue;
+    }
 
     const upper = word.toUpperCase();
     if (upper === 'AND' || upper === 'OR') {

--- a/src/LogsQL/extractMsgSearchWords.ts
+++ b/src/LogsQL/extractMsgSearchWords.ts
@@ -1,6 +1,6 @@
 import { escapeRegExp } from 'lodash';
 
-import { skipBalanced } from '../utils';
+import { findGroupsWithChar, skipBalanced } from '../utils';
 
 import { splitByPipes } from './splitByPipes';
 import { stripComments } from './stripComments';
@@ -114,6 +114,10 @@ function readValueTermInner(s: string, i: number): { term: string | null; isRege
  */
 function scanFilterSegment(segment: string): string[] {
   const results: string[] = [];
+  // A `|` at a group's own level marks that group as a subquery (`in(* | fields x)`): the terms it
+  // matches come from the subquery result, not from this filter. Resolved in one pass up front, so
+  // a group nested inside a subquery does not drag its ancestors down with it.
+  const subqueryGroups = findGroupsWithChar(segment, '(', ')', '|');
   let i = 0;
   let negateNext = false;
 
@@ -139,9 +143,10 @@ function scanFilterSegment(segment: string): string[] {
       continue;
     }
 
-    // grouping parens
+    // grouping parens — every descent into a group funnels through here, including
+    // the `_msg:(...)` and `_msg:fn(...)` branches below, which continue without moving `i`
     if (ch === '(') {
-      if (negateNext) {
+      if (negateNext || subqueryGroups.has(i)) {
         i = skipBalanced(segment, i, '(', ')');
         negateNext = false;
       } else {

--- a/src/LogsQL/extractMsgSearchWords.ts
+++ b/src/LogsQL/extractMsgSearchWords.ts
@@ -193,7 +193,8 @@ function scanFilterSegment(segment: string): string[] {
 
     // An empty word means `ch` is a separator with no dedicated branch above
     // (an argument-list comma, a stray `|` or `}`). Consume it so the scan always advances.
-    if (word === '') {
+    // `:` is deliberately excluded — it must reach the field/value branch below.
+    if (word === '' && (ch === ',' || ch === '|' || ch === '}')) {
       i++;
       continue;
     }
@@ -218,6 +219,12 @@ function scanFilterSegment(segment: string): string[] {
           continue; // scan the group as default _msg context
         }
         i = skipBalanced(segment, i, '(', ')'); // group filters a non-_msg field — skip it
+        negateNext = false;
+        continue;
+      }
+      // range value: `field:[min, max]` — a numeric/time range, never a _msg term
+      if (segment[i] === '[') {
+        i = skipBalanced(segment, i, '[', ']');
         negateNext = false;
         continue;
       }

--- a/src/utils/string/findGroupsWithChar/findGroupsWithChar.test.ts
+++ b/src/utils/string/findGroupsWithChar/findGroupsWithChar.test.ts
@@ -1,0 +1,45 @@
+import { findGroupsWithChar } from './findGroupsWithChar';
+
+const find = (s: string) => [...findGroupsWithChar(s, '(', ')', '|')];
+
+describe('findGroupsWithChar', () => {
+  it('marks a group holding the needle', () => {
+    expect(find('(a | b)')).toEqual([0]);
+    expect(find('(a, b)')).toEqual([]);
+  });
+
+  it('handles an empty block', () => {
+    expect(find('()')).toEqual([]);
+  });
+
+  it('marks only the innermost group enclosing the needle', () => {
+    expect(find('(a (b | c) d)')).toEqual([3]);
+    expect(find('(((a | b)))')).toEqual([2]);
+  });
+
+  it('marks every group that holds the needle at its own level', () => {
+    expect(find('(a | b) (c | d)')).toEqual([0, 8]);
+    expect(find('(a | (b | c))')).toEqual([0, 5]);
+  });
+
+  it('ignores a needle outside any group', () => {
+    expect(find('a | b')).toEqual([]);
+    expect(find('(a) | (b)')).toEqual([]);
+  });
+
+  it('ignores a needle inside quoted strings', () => {
+    expect(find('("a|b")')).toEqual([]);
+    expect(find("('a|b')")).toEqual([]);
+    expect(find('(`a|b`)')).toEqual([]);
+  });
+
+  it('ignores a needle inside an escaped quote span', () => {
+    expect(find('("a\\"|b")')).toEqual([]);
+  });
+
+  it('tolerates unmatched brackets', () => {
+    expect(find('(a | b')).toEqual([0]);
+    expect(find('a | b)')).toEqual([]);
+    expect(find('(a) | b)')).toEqual([]);
+  });
+});

--- a/src/utils/string/findGroupsWithChar/findGroupsWithChar.ts
+++ b/src/utils/string/findGroupsWithChar/findGroupsWithChar.ts
@@ -1,0 +1,45 @@
+/**
+ * Scans `s` once and returns the indices of the `open` chars whose own group level holds `needle`.
+ *
+ * Only the innermost group enclosing an occurrence is marked, so a `needle` sitting in a nested
+ * group does not mark its ancestors. Quote characters (`"`, `'`, `` ` ``) open a quoted span in
+ * which `needle` and the `open`/`close` pair are ignored; a backslash inside a quote escapes the
+ * next character. Unmatched `close` chars are tolerated.
+ *
+ * @param s - the string to scan
+ * @param open - the opening bracket character (e.g. `{` or `(`)
+ * @param close - the matching closing bracket character (e.g. `}` or `)`)
+ * @param needle - the character to look for
+ * @returns the set of `open` indices whose group level holds `needle`
+ *
+ * @example
+ *   findGroupsWithChar('(a | b)', '(', ')', '|')       // Set { 0 }
+ *   findGroupsWithChar('(a (b | c))', '(', ')', '|')   // Set { 3 } — the outer group is not marked
+ *   findGroupsWithChar('("a|b")', '(', ')', '|')       // Set {} — the pipe is quoted
+ */
+export function findGroupsWithChar(s: string, open: string, close: string, needle: string): Set<number> {
+  const marked = new Set<number>();
+  const openIndexes: number[] = [];
+  let quote: string | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (quote) {
+      if (c === '\\') {
+        i++;
+      } else if (c === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      quote = c;
+    } else if (c === open) {
+      openIndexes.push(i);
+    } else if (c === close) {
+      openIndexes.pop();
+    } else if (c === needle && openIndexes.length > 0) {
+      marked.add(openIndexes[openIndexes.length - 1]);
+    }
+  }
+  return marked;
+}

--- a/src/utils/string/index.ts
+++ b/src/utils/string/index.ts
@@ -1,3 +1,4 @@
 export { capitalize } from './capitalize/capitalize';
+export { findGroupsWithChar } from './findGroupsWithChar/findGroupsWithChar';
 export { hashString } from './hashString/hashString';
 export { skipBalanced } from './skipBalanced/skipBalanced';


### PR DESCRIPTION
Related issue: #725 

### Describe Your Changes

- **Comma-separated argument lists** — `seq("foo", "bar")` and `contains_common_case(...)`
  no longer highlight the comma; an argument-list comma is now a term separator.

| Query | Before | After |
|---|---|---|
| `contains_common_case("Order", "details")` | <img width="1536" height="1335" alt="image" src="https://github.com/user-attachments/assets/a20c1322-4fd9-497e-ab41-145b9310ac89" /> | <img width="1535" height="1294" alt="image" src="https://github.com/user-attachments/assets/9e0a04f5-4f82-4ae3-9f3e-6f9c61832805" /> |


- **Bracketed range values** — `_time:[2023-04-25T22:45:59Z, 2023-04-26T22:45:59Z]`
  no longer leaks `59Z]` as a term. A `field:[min, max]` range is skipped as a whole.
- **Colons inside values** — a `:` is again bound to its field instead of being
  swallowed as a stray separator.
- **Subqueries** — `_msg:in(* | fields _msg)` no longer highlights `fields` and `_msg`.
  A group holding an unquoted `|` is a subquery: its terms come from the subquery
  result, not from the enclosing filter, so the group is skipped.



### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
